### PR TITLE
Missing club 404

### DIFF
--- a/netlify/functions/club/awards/ranking.ts
+++ b/netlify/functions/club/awards/ranking.ts
@@ -1,4 +1,4 @@
-import { updateAward } from "./utils";
+import { ClubAwardRequest, updateAward } from "./utils";
 import { secured } from "../../utils/auth";
 import { getFaunaClient } from "../../utils/fauna";
 import { badRequest, ok } from "../../utils/responses";
@@ -6,8 +6,7 @@ import { Router } from "../../utils/router";
 
 const router = new Router("/api/club/:clubId<\\d+>/awards/:year<\\d+>/ranking");
 
-router.post("/", secured, async (event, context, params) => {
-  const clubId = parseInt(params.clubId);
+router.post("/", secured, async ({ event, clubId, year }: ClubAwardRequest) => {
   if (!event.body) return badRequest("Missing body");
   const body = JSON.parse(event.body);
   if (!body.awardTitle) return badRequest("Missing award title in body");
@@ -19,7 +18,6 @@ router.post("/", secured, async (event, context, params) => {
     movies,
     voter,
   }: { awardTitle: string; movies: number[]; voter: string } = body;
-  const year = parseInt(params.year);
 
   const moviesWithRanking = movies.map((id, index) => ({
     id,
@@ -30,8 +28,8 @@ router.post("/", secured, async (event, context, params) => {
 
   await faunaClient.query(
     updateAward(
-      clubId,
-      year,
+      clubId!,
+      year!,
       awardTitle,
       q.Let(
         {

--- a/netlify/functions/club/awards/step.ts
+++ b/netlify/functions/club/awards/step.ts
@@ -1,21 +1,19 @@
-import { updateClubAwardYear } from "./utils";
+import { ClubAwardRequest, updateClubAwardYear } from "./utils";
 import { secured } from "../../utils/auth";
 import { getFaunaClient } from "../../utils/fauna";
 import { badRequest, ok } from "../../utils/responses";
 import { Router } from "../../utils/router";
 
 const router = new Router("/api/club/:clubId<\\d+>/awards/:year<\\d+>/step");
-router.put("/", secured, async (event, context, params) => {
-  const clubId = parseInt(params.clubId);
+router.put("/", secured, async ({ event, clubId, year }: ClubAwardRequest) => {
   if (!event.body) return badRequest("Missing body");
   const body = JSON.parse(event.body);
   if (!body.step) return badRequest("Missing step in body");
 
-  const year = parseInt(params.year);
   const step = parseInt(body.step);
   const { faunaClient } = getFaunaClient();
 
-  await faunaClient.query(updateClubAwardYear(clubId, year, { step }));
+  await faunaClient.query(updateClubAwardYear(clubId!, year!, { step }));
 
   return ok();
 });

--- a/netlify/functions/club/backlog.ts
+++ b/netlify/functions/club/backlog.ts
@@ -4,47 +4,54 @@ import { badRequest, notFound, ok } from "../utils/responses";
 import { Router } from "../utils/router";
 import { getWatchlistItemMovieData } from "../utils/tmdb";
 import { QueryResponse } from "../utils/types";
+import { ClubRequest } from "../utils/validation";
 
 import { Club, WatchListViewModel } from "@/common/types/models";
 
 const router = new Router("/api/club/:clubId<\\d+>/backlog");
 
-router.post("/:movieId<\\d+>", secured, async (event, context, params) => {
-  const clubId = parseInt(params.clubId);
-  const movieId = parseInt(params.movieId);
-  const { faunaClient, q } = getFaunaClient();
-  const watchListResult = await faunaClient.query<WatchListViewModel>(
-    q.Call(q.Function("GetWatchList"), clubId)
-  );
-  if (watchListResult.backlog.some((item) => item.movieId === movieId)) {
-    return badRequest("This movie already exists in the backlog");
-  }
-  const club = (
-    await faunaClient.query<QueryResponse<Club>>(
-      q.Call(q.Function("AddMovieToBacklog"), [clubId, movieId])
-    )
-  ).data;
-
-  const movie = (
-    await getWatchlistItemMovieData([club.backlog[club.backlog.length - 1]])
-  )[0];
-
-  return ok(JSON.stringify(movie));
-});
-
-router.delete("/:movieId<\\d+>", secured, async (event, context, params) => {
-  const clubId = parseInt(params.clubId);
-  const movieId = parseInt(params.movieId);
-  const { faunaClient, q } = getFaunaClient();
-  try {
-    await faunaClient.query(
-      q.Call(q.Function("DeleteBacklogItem"), [clubId, movieId])
+router.post(
+  "/:movieId<\\d+>",
+  secured,
+  async ({ params, clubId }: ClubRequest) => {
+    const movieId = parseInt(params.movieId);
+    const { faunaClient, q } = getFaunaClient();
+    const watchListResult = await faunaClient.query<WatchListViewModel>(
+      q.Call(q.Function("GetWatchList"), clubId!)
     );
-  } catch (err) {
-    return notFound(JSON.stringify(err));
-  }
+    if (watchListResult.backlog.some((item) => item.movieId === movieId)) {
+      return badRequest("This movie already exists in the backlog");
+    }
+    const club = (
+      await faunaClient.query<QueryResponse<Club>>(
+        q.Call(q.Function("AddMovieToBacklog"), [clubId, movieId])
+      )
+    ).data;
 
-  return ok();
-});
+    const movie = (
+      await getWatchlistItemMovieData([club.backlog[club.backlog.length - 1]])
+    )[0];
+
+    return ok(JSON.stringify(movie));
+  }
+);
+
+router.delete(
+  "/:movieId<\\d+>",
+  secured,
+  async ({ params, clubId }: ClubRequest) => {
+    const movieId = parseInt(params.movieId);
+    const { faunaClient, q } = getFaunaClient();
+    try {
+      await faunaClient.query(
+        q.Call(q.Function("DeleteBacklogItem"), [clubId, movieId])
+      );
+    } catch (err) {
+      return notFound(JSON.stringify(err));
+    }
+
+    return ok();
+  }
+);
 
 export default router;

--- a/netlify/functions/club/index.ts
+++ b/netlify/functions/club/index.ts
@@ -101,8 +101,8 @@ router.post("/", loggedIn, async ({ event }) => {
 
 router.put(
   "/:clubId<\\d+>/nextMovie",
-  secured,
   validClubId,
+  secured,
   async ({ event, clubId }: ClubRequest) => {
     if (!event.body) return badRequest("Missing body");
     let movieId: number;

--- a/netlify/functions/club/members.ts
+++ b/netlify/functions/club/members.ts
@@ -1,15 +1,15 @@
 import { getClubProperty, getFaunaClient } from "../utils/fauna";
 import { ok } from "../utils/responses";
 import { Router } from "../utils/router";
+import { ClubRequest } from "../utils/validation";
 
 const router = new Router("/api/club/:clubId<\\d+>/members");
 
-router.get("/", async (event, context, params) => {
+router.get("/", async ({ clubId }: ClubRequest) => {
   const { faunaClient, q } = getFaunaClient();
-  const clubId = parseInt(params.clubId);
   const members = await faunaClient.query(
     q.Map(
-      getClubProperty(clubId, "members"),
+      getClubProperty(clubId!, "members"),
       q.Lambda("memberRef", q.Select("data", q.Get(q.Var("memberRef"))))
     )
   );

--- a/netlify/functions/utils/auth.ts
+++ b/netlify/functions/utils/auth.ts
@@ -3,6 +3,7 @@ import { HandlerContext } from "@netlify/functions";
 import { getFaunaClient } from "./fauna";
 import { unauthorized } from "./responses";
 import { MiddlewareCallback } from "./router";
+import { ClubRequest } from "./validation";
 
 import { Member } from "@/common/types/models";
 
@@ -27,24 +28,23 @@ export async function isAuthorized(
   );
 }
 
-export const loggedIn: MiddlewareCallback = (event, context, params, next) => {
+export const loggedIn: MiddlewareCallback = ({ context }, next) => {
   if (!context.clientContext || !context.clientContext.user)
     return Promise.resolve(unauthorized());
   return next();
 };
 
-export const secured: MiddlewareCallback = (event, context, params, next) => {
-  return loggedIn(event, context, params, async () => {
+export const secured: MiddlewareCallback = (req: ClubRequest, next) => {
+  return loggedIn(req, async () => {
     const { faunaClient, q } = getFaunaClient();
 
-    const clubId = parseInt(params.clubId);
     const members = await faunaClient.query<MembersResponse>(
-      q.Call(q.Function("GetClubMembers"), clubId)
+      q.Call(q.Function("GetClubMembers"), req.clubId!)
     );
 
     if (
       members.members.some(
-        (member) => member.email === context.clientContext?.user.email
+        (member) => member.email === req.context.clientContext?.user.email
       )
     ) {
       return next();

--- a/netlify/functions/utils/auth.ts
+++ b/netlify/functions/utils/auth.ts
@@ -2,7 +2,7 @@ import { HandlerContext } from "@netlify/functions";
 
 import { getFaunaClient } from "./fauna";
 import { unauthorized } from "./responses";
-import { MiddewareCallback } from "./router";
+import { MiddlewareCallback } from "./router";
 
 import { Member } from "@/common/types/models";
 
@@ -27,13 +27,13 @@ export async function isAuthorized(
   );
 }
 
-export const loggedIn: MiddewareCallback = (event, context, params, next) => {
+export const loggedIn: MiddlewareCallback = (event, context, params, next) => {
   if (!context.clientContext || !context.clientContext.user)
     return Promise.resolve(unauthorized());
   return next();
 };
 
-export const secured: MiddewareCallback = (event, context, params, next) => {
+export const secured: MiddlewareCallback = (event, context, params, next) => {
   return loggedIn(event, context, params, async () => {
     const { faunaClient, q } = getFaunaClient();
 

--- a/netlify/functions/utils/validation.ts
+++ b/netlify/functions/utils/validation.ts
@@ -1,4 +1,33 @@
+import { getFaunaClient } from "./fauna";
+import { badRequest, notFound } from "./responses";
+import { MiddlewareCallback, Request } from "./router";
+
 export function getErrorMessage(error: unknown) {
-    if (error instanceof Error) return error.message;
-    return String(error);
+  if (error instanceof Error) return error.message;
+  return String(error);
 }
+
+export interface ClubRequest extends Request {
+  clubId?: number;
+}
+
+export const validClubId: MiddlewareCallback = async (
+  req: ClubRequest,
+  next
+) => {
+  if (!req.params.clubId) return notFound();
+  const clubId = parseInt(req.params.clubId);
+  if (isNaN(clubId)) return badRequest();
+
+  const { faunaClient, q } = getFaunaClient();
+  const clubExists = await faunaClient.query(
+    q.Exists(q.Match(q.Index("club_by_clubId"), clubId))
+  );
+
+  if (clubExists) {
+    req.clubId = clubId;
+    return next();
+  } else {
+    return notFound("Club not found");
+  }
+};

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     ],
     "rules": {
       "vue/no-setup-props-destructure": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
       "import/order": [
         "error",
         {


### PR DESCRIPTION
This fixes #127 
Changes:
- Changed the backend router slightly to pass around a `req` object similar to ExpressJS so now middleware functions can pass information to following handlers.
- Created `validClubId` middleware to verify clubId on every necessary route
- Similarly created `validYear` middleware to verify award year on every necessary route
- To get Typescript to play nice, I had to disable the non-null assertion rule which is the single ! operator. This just tells the compiler the value won't be null. I couldn't find a clean way to "prove" to the compiler that those values would not be null if the right middleware is run before the handler.