### PR TITLE
Add time_added timestamp column to work_list_item and migrate dates to new column

### DIFF
--- a/migrations/data/20240514_FixDateColumn.ts
+++ b/migrations/data/20240514_FixDateColumn.ts
@@ -1,0 +1,97 @@
+import { CockroachDialect } from "@cubos/kysely-cockroach";
+import { Kysely } from "kysely";
+import { Pool } from "pg";
+
+import { getFaunaClient } from "../../netlify/functions/utils/fauna";
+import { Document } from "../../netlify/functions/utils/types";
+import { DB, WorkListType } from "../../src/common/types/generated/db";
+import { WatchListItem as IdealWatchListItem } from "../../src/common/types/watchlist";
+
+type WatchListItem = Omit<IdealWatchListItem, "timeAdded"> & {
+  timeAdded?: { date: Date };
+  timeWatched?: { date: Date };
+};
+
+type Club = {
+  watchList: WatchListItem[];
+  backlog: WatchListItem[];
+};
+
+const { faunaClient, q } = getFaunaClient();
+
+export const db = new Kysely<DB>({
+  dialect: new CockroachDialect({
+    pool: new Pool({
+      connectionString: process.env.DATABASE_URL,
+    }),
+  }),
+});
+
+const migrateDatesToTimestamps = async () => {
+  // Fetch all work list items from CockroachDB
+  const workListItems = await db
+    .selectFrom("work_list_item")
+    .innerJoin("work_list", "work_list.id", "work_list_item.list_id")
+    .innerJoin("club", "club.id", "work_list.club_id")
+    .innerJoin("work", "work.id", "work_list_item.work_id")
+    .select([
+      "work_list_item.list_id",
+      "work_list_item.work_id",
+      "work_list_item.created_date",
+      "work.external_id",
+      "work.title",
+      "club.legacy_id",
+      "club.name",
+      "work_list.type",
+    ])
+    .execute();
+
+  const faunaClubMap = new Map<string, Club>();
+
+  for (const item of workListItems) {
+    let timestamp: Date | undefined;
+
+    let club: Club | undefined;
+    if (item.legacy_id && faunaClubMap.has(item.legacy_id)) {
+      club = faunaClubMap.get(item.legacy_id);
+    } else if (item.legacy_id) {
+      // Fetch the corresponding club from FaunaDB
+      const faunaData = await faunaClient.query<Document<Club>>(
+        q.Get(q.Match(q.Index("club_by_clubId"), parseInt(item.legacy_id)))
+      );
+      club = faunaData.data;
+      faunaClubMap.set(item.legacy_id, club);
+    }
+
+    if (club) {
+      const list =
+        item.type === WorkListType.backlog ? club.backlog : club.watchList;
+      const movie = list.find(
+        (movie) => movie.movieId.toString() === item.external_id
+      );
+      if (movie) {
+        timestamp = movie.timeAdded?.date ?? movie.timeWatched?.date;
+      }
+    }
+
+    if (!timestamp) {
+      timestamp = item.created_date ?? new Date();
+    }
+
+    console.log(
+      `Migrating work list item for work ${item.title} in club ${item.name} to timestamp ${timestamp}`
+    );
+    await db
+      .updateTable("work_list_item")
+      .set({
+        time_added: timestamp,
+      })
+      .where("list_id", "=", item.list_id)
+      .where("work_id", "=", item.work_id)
+      .execute();
+  }
+};
+
+migrateDatesToTimestamps().then(() =>
+  console.log("Migration of dates to timestamps completed")
+);

--- a/migrations/schema/20240511_ListDateColumn.ts
+++ b/migrations/schema/20240511_ListDateColumn.ts
@@ -1,0 +1,27 @@
+import { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>) {
+  await db.schema
+    .alterTable("work_list_item")
+    .alterColumn("created_date", (col) => col.dropNotNull())
+    .execute();
+
+  await db.schema
+    .alterTable("work_list_item")
+    .addColumn("time_added", "timestamptz", (col) =>
+      col.notNull().defaultTo("now()")
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>) {
+  await db.schema
+    .alterTable("work_list_item")
+    .alterColumn("created_date", (col) => col.setNotNull())
+    .execute();
+
+  await db.schema
+    .alterTable("work_list_item")
+    .dropColumn("time_added")
+    .execute();
+}

--- a/netlify/functions/club/list.ts
+++ b/netlify/functions/club/list.ts
@@ -22,7 +22,7 @@ router.get("/:type", async ({ clubId, params }: ClubRequest) => {
       id: item.id,
       title: item.title,
       type: item.type,
-      createdDate: item.created_date.toISOString(),
+      createdDate: item.time_added.toISOString(),
       imageUrl: item.image_url ?? undefined,
       externalId: item.external_id ?? undefined,
     }))

--- a/netlify/functions/repositories/ListRepository.ts
+++ b/netlify/functions/repositories/ListRepository.ts
@@ -18,7 +18,7 @@ class ListRepository {
         "work.type",
         "work.image_url",
         "work.external_id",
-        "work_list_item.created_date",
+        "work_list_item.time_added",
       ])
       .execute();
   }
@@ -46,7 +46,6 @@ class ListRepository {
       .values({
         list_id: this.listIdFromType(clubId, listType),
         work_id: workId,
-        created_date: new Date(),
       })
       .execute();
   }

--- a/src/common/types/generated/db.ts
+++ b/src/common/types/generated/db.ts
@@ -62,8 +62,9 @@ export interface WorkList {
 }
 
 export interface WorkListItem {
-  created_date: Timestamp;
+  created_date: Timestamp | null;
   list_id: Int8;
+  time_added: Generated<Timestamp>;
   work_id: Int8;
 }
 


### PR DESCRIPTION
Made an oopsie when creating the date column for work_list_items. Should be a timestamp instead of a date. This PR makes the created_date optional (for future removal) and add the required (and generated) time_added column.