### PR TITLE
Filter reviews by year

### DIFF
--- a/src/common/searchMovies.ts
+++ b/src/common/searchMovies.ts
@@ -13,12 +13,6 @@ import { DetailedWorkListItem } from "./types/lists";
  *
  * Incluidng multiple filters seperated by spaces will implicitly do an AND search between them.
  * 
- * Supported filters:
- * genre: filters by genre
- * title: filters by title
- * company: filters by production company
- * year: filters by year review was created (not when the movie came out)
- *
  * TODO: Add support for OR searches.
  * TODO: Create a new vue component for the search bar that highlights filters different colors.
  * TODO: Make the watchlist and backlog use DetailedMovie[] so they can use the same search function and bar.

--- a/src/common/searchMovies.ts
+++ b/src/common/searchMovies.ts
@@ -5,12 +5,19 @@ import { DetailedWorkListItem } from "./types/lists";
  * @param works
  * @param searchQuery
  * @returns reviews filtered by searchQuery.
+ * 
  *
  * You can apply filters on the searchQuery with text:value. For example, to filter by title and genre, you can use:
  *
  * "title:jaws genre:horror"
  *
  * Incluidng multiple filters seperated by spaces will implicitly do an AND search between them.
+ * 
+ * Supported filters:
+ * genre: filters by genre
+ * title: filters by title
+ * company: filters by production company
+ * year: filters by year review was created (not when the movie came out)
  *
  * TODO: Add support for OR searches.
  * TODO: Create a new vue component for the search bar that highlights filters different colors.
@@ -68,6 +75,12 @@ export function filterMovies<T extends DetailedWorkListItem>(
       review.externalData?.genres.some((genre) =>
         genre.toLocaleLowerCase().includes(filters.genre.toLowerCase()),
       ),
+    );
+  }
+
+  if (filters.year) {
+    filteredReviews = filteredReviews.filter((review) =>
+      new Date(review.createdDate).getFullYear() === parseInt(filters.year)
     );
   }
 

--- a/src/common/searchMovies.ts
+++ b/src/common/searchMovies.ts
@@ -6,13 +6,12 @@ import { DetailedWorkListItem } from "./types/lists";
  * @param searchQuery
  * @returns reviews filtered by searchQuery.
  * 
- *
  * You can apply filters on the searchQuery with text:value. For example, to filter by title and genre, you can use:
  *
  * "title:jaws genre:horror"
  *
  * Incluidng multiple filters seperated by spaces will implicitly do an AND search between them.
- * 
+ *
  * TODO: Add support for OR searches.
  * TODO: Create a new vue component for the search bar that highlights filters different colors.
  * TODO: Make the watchlist and backlog use DetailedMovie[] so they can use the same search function and bar.

--- a/src/common/searchMovies.ts
+++ b/src/common/searchMovies.ts
@@ -5,7 +5,7 @@ import { DetailedWorkListItem } from "./types/lists";
  * @param works
  * @param searchQuery
  * @returns reviews filtered by searchQuery.
- * 
+ *
  * You can apply filters on the searchQuery with text:value. For example, to filter by title and genre, you can use:
  *
  * "title:jaws genre:horror"


### PR DESCRIPTION
In preparation for awards season, we can now filter reviews by the year we watched them! Just type `year:2022` or whatever to see it in action 😄 

<img width="1470" alt="Screenshot 2024-12-22 at 10 23 33 AM" src="https://github.com/user-attachments/assets/1939e84a-6c5b-46a7-85bf-11dc5080cefb" />
