### PR TITLE
Fix scroll position persisting across route navigation

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -198,6 +198,10 @@ const routes: Array<RouteRecordRaw> = [
 const router = createRouter({
   routes,
   history: createWebHistory(),
+  scrollBehavior() {
+    // Always scroll to top when navigating between routes
+    return { top: 0 };
+  },
 });
 
 router.beforeEach((to, from) => {


### PR DESCRIPTION
Added scrollBehavior function to Vue Router configuration to ensure
pages always scroll to the top when navigating between routes. This
fixes the bug where scrolling on the club home page would cause
reviews, watch list, and statistics pages to start at the same
scroll position instead of at the top.