### PR TITLE
Make navigation cards responsive with CSS Grid layout

### DIFF
--- a/src/features/clubs/components/MenuCard.vue
+++ b/src/features/clubs/components/MenuCard.vue
@@ -1,10 +1,10 @@
 <template>
   <button
-    class="rounded-xl p-3 text-2xl tracking-wide duration-150 hover:brightness-105 active:brightness-110"
+    class="w-full rounded-xl p-2 text-base tracking-wide duration-150 hover:brightness-105 active:brightness-110 md:p-3 md:text-xl"
     :class="`bg-${bgColor}`"
     @click="emit('click')"
   >
-    <img :src="image" class="mx-auto mb-2 h-24 w-48" />
+    <img :src="image" class="mx-auto mb-1 h-16 w-32 md:mb-2 md:h-20 md:w-40" />
     <div class="prompt">
       <slot />
     </div>

--- a/src/features/clubs/views/ClubHomeView.vue
+++ b/src/features/clubs/views/ClubHomeView.vue
@@ -71,27 +71,20 @@
       </div>
     </div>
 
-    <div class="flex flex-col justify-center pb-6 md:flex-row">
-      <div class="p-3">
-        <router-link :to="{ name: 'Reviews' }">
-          <menu-card :image="reviewSvg"> Reviews </menu-card>
-        </router-link>
-      </div>
-      <div class="p-3">
-        <router-link :to="{ name: 'WatchList' }">
-          <menu-card :image="watchlistSvg"> Watch List </menu-card>
-        </router-link>
-      </div>
-      <div class="p-3">
-        <router-link :to="{ name: 'Statistics' }">
-          <menu-card :image="statisticsSvg"> Statistics </menu-card>
-        </router-link>
-      </div>
-      <div class="p-3">
-        <router-link :to="{ name: 'Awards' }">
-          <menu-card :image="awardsSvg"> Awards </menu-card>
-        </router-link>
-      </div>
+    <!-- Navigation cards grid -->
+    <div class="mx-auto grid max-w-5xl grid-cols-2 gap-3 px-4 pb-6 md:grid-cols-4">
+      <router-link :to="{ name: 'Reviews' }">
+        <menu-card :image="reviewSvg"> Reviews </menu-card>
+      </router-link>
+      <router-link :to="{ name: 'WatchList' }">
+        <menu-card :image="watchlistSvg"> Watch List </menu-card>
+      </router-link>
+      <router-link :to="{ name: 'Statistics' }">
+        <menu-card :image="statisticsSvg"> Statistics </menu-card>
+      </router-link>
+      <router-link :to="{ name: 'Awards' }">
+        <menu-card :image="awardsSvg"> Awards </menu-card>
+      </router-link>
     </div>
 
     <div class="flex justify-center">


### PR DESCRIPTION
- Replace flexbox layout with CSS Grid for better responsiveness
- Mobile: 2 columns, Desktop: 4 columns
- Reduce card sizes on mobile (smaller images and text)
- Scale up on larger screens using Tailwind responsive classes
- Grid automatically adapts to any number of navigation buttons
- Remove individual padding wrappers for cleaner markup