### PR TITLE
Fix profile photo upload not working

### DIFF
--- a/src/features/profile/views/ProfileView.vue
+++ b/src/features/profile/views/ProfileView.vue
@@ -60,7 +60,7 @@ const { mutate, isLoading: isAvatarLoading } = useUpdateAvatar();
 const toast = useToast();
 const uploadAvatar = (event: Event) => {
   const input = event.target as HTMLInputElement;
-  if (!isDefined(input.files) || input.files.length > 0) return;
+  if (!isDefined(input.files) || input.files.length === 0) return;
 
   const file = input.files[0];
   const maxFileSize = 6 * 1024 * 1024;


### PR DESCRIPTION
Fixed logic error in uploadAvatar function where the condition was checking if files.length > 0 instead of === 0, causing the function to return early when a file was actually selected.