### PR TITLE
Fix data refresh when creating new club

### DIFF
--- a/src/service/useClub.ts
+++ b/src/service/useClub.ts
@@ -33,7 +33,7 @@ export function useCreateClub() {
       members: string[];
     }) => auth.request.post(`/api/club`, { name: clubName, members }),
     onSuccess: () => {
-      queryClient.invalidateQueries(["clubs"]).catch(console.error);
+      queryClient.invalidateQueries(["user", "clubs"]).catch(console.error);
     },
   });
 }
@@ -77,10 +77,14 @@ export function useAddMembers(clubId: string) {
 export function useLeaveClub(clubId: string) {
   const auth = useAuthStore();
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: () => auth.request.delete(`/api/club/${clubId}/members/self`),
-    onSuccess: () => router.push({ name: "Clubs" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries(["user", "clubs"]).catch(console.error);
+      router.push({ name: "Clubs" }).catch(console.error);
+    },
   });
 }
 


### PR DESCRIPTION
Fixed cache invalidation issue where newly created clubs wouldn't appear and left clubs would still show until manual page refresh. The query key used for invalidation was ["clubs"] but should have been ["user", "clubs"] to match the actual query key used by useUserClubs().

- useCreateClub: Fixed query invalidation key from ["clubs"] to ["user", "clubs"]
- useLeaveClub: Added query invalidation for ["user", "clubs"] to update club list

Matches the pattern already used in useJoinClub().