### PR TITLE
fix: Stop event propagation on review score click handlers

### DIFF
--- a/src/features/reviews/components/ReviewScore.vue
+++ b/src/features/reviews/components/ReviewScore.vue
@@ -4,7 +4,7 @@
     :class="{
       'cursor-pointer': isMe,
     }"
-    @click="openScoreInput"
+    @click.stop="openScoreInput"
   >
     {{ score }}
   </span>
@@ -13,7 +13,7 @@
     role="button"
     aria-label="Add score"
     class="flex cursor-pointer justify-center"
-    @click="openScoreInput"
+    @click.stop="openScoreInput"
   >
     <mdicon name="plus" />
   </span>


### PR DESCRIPTION
Prevent the click events on the "+" icon and existing scores from
bubbling up to the parent MoviePosterCard, which was incorrectly
opening the movie details bottom sheet.