### PR TITLE
Add year range search filters to search bar

### DIFF
--- a/src/common/searchMovies.ts
+++ b/src/common/searchMovies.ts
@@ -52,7 +52,7 @@ export function filterMovies<T extends DetailedWorkListItem>(
 
   // If there are filters, remove the filter and the value from the search query.
   if (Object.keys(filters).length > 0) {
-    searchQuery = searchQuery.replace(/(\w+:\w+\s?)/g, "");
+    searchQuery = searchQuery.replace(/(\w+:\S+\s?)/g, "");
   }
 
   // If there are filters, filter the reviews by them.


### PR DESCRIPTION
Add support for comparison operators (<, >, <=, >=) in year filters. Users can now search for movies by year ranges, e.g.:
- year:<1950 - Movies before 1950
- year:>2000 - Movies after 2000
- year:<=1980 - Movies in or before 1980
- year:>=2010 - Movies in or after 2010

Exact year matching (year:2000) is still supported for backward compatibility.