### PR TITLE
fix: Disable create club button while mutation is pending

### DIFF
--- a/src/features/clubs/views/NewClubView.vue
+++ b/src/features/clubs/views/NewClubView.vue
@@ -27,7 +27,7 @@
       </div>
 
       <div class="mt-6 flex justify-evenly">
-        <v-btn @click="submit()"> Create club </v-btn>
+        <v-btn :disabled="isCreating" @click="submit()"> Create club </v-btn>
       </div>
     </div>
     <div v-else>Must be logged in to create a new club!</div>
@@ -49,12 +49,12 @@ const authStore = useAuthStore();
 const isLoggedIn = computed(() => authStore.isLoggedIn);
 
 const isClubNameValid = computed(() => clubName.value.trim().length > 0);
-const { mutate: createClub } = useCreateClub();
+const { mutate: createClub, isPending: isCreating } = useCreateClub();
 
 const submit = () => {
   showErrors.value = true;
 
-  if (!isClubNameValid.value) {
+  if (!isClubNameValid.value || isCreating.value) {
     return;
   }
 


### PR DESCRIPTION
Prevents duplicate club creation when clicking the button multiple times
rapidly by disabling the button while the createClub mutation is in progress.

https://claude.ai/code/session_01RZVRRAzkjz2QnLGVstA4hR