### PR TITLE
fix: Add spacing between search bar and action buttons on mobile watchlist

### DIFF
--- a/src/features/watch-list/views/WatchListView.vue
+++ b/src/features/watch-list/views/WatchListView.vue
@@ -10,7 +10,7 @@
       <loading-spinner v-if="isLoading" />
 
       <div v-if="!isLoading">
-        <div class="flex items-center justify-center" :class="'mb-0'">
+        <div class="mb-2 flex items-center justify-center">
           <div class="relative">
             <mdicon
               name="magnify"


### PR DESCRIPTION
The search container had an explicit mb-0 class removing bottom margin,
causing the search bar and Add Movie/Random buttons to appear too close
together on mobile devices.

https://claude.ai/code/session_0112MsZs7pojrT7vHEhvHvk7