### PR TITLE
fix: Allow deleting next watch movie from watchlist

### DIFF
--- a/src/features/watch-list/components/WatchList.vue
+++ b/src/features/watch-list/components/WatchList.vue
@@ -55,7 +55,7 @@
       <MoviePosterCard
         v-for="work in draggableList"
         :key="work.id"
-        :class="work.id === nextWorkId ? 'no-drag z-0' : 'z-10'"
+        :class="work.id === nextWorkId ? 'no-drag' : ''"
         :show-drag-handle="reorderMode && work.id !== nextWorkId"
         class="bg-background"
         :movie-title="work.title"

--- a/src/service/useList.ts
+++ b/src/service/useList.ts
@@ -88,9 +88,22 @@ export function useDeleteListItem(clubId: string, type: WorkListType) {
           return currentList.filter((item) => item.id !== workId);
         },
       );
+      if (type === WorkListType.watchlist) {
+        const nextWorkId = queryClient.getQueryData<string>([
+          "nextWork",
+          clubId,
+        ]);
+        if (nextWorkId === workId) {
+          queryClient.setQueryData(["nextWork", clubId], undefined);
+        }
+      }
     },
-    onSettled: () =>
-      queryClient.invalidateQueries({ queryKey: ["list", clubId, type] }),
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["list", clubId, type] });
+      if (type === WorkListType.watchlist) {
+        await queryClient.invalidateQueries({ queryKey: ["nextWork", clubId] });
+      }
+    },
   });
 }
 


### PR DESCRIPTION
The next watch item had z-0 while other items had z-10, causing
neighboring cards to overlap the delete button and making it
unclickable. Removed the z-index classes since the no-drag class
already prevents the next watch from being dragged.

Also invalidate the nextWork query cache when deleting a watchlist
item so stale next watch state is cleaned up.

https://claude.ai/code/session_017CmndDTEkVgQCf9zVaRG1U