### PR TITLE
Redesign stats page with Flighty-inspired bento grid layout

### DIFF
--- a/src/features/statistics/components/ClubConsensusWidget.vue
+++ b/src/features/statistics/components/ClubConsensusWidget.vue
@@ -1,9 +1,9 @@
 <template>
   <div
     v-if="consensus.mostAgreed.length > 0"
-    class="mx-auto grid w-11/12 grid-cols-1 gap-6 md:grid-cols-2"
+    class="grid grid-cols-1 gap-4 sm:grid-cols-2"
   >
-    <WidgetShell title="Most Agreed Upon" outer-class="w-full">
+    <WidgetShell title="Most Agreed Upon" icon="check-circle" outer-class="w-full">
       <div class="space-y-2">
         <div
           v-for="movie in consensus.mostAgreed"
@@ -48,7 +48,7 @@
       </div>
     </WidgetShell>
 
-    <WidgetShell title="Most Divisive" outer-class="w-full">
+    <WidgetShell title="Most Divisive" icon="scale-unbalanced" outer-class="w-full">
       <div class="space-y-2">
         <div
           v-for="movie in consensus.mostDivisive"

--- a/src/features/statistics/components/DecadeStatsWidget.vue
+++ b/src/features/statistics/components/DecadeStatsWidget.vue
@@ -1,12 +1,12 @@
 <template>
-  <WidgetShell v-if="decadeStats.length > 0" title="Scores by Decade">
+  <WidgetShell v-if="decadeStats.length > 0" title="Scores by Decade" icon="calendar-decade">
     <div class="mb-4 flex flex-wrap items-center gap-2">
       <button
         class="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-all"
         :class="
           !isDefined(selectedMemberId)
             ? 'bg-primary text-white shadow-md shadow-primary/25'
-            : 'bg-lowBackground text-gray-400 hover:bg-gray-600 hover:text-white'
+            : 'bg-slate-700/50 text-slate-300 hover:bg-slate-600'
         "
         @click="selectedMemberId = undefined"
       >
@@ -19,7 +19,7 @@
         :class="
           selectedMemberId === member.id
             ? 'bg-primary text-white shadow-md shadow-primary/25'
-            : 'bg-lowBackground text-gray-400 hover:bg-gray-600 hover:text-white'
+            : 'bg-slate-700/50 text-slate-300 hover:bg-slate-600'
         "
         @click="selectedMemberId = member.id"
       >

--- a/src/features/statistics/components/GenreStatsWidget.vue
+++ b/src/features/statistics/components/GenreStatsWidget.vue
@@ -1,15 +1,14 @@
 <template>
   <div
     v-if="genreStats.mostLoved.length > 0 || genreStats.leastLoved.length > 0"
-    class="mx-auto w-11/12"
   >
-    <div class="mb-4 flex flex-wrap items-center gap-2">
+    <div class="mb-3 flex flex-wrap items-center gap-2">
       <button
         class="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-all"
         :class="
           !isDefined(selectedMemberId)
             ? 'bg-primary text-white shadow-md shadow-primary/25'
-            : 'bg-lowBackground text-gray-400 hover:bg-gray-600 hover:text-white'
+            : 'bg-slate-700/50 text-slate-300 hover:bg-slate-600'
         "
         @click="selectedMemberId = undefined"
       >
@@ -22,7 +21,7 @@
         :class="
           selectedMemberId === member.id
             ? 'bg-primary text-white shadow-md shadow-primary/25'
-            : 'bg-lowBackground text-gray-400 hover:bg-gray-600 hover:text-white'
+            : 'bg-slate-700/50 text-slate-300 hover:bg-slate-600'
         "
         @click="selectedMemberId = member.id"
       >
@@ -31,31 +30,40 @@
       </button>
     </div>
 
-    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <WidgetShell
         v-if="genreStats.mostLoved.length > 0"
         title="Most Loved Genres"
+        icon="heart"
         outer-class="w-full"
       >
         <ul class="space-y-3">
           <li
             v-for="(genre, index) in genreStats.mostLoved"
             :key="genre.genre"
-            class="flex items-center justify-between"
           >
-            <div class="flex items-center gap-3">
-              <span class="text-2xl font-bold text-green-400">
-                {{ index + 1 }}
-              </span>
-              <span class="text-white">{{ genre.genre }}</span>
+            <div class="mb-1.5 flex items-center justify-between">
+              <div class="flex items-center gap-3">
+                <div class="h-5 w-1 shrink-0 rounded-full bg-green-400" />
+                <div>
+                  <span class="text-sm text-white">{{ genre.genre }}</span>
+                  <span class="ml-2 text-xs text-slate-500">#{{ index + 1 }}</span>
+                </div>
+              </div>
+              <div class="flex items-center gap-2 text-sm">
+                <span class="text-xs text-slate-400">{{ genre.count }} films</span>
+                <span
+                  class="min-w-[3rem] rounded bg-green-900/50 px-2 py-0.5 text-center text-xs font-semibold text-green-300"
+                >
+                  {{ genre.averageScore }}
+                </span>
+              </div>
             </div>
-            <div class="flex items-center gap-3 text-sm">
-              <span class="text-gray-400">{{ genre.count }} movies</span>
-              <span
-                class="min-w-[3rem] rounded bg-green-900/50 px-2 py-1 text-center font-semibold text-green-300"
-              >
-                {{ genre.averageScore }}
-              </span>
+            <div class="h-1 w-full overflow-hidden rounded-full bg-slate-700/50">
+              <div
+                class="h-full rounded-full bg-green-400/60"
+                :style="{ width: scoreBarWidth(genre.averageScore) + '%' }"
+              />
             </div>
           </li>
         </ul>
@@ -64,27 +72,36 @@
       <WidgetShell
         v-if="genreStats.leastLoved.length > 0"
         title="Least Loved Genres"
+        icon="heart-broken"
         outer-class="w-full"
       >
         <ul class="space-y-3">
           <li
             v-for="(genre, index) in genreStats.leastLoved"
             :key="genre.genre"
-            class="flex items-center justify-between"
           >
-            <div class="flex items-center gap-3">
-              <span class="text-2xl font-bold text-red-400">
-                {{ index + 1 }}
-              </span>
-              <span class="text-white">{{ genre.genre }}</span>
+            <div class="mb-1.5 flex items-center justify-between">
+              <div class="flex items-center gap-3">
+                <div class="h-5 w-1 shrink-0 rounded-full bg-red-400" />
+                <div>
+                  <span class="text-sm text-white">{{ genre.genre }}</span>
+                  <span class="ml-2 text-xs text-slate-500">#{{ index + 1 }}</span>
+                </div>
+              </div>
+              <div class="flex items-center gap-2 text-sm">
+                <span class="text-xs text-slate-400">{{ genre.count }} films</span>
+                <span
+                  class="min-w-[3rem] rounded bg-red-900/50 px-2 py-0.5 text-center text-xs font-semibold text-red-300"
+                >
+                  {{ genre.averageScore }}
+                </span>
+              </div>
             </div>
-            <div class="flex items-center gap-3 text-sm">
-              <span class="text-gray-400">{{ genre.count }} movies</span>
-              <span
-                class="min-w-[3rem] rounded bg-red-900/50 px-2 py-1 text-center font-semibold text-red-300"
-              >
-                {{ genre.averageScore }}
-              </span>
+            <div class="h-1 w-full overflow-hidden rounded-full bg-slate-700/50">
+              <div
+                class="h-full rounded-full bg-red-400/60"
+                :style="{ width: scoreBarWidth(genre.averageScore) + '%' }"
+              />
             </div>
           </li>
         </ul>
@@ -114,4 +131,8 @@ const selectedMemberId = ref<string | undefined>(undefined);
 const genreStats = computed(() =>
   computeGenreStats(props.movieData, selectedMemberId.value),
 );
+
+function scoreBarWidth(score: number): number {
+  return Math.round((score / 10) * 100);
+}
 </script>

--- a/src/features/statistics/components/GenreWatchCountWidget.vue
+++ b/src/features/statistics/components/GenreWatchCountWidget.vue
@@ -1,74 +1,69 @@
 <template>
-  <div v-if="watchCounts.mostWatched.length > 0" class="mx-auto w-11/12">
-    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
-      <WidgetShell title="Most Watched Genres" outer-class="w-full">
-        <ul class="space-y-3">
-          <li
-            v-for="(genre, index) in watchCounts.mostWatched"
-            :key="genre.genre"
-            class="flex items-center justify-between"
-          >
+  <div v-if="watchCounts.mostWatched.length > 0" class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+    <WidgetShell title="Most Watched Genres" icon="eye" outer-class="w-full">
+      <ul class="space-y-3">
+        <li
+          v-for="(genre, index) in watchCounts.mostWatched"
+          :key="genre.genre"
+        >
+          <div class="mb-1.5 flex items-center justify-between">
             <div class="flex items-center gap-3">
-              <span class="text-2xl font-bold text-green-400">
-                {{ index + 1 }}
-              </span>
-              <div class="flex flex-col">
-                <span class="text-white">{{ genre.genre }}</span>
-                <div
-                  class="mt-1 h-1.5 w-24 overflow-hidden rounded-full bg-gray-700"
-                >
-                  <div
-                    class="h-full rounded-full bg-green-400"
-                    :style="{ width: barWidth(genre.count) }"
-                  />
-                </div>
+              <div class="h-5 w-1 shrink-0 rounded-full bg-green-400" />
+              <div>
+                <span class="text-sm text-white">{{ genre.genre }}</span>
+                <span class="ml-2 text-xs text-slate-500">#{{ index + 1 }}</span>
               </div>
             </div>
             <span
-              class="min-w-[3rem] rounded bg-green-900/50 px-2 py-1 text-center text-sm font-semibold text-green-300"
+              class="min-w-[3rem] rounded bg-green-900/50 px-2 py-0.5 text-center text-xs font-semibold text-green-300"
             >
               {{ genre.count }}
             </span>
-          </li>
-        </ul>
-      </WidgetShell>
+          </div>
+          <div class="h-1 w-full overflow-hidden rounded-full bg-slate-700/50">
+            <div
+              class="h-full rounded-full bg-green-400/60"
+              :style="{ width: barWidth(genre.count) }"
+            />
+          </div>
+        </li>
+      </ul>
+    </WidgetShell>
 
-      <WidgetShell
-        v-if="watchCounts.leastWatched.length > 0"
-        title="Least Watched Genres"
-        outer-class="w-full"
-      >
-        <ul class="space-y-3">
-          <li
-            v-for="(genre, index) in watchCounts.leastWatched"
-            :key="genre.genre"
-            class="flex items-center justify-between"
-          >
+    <WidgetShell
+      v-if="watchCounts.leastWatched.length > 0"
+      title="Least Watched Genres"
+      icon="eye-off"
+      outer-class="w-full"
+    >
+      <ul class="space-y-3">
+        <li
+          v-for="(genre, index) in watchCounts.leastWatched"
+          :key="genre.genre"
+        >
+          <div class="mb-1.5 flex items-center justify-between">
             <div class="flex items-center gap-3">
-              <span class="text-2xl font-bold text-red-400">
-                {{ index + 1 }}
-              </span>
-              <div class="flex flex-col">
-                <span class="text-white">{{ genre.genre }}</span>
-                <div
-                  class="mt-1 h-1.5 w-24 overflow-hidden rounded-full bg-gray-700"
-                >
-                  <div
-                    class="h-full rounded-full bg-red-400"
-                    :style="{ width: barWidth(genre.count) }"
-                  />
-                </div>
+              <div class="h-5 w-1 shrink-0 rounded-full bg-red-400" />
+              <div>
+                <span class="text-sm text-white">{{ genre.genre }}</span>
+                <span class="ml-2 text-xs text-slate-500">#{{ index + 1 }}</span>
               </div>
             </div>
             <span
-              class="min-w-[3rem] rounded bg-red-900/50 px-2 py-1 text-center text-sm font-semibold text-red-300"
+              class="min-w-[3rem] rounded bg-red-900/50 px-2 py-0.5 text-center text-xs font-semibold text-red-300"
             >
               {{ genre.count }}
             </span>
-          </li>
-        </ul>
-      </WidgetShell>
-    </div>
+          </div>
+          <div class="h-1 w-full overflow-hidden rounded-full bg-slate-700/50">
+            <div
+              class="h-full rounded-full bg-red-400/60"
+              :style="{ width: barWidth(genre.count) }"
+            />
+          </div>
+        </li>
+      </ul>
+    </WidgetShell>
   </div>
 </template>
 

--- a/src/features/statistics/components/LeaderboardsWidget.vue
+++ b/src/features/statistics/components/LeaderboardsWidget.vue
@@ -1,9 +1,6 @@
 <template>
-  <div class="mx-auto grid w-11/12 grid-cols-1 gap-6 md:grid-cols-2">
-    <WidgetShell
-      outer-class="w-full"
-      inner-class="rounded-xl border border-slate-700/50 bg-lowBackground/60 p-6"
-    >
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+    <WidgetShell outer-class="w-full">
       <PersonLeaderboard
         title="Most Watched Directors"
         :entries="topDirectors"
@@ -11,10 +8,7 @@
       />
     </WidgetShell>
 
-    <WidgetShell
-      outer-class="w-full"
-      inner-class="rounded-xl border border-slate-700/50 bg-lowBackground/60 p-6"
-    >
+    <WidgetShell outer-class="w-full">
       <PersonLeaderboard
         title="Most Watched Actors"
         :entries="topActors"

--- a/src/features/statistics/components/ReviewerLeaderboardWidget.vue
+++ b/src/features/statistics/components/ReviewerLeaderboardWidget.vue
@@ -1,37 +1,42 @@
 <template>
-  <WidgetShell v-if="leaderboard.length > 0" title="Reviewer Stats">
-    <p class="mb-4 text-sm text-slate-400">Average score per member</p>
+  <WidgetShell v-if="leaderboard.length > 0" title="Reviewer Stats" icon="account-group">
+    <p class="mb-4 text-xs text-slate-400">Average score per member</p>
     <ul class="space-y-3">
       <li
         v-for="entry in leaderboard"
         :key="entry.member.id"
-        class="flex items-center justify-between rounded-lg px-3 py-2"
+        class="flex items-center gap-3 rounded-lg px-3 py-2"
       >
-        <div class="flex items-center gap-3">
-          <v-avatar
-            :src="entry.member.image"
-            :name="entry.member.name"
-            :size="36"
-          />
-          <div>
-            <span class="font-medium text-white">
-              {{ entry.member.name }}
-            </span>
-            <span
-              v-if="entry.title"
-              class="ml-2 rounded px-2 py-0.5 text-xs font-semibold"
-              :class="titleBadgeClass(entry.title)"
-            >
-              {{ entry.title }}
+        <v-avatar
+          :src="entry.member.image"
+          :name="entry.member.name"
+          :size="36"
+        />
+        <div class="min-w-0 flex-1">
+          <div class="mb-1.5 flex items-center justify-between gap-2">
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-white">
+                {{ entry.member.name }}
+              </span>
+              <span
+                v-if="entry.title"
+                class="rounded px-2 py-0.5 text-xs font-semibold"
+                :class="titleBadgeClass(entry.title)"
+              >
+                {{ entry.title }}
+              </span>
+            </div>
+            <span class="shrink-0 text-sm font-bold text-white">
+              {{ entry.averageScore }}
             </span>
           </div>
-        </div>
-        <div class="flex items-center gap-4 text-sm">
-          <span
-            class="min-w-[3.5rem] rounded px-2 py-1 text-center font-semibold text-slate-300"
-          >
-            {{ entry.averageScore }}
-          </span>
+          <div class="h-1.5 w-full overflow-hidden rounded-full bg-slate-700/50">
+            <div
+              class="h-full rounded-full transition-all duration-500"
+              :class="barColor(Number(entry.averageScore))"
+              :style="{ width: barWidth(Number(entry.averageScore)) + '%' }"
+            />
+          </div>
         </div>
       </li>
     </ul>
@@ -58,5 +63,15 @@ const leaderboard = computed(() =>
 function titleBadgeClass(title: string): string {
   if (title === "The Softie") return "bg-amber-900/50 text-amber-300";
   return "bg-red-900/50 text-red-300";
+}
+
+function barColor(score: number): string {
+  if (score >= 7.5) return "bg-emerald-500/70";
+  if (score >= 5) return "bg-primary/70";
+  return "bg-orange-500/70";
+}
+
+function barWidth(score: number): number {
+  return (score / 10) * 100;
 }
 </script>

--- a/src/features/statistics/components/StatsWidget.vue
+++ b/src/features/statistics/components/StatsWidget.vue
@@ -1,18 +1,18 @@
 <template>
-  <div class="mx-auto flex w-11/12 gap-3 pt-4">
+  <div class="flex gap-3 pt-1">
     <div
-      class="flex flex-1 flex-col items-center rounded-xl border border-slate-700 bg-lowBackground py-5"
+      class="flex flex-1 flex-col items-center rounded-xl border border-slate-700 bg-lowBackground py-6"
     >
-      <mdicon name="filmstrip" class="mb-2 text-primary" :size="20" />
-      <p class="text-3xl font-bold text-white">{{ totalMovies }}</p>
-      <p class="text-xs tracking-wide text-slate-400">movies watched</p>
+      <mdicon name="filmstrip" class="mb-2 text-primary" :size="22" />
+      <p class="text-5xl font-black text-white">{{ totalMovies }}</p>
+      <p class="mt-1 text-xs tracking-wide text-slate-400">movies watched</p>
     </div>
     <div
-      class="flex flex-1 flex-col items-center rounded-xl border border-slate-700 bg-lowBackground py-5"
+      class="flex flex-1 flex-col items-center rounded-xl border border-slate-700 bg-lowBackground py-6"
     >
-      <mdicon name="clock-outline" class="mb-2 text-primary" :size="20" />
-      <p class="text-3xl font-bold text-white">{{ formattedTime }}</p>
-      <p class="text-xs tracking-wide text-slate-400">
+      <mdicon name="clock-outline" class="mb-2 text-primary" :size="22" />
+      <p class="text-5xl font-black text-white">{{ formattedTime }}</p>
+      <p class="mt-1 text-xs tracking-wide text-slate-400">
         watch time<template v-if="totalDays > 0">
           ({{ totalDays }} {{ totalDays === 1 ? "day" : "days" }})</template
         >

--- a/src/features/statistics/components/TasteSimilarityWidget.vue
+++ b/src/features/statistics/components/TasteSimilarityWidget.vue
@@ -1,25 +1,26 @@
 <template>
   <div v-if="tasteSimilarity.mostSimilar || tasteSimilarity.leastSimilar">
-    <div class="mx-auto mb-4 flex w-11/12 flex-col gap-1">
-      <div class="flex items-center gap-2">
-        <v-switch v-model="useNormalized" color="primary" />
+    <div class="mb-3 flex items-center gap-2">
+      <v-switch v-model="useNormalized" color="primary" />
+      <div>
         <span class="text-sm text-gray-300">Normalized Scores</span>
+        <p class="text-xs text-slate-500">
+          {{
+            useNormalized
+              ? "Comparing relative taste — ignores whether someone rates high or low overall"
+              : "Comparing raw scores directly"
+          }}
+        </p>
       </div>
-      <p class="text-xs text-slate-500">
-        {{
-          useNormalized
-            ? "Comparing relative taste — ignores whether someone rates high or low overall"
-            : "Comparing raw scores directly"
-        }}
-      </p>
     </div>
-    <div class="mx-auto grid w-11/12 grid-cols-1 gap-6 md:grid-cols-2">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <WidgetShell
         v-if="tasteSimilarity.mostSimilar"
         title="Most Similar Taste"
+        icon="hand-heart"
         outer-class="w-full"
       >
-        <div class="mb-4 flex items-center justify-center gap-3">
+        <div class="mb-4 flex items-center justify-center gap-4">
           <div class="flex flex-col items-center">
             <v-avatar
               :src="tasteSimilarity.mostSimilar.memberA.image"
@@ -30,8 +31,8 @@
               firstName(tasteSimilarity.mostSimilar.memberA.name)
             }}</span>
           </div>
-          <div class="flex flex-col items-center px-3">
-            <span class="text-2xl font-bold text-green-400"
+          <div class="flex flex-col items-center px-2">
+            <span class="text-4xl font-black text-green-400"
               >{{ tasteSimilarity.mostSimilar.similarityPercent }}%</span
             >
             <span class="text-xs text-slate-400">similar</span>
@@ -84,9 +85,10 @@
       <WidgetShell
         v-if="tasteSimilarity.leastSimilar"
         title="Least Similar Taste"
+        icon="compare"
         outer-class="w-full"
       >
-        <div class="mb-4 flex items-center justify-center gap-3">
+        <div class="mb-4 flex items-center justify-center gap-4">
           <div class="flex flex-col items-center">
             <v-avatar
               :src="tasteSimilarity.leastSimilar.memberA.image"
@@ -97,8 +99,8 @@
               firstName(tasteSimilarity.leastSimilar.memberA.name)
             }}</span>
           </div>
-          <div class="flex flex-col items-center px-3">
-            <span class="text-2xl font-bold text-red-400"
+          <div class="flex flex-col items-center px-2">
+            <span class="text-4xl font-black text-red-400"
               >{{ tasteSimilarity.leastSimilar.similarityPercent }}%</span
             >
             <span class="text-xs text-slate-400">similar</span>

--- a/src/features/statistics/components/TmdbDeviationWidget.vue
+++ b/src/features/statistics/components/TmdbDeviationWidget.vue
@@ -4,11 +4,12 @@
       deviation.clubRatedHigher.length > 0 ||
       deviation.clubRatedLower.length > 0
     "
-    class="mx-auto grid w-11/12 grid-cols-1 gap-6 md:grid-cols-2"
+    class="grid grid-cols-1 gap-4 sm:grid-cols-2"
   >
     <WidgetShell
       v-if="deviation.clubRatedHigher.length > 0"
       title="Club Rated Higher"
+      icon="trending-up"
       outer-class="w-full"
     >
       <div class="space-y-2">
@@ -56,6 +57,7 @@
     <WidgetShell
       v-if="deviation.clubRatedLower.length > 0"
       title="Club Rated Lower"
+      icon="trending-down"
       outer-class="w-full"
     >
       <div class="space-y-2">

--- a/src/features/statistics/components/WidgetShell.vue
+++ b/src/features/statistics/components/WidgetShell.vue
@@ -1,9 +1,10 @@
 <template>
-  <div class="mx-auto w-11/12" :class="outerClass">
-    <div :class="innerClass ?? 'rounded-lg bg-lowBackground p-5'">
-      <h3 v-if="title" class="mb-4 text-lg font-bold text-white">
-        {{ title }}
-      </h3>
+  <div :class="outerClass">
+    <div :class="innerClass ?? 'rounded-lg border border-slate-700/50 bg-lowBackground p-5'">
+      <div v-if="title" class="mb-4 flex items-center gap-2">
+        <mdicon v-if="icon" :name="icon" class="text-slate-400" :size="18" />
+        <h3 class="text-base font-semibold text-white">{{ title }}</h3>
+      </div>
       <slot />
     </div>
   </div>
@@ -12,6 +13,7 @@
 <script setup lang="ts">
 defineProps<{
   title?: string;
+  icon?: string;
   outerClass?: string;
   innerClass?: string;
 }>();

--- a/src/features/statistics/views/InsightsView.vue
+++ b/src/features/statistics/views/InsightsView.vue
@@ -1,26 +1,47 @@
 <template>
-  <div class="space-y-6 pb-6">
+  <div class="grid grid-cols-1 gap-4 px-4 pb-6 sm:grid-cols-2 lg:grid-cols-3 lg:px-6">
     <StatsWidget :movie-data="movieData" />
     <ScoreDistributionWidget
+      class="sm:col-span-1 lg:col-span-2"
       :movie-data="movieData"
       :members="members"
       :histogram-data="histogramData"
     />
-    <ScoreTrendWidget :movie-data="movieData" :members="members" />
-    <GenreStatsWidget :movie-data="movieData" :members="members" />
-    <GenreWatchCountWidget :movie-data="movieData" />
-    <DecadeStatsWidget :movie-data="movieData" :members="members" />
+    <ScoreTrendWidget
+      class="sm:col-span-2 lg:col-span-3"
+      :movie-data="movieData"
+      :members="members"
+    />
     <ReviewerLeaderboardWidget
       v-if="members.length > 1"
       :movie-data="movieData"
       :members="members"
     />
-    <TasteSimilarityWidget
-      v-if="members.length > 2"
+    <GenreStatsWidget
+      class="sm:col-span-1 lg:col-span-2"
       :movie-data="movieData"
       :members="members"
     />
-    <ClubConsensusWidget :movie-data="movieData" :members="members" />
+    <GenreWatchCountWidget
+      class="sm:col-span-2 lg:col-span-3"
+      :movie-data="movieData"
+    />
+    <DecadeStatsWidget
+      class="sm:col-span-1 lg:col-span-2"
+      :movie-data="movieData"
+      :members="members"
+    />
+    <TasteSimilarityWidget
+      v-if="members.length > 2"
+      class="sm:col-span-2 lg:col-span-3"
+      :movie-data="movieData"
+      :members="members"
+    />
+    <ClubConsensusWidget
+      class="sm:col-span-2 lg:col-span-3"
+      :movie-data="movieData"
+      :members="members"
+    />
     <GuiltyPleasuresWidget
       v-if="members.length > 1"
       :movie-data="movieData"
@@ -31,8 +52,14 @@
       :movie-data="movieData"
       :members="members"
     />
-    <LeaderboardsWidget :movie-data="movieData" />
-    <TmdbDeviationWidget :movie-data="movieData" />
+    <LeaderboardsWidget
+      class="sm:col-span-2 lg:col-span-3"
+      :movie-data="movieData"
+    />
+    <TmdbDeviationWidget
+      class="sm:col-span-2 lg:col-span-3"
+      :movie-data="movieData"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
- Replace vertical stack with responsive 1/2/3-col bento grid in InsightsView
- WidgetShell: remove mx-auto w-11/12 centering, add subtle border, support optional icon prop
- StatsWidget: scale up key numbers to text-5xl font-black for visual prominence
- ReviewerLeaderboardWidget: add Flighty-style proportional fill bars per member
- GenreStatsWidget/GenreWatchCountWidget: replace rank numbers with colored left-bar indicators and full-width proportion bars
- DecadeStatsWidget: refine filter pill styling
- TasteSimilarityWidget: scale similarity % to text-4xl font-black, remove outer wrappers
- ClubConsensusWidget/LeaderboardsWidget/TmdbDeviationWidget: remove mx-auto w-11/12 outer wrappers so parent grid controls layout

https://claude.ai/code/session_01SZAvCP74GKdKFhXmi2TfHQ