### PR TITLE
Fix directors displaying as [object Object] in mobile movie details

### DIFF
--- a/src/features/reviews/components/MovieDetailsContent.vue
+++ b/src/features/reviews/components/MovieDetailsContent.vue
@@ -266,7 +266,11 @@
           </div>
           <div v-if="movie.original.externalData?.directors?.length">
             <span class="text-gray-400">Director: </span>
-            <span>{{ movie.original.externalData.directors.join(", ") }}</span>
+            <span>{{
+              movie.original.externalData.directors
+                .map((d) => d.name)
+                .join(", ")
+            }}</span>
           </div>
           <div
             v-if="movie.original.externalData?.actors?.length"


### PR DESCRIPTION
The mobile layout's director display was calling .join() directly on director
objects instead of mapping to .name first, unlike the desktop layout.

https://claude.ai/code/session_019NYCepAXQrnLRFc8xUSs4Y