### PR TITLE
Split CLAUDE.md into path-scoped rules files

### DIFF
--- a/.claude/rules/backend-architecture.md
+++ b/.claude/rules/backend-architecture.md
@@ -1,0 +1,110 @@
+---
+paths:
+  - "netlify/**"
+---
+
+# Backend Architecture (Netlify Functions)
+
+## Custom Router System
+
+Located in `netlify/functions/utils/router.ts`. A type-safe Express-like router supporting middleware chaining with type transformations, path parameter extraction via `path-parser`, method routing (GET, POST, PUT, DELETE), sub-routers with `use()`, and automatic 404/405 responses.
+
+```typescript
+const router = new Router("/api/club");
+router.use("/:clubSlug/list", validClubSlug, listRouter);
+router.get("/:clubSlug", validClubSlug, async ({ clubSlug }, res) => {
+  const club = await ClubRepository.getBySlug(clubSlug);
+  return res(ok(JSON.stringify(result)));
+});
+```
+
+## API Structure
+
+- `/api/og-image` - Open Graph image generation for shared reviews
+- `/api/auth/*` - BetterAuth endpoints (handled automatically)
+- `/api/club/*` - All club-related endpoints
+  - `/:clubSlug/list` - Watchlist/backlog management
+    - `PUT /:type/reorder` - Reorder list items
+    - `PUT /:type/:workId/added-date` - Update item added date
+  - `/:clubSlug/reviews` - Movie reviews
+    - `GET /:workId/shared` - Shared review data for external sharing
+    - `GET /:workId/comments` - Get comments for a work
+    - `POST /:workId/comments` - Add comment to a work
+    - `PUT /:workId/comments/:commentId` - Update a comment
+    - `DELETE /:workId/comments/:commentId` - Delete a comment
+  - `/:clubSlug/members` - Club membership
+  - `/:clubSlug/awards` - Awards system (categories, nominations, rankings)
+  - `/:clubSlug/invite` - Invite token management
+  - `/:clubSlug/settings` - Club settings
+  - `/:clubSlug/nextWork` - Current movie being watched
+  - `/:clubSlug/name` - Update club name (PUT)
+  - `/:clubSlug/slug` - Update club slug (PUT)
+  - `/join` - Join club via invite
+  - `/joinInfo/:token` - Get club info from invite token
+- `/api/member/*` - User-specific endpoints
+  - `/clubs` - Get user's clubs
+  - `POST /avatar` - Upload avatar
+  - `DELETE /avatar` - Delete avatar
+  - `PUT /name` - Update user name
+
+## Key Backend Patterns
+
+- Repository pattern for data access (e.g., `ClubRepository`, `UserRepository`, `WorkRepository`)
+- Middleware for authentication (`loggedIn`, `secured`) and validation (`validClubSlug`)
+- Zod schemas for request body validation
+- Kysely for type-safe database queries
+- Response helpers from `utils/responses.ts` (`ok`, `badRequest`, `unauthorized`, `notFound`, `svg`, `redirect`)
+
+## Repository Classes
+
+Located in `netlify/functions/repositories/`:
+
+- `ClubRepository` - Club CRUD, membership checks, invites
+- `UserRepository` - User lookup and management
+- `WorkRepository` - Movie/work management
+- `ListRepository` - List operations (reviews, watchlist, backlog)
+- `ReviewRepository` - Review data access
+- `AwardsRepository` - Awards system data
+- `SettingsRepository` - Club settings storage
+- `ImageRepository` - Cloudinary image management
+- `DatabaseCleanupRepository` - Preview database lifecycle management
+- `MovieRefreshRepository` - Movie data refresh operations
+- `WorkCommentRepository` - Work comment CRUD
+
+## Scheduled Functions
+
+- `netlify/functions/scheduled-db-cleanup.ts` - Daily cleanup of stale preview databases
+- `netlify/functions/scheduled-movie-refresh.ts` - Scheduled movie data refresh
+
+## Edge Functions
+
+- `netlify/edge-functions/shared-review.ts` - Edge function for shared review pages (`/share/club/:clubSlug/review/:workId`)
+
+## Netlify Plugins
+
+- `netlify/plugins/preview-database/` - Preview database management for deploy previews
+- `netlify/plugins/auth-config/` - Authentication configuration for deploys
+
+## Authentication (Backend)
+
+Backend uses `loggedIn` (any authenticated user) and `secured` (authenticated + club member) middleware. See `better-auth-best-practices` skill for general BetterAuth patterns.
+
+- `netlify/functions/utils/auth.ts` — BetterAuth server config (bcrypt hashing, Google OAuth, Resend emails, mixed ID generation: auto-increment for users, UUIDs for sessions)
+
+## Key Backend Files
+
+- `netlify/functions/club/index.ts` - Main club API router
+- `netlify/functions/auth.ts` - BetterAuth handler
+- `netlify/functions/member.ts` - Member API endpoints
+- `netlify/functions/utils/router.ts` - Custom routing framework
+- `netlify/functions/utils/database.ts` - Database connection singleton
+- `netlify/functions/utils/auth.ts` - Auth configuration and middleware
+- `netlify/functions/utils/responses.ts` - HTTP response helpers
+- `netlify/functions/utils/validation.ts` - Request validation middleware
+- `netlify/functions/utils/slug.ts` - Slug generation and validation
+- `netlify/functions/utils/email.ts` - Resend email templates
+- `netlify/functions/utils/workDetailsMapper.ts` - Work-to-external-data mapper
+- `netlify/functions/utils/movieDetailsUpdater.ts` - Movie details update utility
+- `netlify/functions/og-image.ts` - Open Graph image generation
+- `netlify/functions/services/SharedReviewService.ts` - Shared review data service
+- `lib/types/*.ts` - Shared type definitions (club, movie, reviews, awards, lists, common, watchlist, etc.)

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -1,0 +1,75 @@
+# Code Quality Rules
+
+## Type Guards and Utility Functions
+
+**Location:** `lib/checks/checks.ts`
+
+Always use these utilities instead of manual null/undefined checks. They maintain consistency and satisfy ESLint's `@typescript-eslint/strict-boolean-expressions` rule.
+
+```typescript
+// PREFERRED: Check if string has value (not null/undefined/empty)
+import { hasValue } from "@/lib/checks/checks";
+
+if (hasValue(myString)) {
+  // TypeScript knows myString is string here
+  console.log(myString.toUpperCase());
+}
+
+// AVOID: Manual checks that ESLint will flag
+if (myString && myString.trim() !== "") {}
+if (typeof myString === "string" && myString.length > 0) {}
+```
+
+**Available Utilities:**
+
+- `hasValue(s: string | undefined | null): s is string` - Returns true if string is defined and not empty
+- `isDefined<T>(value: T | null | undefined): value is T` - Returns true if not null/undefined
+- `isString(s: unknown): s is string` - Type guard for strings
+- `isTrue(b: unknown): b is true` - Type guard for true boolean
+- `hasElements<T>(arr: ReadonlyArray<T> | null | undefined): arr is NonEmptyArray<T>` - Returns true if array is defined and non-empty
+- `ensure<T>(val: T | undefined | null, message?: string): T` - Throws if value is null/undefined, otherwise returns the value
+- `filterUndefinedProperties(obj: Record<string, string | undefined>): Record<string, string>` - Filters out undefined properties
+
+**When to Use Each:**
+
+- `hasValue()` for **string checks** (most common)
+- `isDefined()` for **object/number/boolean checks**
+- `hasElements()` for **array checks**
+- `ensure()` when you want to **throw on null/undefined** (guard clauses)
+
+## Avoid `as` Type Casting
+
+Never use `as` casts (especially `as unknown as T`) in tests or production code. These silence TypeScript without providing type safety and can mask real bugs. If a test requires casting to simulate an invalid state, that is a sign the test should be removed — our type system prevents that state from occurring.
+
+```ts
+// AVOID:
+const input = [2, undefined as unknown as number, 6]; // masks a type violation
+
+// PREFERRED: Only test states that TypeScript types actually permit.
+```
+
+## Avoid `watch()` - Prefer Keyed Components
+
+Using `watch()` on query values is often a code smell. Instead, prefer higher-order components that pass data down as props and use the `:key` attribute to force re-renders when data changes.
+
+```typescript
+// AVOID: Using watch for query data
+const { data: club } = useClub(clubSlug);
+watch(club, (newClub) => {
+  updateSomething(newClub);
+});
+```
+
+```vue
+<!-- PREFERRED: Keyed components that re-render -->
+<template>
+  <ClubDetails v-if="club" :key="club?.id" :club="club" />
+</template>
+```
+
+When `club` data changes, Vue destroys and recreates `ClubDetails` with clean state. This makes data flow explicit, avoids timing issues with watchers, and reduces bugs from stale closures.
+
+**When `watch()` is acceptable:**
+
+- Syncing with external systems (localStorage, browser APIs)
+- Triggering animations or side effects that are truly reactive in nature

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -1,0 +1,36 @@
+---
+paths:
+  - "migrations/**"
+  - "lib/types/**"
+  - "netlify/functions/repositories/**"
+---
+
+# Database Architecture
+
+**ORM:** Kysely with CockroachDB dialect (PostgreSQL-compatible). See `kysely` skill for query patterns, migration syntax, and type helpers.
+
+**Key Files:**
+
+- Connection: `netlify/functions/utils/database.ts` (singleton `Kysely<DB>` instance)
+- Generated types: `lib/types/generated/db.ts` (run `npm run codegen` after schema changes)
+- Migrations: `migrations/schema/` (naming: `YYYYMMDD_Description.ts`)
+
+**Key Tables:**
+
+- `club` - Movie clubs (id, name, slug, legacy_id)
+- `club_member` - Club membership with roles (club_id, user_id, role)
+- `club_invite` - Invite tokens with expiration
+- `club_settings` - Key-value settings storage (JSON values)
+- `user` - User profiles (BetterAuth managed)
+- `account` - OAuth accounts (BetterAuth managed)
+- `session` - User sessions (BetterAuth managed)
+- `verification` - Email verification tokens (BetterAuth managed)
+- `movie_details` - Cached movie metadata from TMDB
+- `work_list` - Generic list for reviews, watchlist, backlog, awards
+- `work_comment` - Comments on movie works (club_id, content, spoiler, user_id, work_id)
+- `review` - Movie reviews with scores
+- `awards_temp` - Temporary awards data storage (JSON)
+- `movie_directors` - Movie-to-director junction table
+- Various movie metadata junction tables (genres, production companies, countries)
+
+**Enums:** `WorkListType` (reviews, watchlist, backlog, award_nominations), `WorkType` (movie)

--- a/.claude/rules/frontend-architecture.md
+++ b/.claude/rules/frontend-architecture.md
@@ -1,0 +1,92 @@
+---
+paths:
+  - "src/**"
+---
+
+# Frontend Architecture (Vue 3 + Vite)
+
+## Project Structure
+
+- `src/features/` - Feature-based modules containing views, components, and composables
+  - `auth/` - Authentication views (verify email, password reset)
+  - `awards/` - Awards system with nominations, rankings, and results
+  - `clubs/` - Club listing and creation
+  - `profile/` - User profile management
+  - `reviews/` - Movie reviews with gallery and table views
+  - `settings/` - Club settings and member management
+  - `statistics/` - Club statistics and charts
+  - `watch-list/` - Watchlist and backlog management
+- `src/common/` - Shared components and utilities
+  - `components/` - Reusable UI components (VBtn, VModal, VSelect, etc.)
+  - `composables/` - Shared Vue composables
+  - `errorCodes.ts` - Error code definitions
+- `src/service/` - TanStack Query composables for data fetching
+- `src/stores/` - Pinia stores (currently `auth.ts`)
+- `src/router/` - Vue Router configuration with auth guards
+- `src/lib/` - Library code (auth client)
+- `src/directives/` - Custom Vue directives (LazyLoad)
+- `src/mocks/` - MSW handlers and test data
+
+## Key Technologies
+
+- **Vue 3** with Composition API and `<script setup>`
+- **Vite** for build tooling
+- **TypeScript** with strict mode
+- **Pinia** for state management
+- **Vue Router 4** with route-based code splitting
+- **TanStack Query (Vue Query)** for server state management with persistence
+- **BetterAuth** (better-auth/vue) for authentication with email/password and Google OAuth
+- **Tailwind CSS** for styling
+- **Vitest** for testing with jsdom environment
+- **mdi-vue** for Material Design Icons
+- **vue-toastification** for toast notifications
+- **AG Charts** for statistics visualizations
+- **Headless UI** for accessible UI primitives
+
+## Global Components
+
+Registered in `src/main.ts`: `v-avatar`, `v-backdrop`, `v-btn`, `v-select`, `v-switch`, `loading-spinner`, `movie-table`, `menu-card`, `v-modal`, `page-header`, `empty-state`
+
+## Custom Directives
+
+- `v-lazy-load` - Intersection Observer-based lazy loading for images
+
+## Path Alias
+
+- `@/*` maps to `src/*`
+
+## Router Architecture
+
+- Routes use a `depth` meta property for slide-in/slide-out transitions
+- `checkClubAccess` guard ensures users are club members before accessing club routes
+- Route transitions use animate.css classes (`animate__slideInRight`, `animate__slideInLeft`, etc.)
+- Routes with `noAuth: true` meta are accessible without authentication
+- Routes with `authRequired: true` meta redirect to Clubs page if not logged in
+
+## Service Layer
+
+Located in `src/service/`, these composables provide TanStack Query hooks for data fetching:
+
+- `useClub.ts` - Club CRUD, membership, invites, settings
+- `useReviews.ts` - Review management and scoring
+- `useList.ts` - Watchlist/backlog operations
+- `useAwards.ts` - Awards system data
+- `useUser.ts` - User profile and clubs
+- `useTMDB.ts` - TMDB movie search integration
+
+See `tanstack-query-vue` skill for query key conventions, mutation patterns, caching config, and optimistic update strategies.
+
+## Authentication (Frontend)
+
+Auth store (Pinia) manages user state via `authClient.useSession()`. Router guards check auth before accessing protected routes.
+
+- `src/lib/auth-client.ts` — BetterAuth Vue client
+- `src/stores/auth.ts` — Authentication state and session management
+
+## Key Frontend Files
+
+- `src/main.ts` - Vue app initialization, global components, plugins
+- `src/App.vue` - Root component with router view and transitions
+- `src/router/index.ts` - Route definitions and navigation guards
+- `vite.config.ts` - Vite and Vitest configuration
+- `tailwind.config.cjs` - Tailwind CSS configuration

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "**/*.spec.*"
+  - "**/*.test.*"
+  - "**/tests/**"
+  - "src/mocks/**"
+---
+
+# Testing
+
+- **Framework:** Vitest with jsdom environment
+- **Setup file:** `src/tests/setup.ts`
+- **API mocking:** Mock Service Worker (MSW) — handlers in `src/mocks/handlers.ts`
+- **Helper utilities:** `src/tests/utils.ts`
+- **Test data:** `src/mocks/data/`
+- **Coverage:** excludes mocks and test directories
+- **Test location:** feature tests live in `src/features/<feature>/tests/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. Detailed architecture docs are in `.claude/rules/`.
 
 ## Project Overview
 
@@ -18,6 +18,7 @@ Skills in `.claude/skills/` provide domain-specific guidance for Claude Code ses
 - **vue-best-practices** — Vue 3 Composition API guide covering reactivity, SFC structure, component data flow, composables, and performance. Automatically consulted when working on Vue components.
 - **tanstack-query-vue** — TanStack Query v4 patterns for data fetching, caching, mutations, and optimistic updates. Automatically consulted when working on service composables or server state.
 - **kysely** — Kysely v0.27 query builder patterns with CockroachDB dialect. Automatically consulted when working on database queries, repositories, or migrations.
+- **playwright-cli** — Browser automation for web testing, form filling, screenshots, and data extraction.
 
 ## Development Commands
 
@@ -71,310 +72,26 @@ Migration files are located in `migrations/schema/` and must follow the naming c
 
 ### Database Management
 
-**Preview Databases & Isolated Development:**
-
-The project uses CockroachDB's BACKUP/RESTORE with S3 to create isolated database environments for development and deploy previews. This prevents migration conflicts when multiple developers or PRs have schema changes.
-
-**Snapshot Management:**
+The project uses CockroachDB's BACKUP/RESTORE with S3 to create isolated database environments for development and deploy previews.
 
 ```bash
 npm run db:snapshot         # Create backup snapshot of dev database to S3
 npm run db:snapshot prod    # Snapshot production database
+npm run db:spawn my-feature # Create personal dev database from latest snapshot
+npm run db:list             # List all databases with metadata
+npm run db:cleanup my-feature       # Delete personal database when done
+npm run db:cleanup --older-than 7   # Clean up databases older than 7 days
 ```
 
-Snapshots are stored in `s3://movie-club-crdb-dev-exports` and should be created periodically (e.g., weekly) to keep spawned databases up-to-date. The script will warn when you have more than 5 snapshots.
+Snapshots are stored in `s3://movie-club-crdb-dev-exports`. The spawn command creates `dev_{username}_my-feature` by restoring from the latest S3 snapshot.
 
-**Spawning Development Databases:**
+**Required env vars:** `DATABASE_URL`, `AWS_ACCESS_KEY_COCKROACH_BACKUP`, `AWS_SECRET_ACCESS_KEY_COCKROACH_BACKUP`
 
-```bash
-npm run db:spawn my-feature  # Create personal dev database from latest snapshot
-```
+## Key Conventions
 
-This creates `dev_{username}_my-feature` by restoring from the latest S3 snapshot. Much faster than the old row-by-row copying approach (seconds vs. minutes).
-
-**Database Utilities:**
-
-```bash
-npm run db:list              # List all databases with metadata
-npm run db:cleanup my-feature  # Delete personal database when done
-npm run db:cleanup --older-than 7  # Clean up databases older than 7 days
-```
-
-**Environment Variables Required:**
-
-- `DATABASE_URL` - CockroachDB connection string
-- `AWS_ACCESS_KEY_COCKROACH_BACKUP` - AWS access key for S3 backups
-- `AWS_SECRET_ACCESS_KEY_COCKROACH_BACKUP` - AWS secret key for S3 backups
-
-**When to Use:**
-
-- Working on schema migrations that conflict with others
-- Testing migrations in isolation
-- Need a clean database state from a known snapshot
-- Deploy previews with migrations (automated by Netlify plugin)
-
-
-## Architecture
-
-### Frontend Architecture (Vue 3 + Vite)
-
-**Project Structure:**
-
-- `src/features/` - Feature-based modules containing views, components, and composables
-  - `auth/` - Authentication views (verify email, password reset)
-  - `awards/` - Awards system with nominations, rankings, and results
-  - `clubs/` - Club listing and creation
-  - `profile/` - User profile management
-  - `reviews/` - Movie reviews with gallery and table views
-  - `settings/` - Club settings and member management
-  - `statistics/` - Club statistics and charts
-  - `watch-list/` - Watchlist and backlog management
-- `src/common/` - Shared components and utilities
-  - `components/` - Reusable UI components (VBtn, VModal, VSelect, etc.)
-  - `composables/` - Shared Vue composables
-  - `errorCodes.ts` - Error code definitions
-- `src/service/` - TanStack Query composables for data fetching
-- `src/stores/` - Pinia stores (currently `auth.ts`)
-- `src/router/` - Vue Router configuration with auth guards
-- `src/lib/` - Library code (auth client)
-- `src/directives/` - Custom Vue directives (LazyLoad)
-- `src/mocks/` - MSW handlers and test data
-
-**Key Technologies:**
-
-- **Vue 3** with Composition API and `<script setup>`
-- **Vite** for build tooling
-- **TypeScript** with strict mode
-- **Pinia** for state management
-- **Vue Router 4** with route-based code splitting
-- **TanStack Query (Vue Query)** for server state management with persistence
-- **BetterAuth** (better-auth/vue) for authentication with email/password and Google OAuth
-- **Tailwind CSS** for styling
-- **Vitest** for testing with jsdom environment
-- **mdi-vue** for Material Design Icons
-- **vue-toastification** for toast notifications
-- **AG Charts** for statistics visualizations
-- **Headless UI** for accessible UI primitives
-
-**Global Components:**
-Registered in `src/main.ts`: `v-avatar`, `v-backdrop`, `v-btn`, `v-select`, `v-switch`, `loading-spinner`, `movie-table`, `menu-card`, `v-modal`, `page-header`, `empty-state`
-
-**Custom Directives:**
-
-- `v-lazy-load` - Intersection Observer-based lazy loading for images
-
-**Path Alias:**
-
-- `@/*` maps to `src/*`
-
-**Router Architecture:**
-
-- Routes use a `depth` meta property for slide-in/slide-out transitions
-- `checkClubAccess` guard ensures users are club members before accessing club routes
-- Route transitions use animate.css classes (`animate__slideInRight`, `animate__slideInLeft`, etc.)
-- Routes with `noAuth: true` meta are accessible without authentication
-- Routes with `authRequired: true` meta redirect to Clubs page if not logged in
-
-### Service Layer
-
-Located in `src/service/`, these composables provide TanStack Query hooks for data fetching:
-
-- `useClub.ts` - Club CRUD, membership, invites, settings
-- `useReviews.ts` - Review management and scoring
-- `useList.ts` - Watchlist/backlog operations
-- `useAwards.ts` - Awards system data
-- `useUser.ts` - User profile and clubs
-- `useTMDB.ts` - TMDB movie search integration
-
-See `tanstack-query-vue` skill for query key conventions, mutation patterns, caching config, and optimistic update strategies.
-
-### Backend Architecture (Netlify Functions)
-
-**Custom Router System:**
-Located in `netlify/functions/utils/router.ts`. A type-safe Express-like router implementation that supports:
-
-- Middleware chaining with type transformations
-- Path parameter extraction using `path-parser` (e.g., `/:clubSlug`)
-- Method routing (GET, POST, PUT, DELETE)
-- Sub-routers with the `use()` method
-- Automatic 404 and 405 responses
-
-**Example Pattern:**
-
-```typescript
-const router = new Router("/api/club");
-router.use("/:clubSlug/list", validClubSlug, listRouter);
-router.get("/:clubSlug", validClubSlug, async ({ clubSlug }, res) => {
-  const club = await ClubRepository.getBySlug(clubSlug);
-  return res(ok(JSON.stringify(result)));
-});
-```
-
-**API Structure:**
-
-- `/api/og-image` - Open Graph image generation for shared reviews
-- `/api/auth/*` - BetterAuth endpoints (handled automatically)
-- `/api/club/*` - All club-related endpoints
-  - `/:clubSlug/list` - Watchlist/backlog management
-  - `/:clubSlug/reviews` - Movie reviews
-  - `/:clubSlug/members` - Club membership
-  - `/:clubSlug/awards` - Awards system (categories, nominations, rankings)
-  - `/:clubSlug/invite` - Invite token management
-  - `/:clubSlug/settings` - Club settings
-  - `/:clubSlug/nextWork` - Current movie being watched
-  - `/:clubSlug/name` - Update club name (PUT)
-  - `/:clubSlug/slug` - Update club slug (PUT)
-  - `/join` - Join club via invite
-  - `/joinInfo/:token` - Get club info from invite token
-- `/api/member/*` - User-specific endpoints
-  - `/clubs` - Get user's clubs
-
-**Key Backend Patterns:**
-
-- Repository pattern for data access (e.g., `ClubRepository`, `UserRepository`, `WorkRepository`)
-- Middleware for authentication (`loggedIn`, `secured`) and validation (`validClubSlug`)
-- Zod schemas for request body validation
-- Kysely for type-safe database queries
-- Response helpers from `utils/responses.ts` (`ok`, `badRequest`, `unauthorized`, `notFound`, `svg`, `redirect`)
-
-**Repository Classes:**
-Located in `netlify/functions/repositories/`:
-
-- `ClubRepository` - Club CRUD, membership checks, invites
-- `UserRepository` - User lookup and management
-- `WorkRepository` - Movie/work management
-- `ListRepository` - List operations (reviews, watchlist, backlog)
-- `ReviewRepository` - Review data access
-- `AwardsRepository` - Awards system data
-- `SettingsRepository` - Club settings storage
-- `ImageRepository` - Cloudinary image management
-- `DatabaseCleanupRepository` - Preview database lifecycle management
-
-### Database Architecture
-
-**ORM:** Kysely with CockroachDB dialect (PostgreSQL-compatible). See `kysely` skill for query patterns, migration syntax, and type helpers.
-
-**Key Files:**
-
-- Connection: `netlify/functions/utils/database.ts` (singleton `Kysely<DB>` instance)
-- Generated types: `lib/types/generated/db.ts` (run `npm run codegen` after schema changes)
-- Migrations: `migrations/schema/` (naming: `YYYYMMDD_Description.ts`)
-
-**Key Tables:**
-
-- `club` - Movie clubs (id, name, slug, legacy_id)
-- `club_member` - Club membership with roles (club_id, user_id, role)
-- `club_invite` - Invite tokens with expiration
-- `club_settings` - Key-value settings storage (JSON values)
-- `user` - User profiles (BetterAuth managed)
-- `account` - OAuth accounts (BetterAuth managed)
-- `session` - User sessions (BetterAuth managed)
-- `verification` - Email verification tokens (BetterAuth managed)
-- `movie_details` - Cached movie metadata from TMDB
-- `work_list` - Generic list for reviews, watchlist, backlog, awards
-- `review` - Movie reviews with scores
-- `awards_temp` - Temporary awards data storage (JSON)
-- `movie_directors` - Movie-to-director junction table
-- Various movie metadata junction tables (genres, production companies, countries)
-- **Enums:** `WorkListType` (reviews, watchlist, backlog, award_nominations), `WorkType` (movie)
-
-### Authentication Flow
-
-Auth store (Pinia) manages user state via `authClient.useSession()`. Router guards check auth before accessing protected routes. Backend uses `loggedIn` (any authenticated user) and `secured` (authenticated + club member) middleware. See `better-auth-best-practices` skill for general BetterAuth patterns.
-
-**Auth Configuration:**
-
-- Frontend: `src/lib/auth-client.ts` — BetterAuth Vue client
-- Backend: `netlify/functions/utils/auth.ts` — BetterAuth server config (bcrypt hashing, Google OAuth, Resend emails, mixed ID generation: auto-increment for users, UUIDs for sessions)
-
-## Code Quality & Utilities
-
-### Type Guards and Utility Functions
-
-**Location:** `lib/checks/checks.ts`
-
-This module provides utility functions for type-safe null/undefined checks and type guards. **Always use these instead of manual checks** to maintain consistency and satisfy ESLint's `@typescript-eslint/strict-boolean-expressions` rule.
-
-**Key Functions:**
-
-```typescript
-// ✅ PREFERRED: Check if string has value (not null/undefined/empty)
-import { hasValue } from "@/lib/checks/checks";
-
-if (hasValue(myString)) {
-  // TypeScript knows myString is string here
-  console.log(myString.toUpperCase());
-}
-
-// ❌ AVOID: Manual checks that ESLint will flag
-if (myString && myString.trim() !== "") {
-}
-if (typeof myString === "string" && myString.length > 0) {
-}
-```
-
-**Available Utilities:**
-
-- `hasValue(s: string | undefined | null): s is string` - Returns true if string is defined and not empty
-- `isDefined<T>(value: T | null | undefined): value is T` - Returns true if not null/undefined
-- `isString(s: unknown): s is string` - Type guard for strings
-- `isTrue(b: unknown): b is true` - Type guard for true boolean
-- `hasElements<T>(arr: ReadonlyArray<T> | null | undefined): arr is NonEmptyArray<T>` - Returns true if array is defined and non-empty
-- `ensure<T>(val: T | undefined | null, message?: string): T` - Throws if value is null/undefined, otherwise returns the value
-- `filterUndefinedProperties(obj: Record<string, string | undefined>): Record<string, string>` - Filters out undefined properties from an object
-
-**When to Use Each:**
-
-- Use `hasValue()` for **string checks** (most common)
-- Use `isDefined()` for **object/number/boolean checks**
-- Use `hasElements()` for **array checks**
-- Use `ensure()` when you want to **throw on null/undefined** (guard clauses)
-
-### Avoid `as` Type Casting
-
-Never use `as` casts (especially `as unknown as T`) in tests or production code. These silence TypeScript without providing type safety and can mask real bugs. If a test requires casting to simulate an invalid state, that is a sign the test should be removed — our type system prevents that state from occurring.
-
-**❌ AVOID:**
-```ts
-const input = [2, undefined as unknown as number, 6]; // masks a type violation
-```
-
-**✅ PREFERRED:** Only test states that TypeScript types actually permit.
-
-### Avoid `watch()` - Prefer Keyed Components
-
-**Using `watch()` on query values is often a code smell.** Instead of watching reactive data and running side effects, prefer creating higher-order components that pass data down as props and use the `:key` attribute to force re-renders when data changes.
-
-**❌ AVOID: Using watch for query data**
-
-```typescript
-const { data: club } = useClub(clubSlug);
-
-watch(club, (newClub) => {
-  // Side effect when club changes
-  updateSomething(newClub);
-});
-```
-
-**✅ PREFERRED: Keyed components that re-render**
-
-```vue
-<template>
-  <ClubDetails v-if="club" :key="club?.id" :club="club" />
-</template>
-```
-
-When the `club` data changes, Vue will destroy and recreate the entire `ClubDetails` component, giving it a clean state. This approach:
-
-- Makes data flow explicit and unidirectional
-- Avoids timing issues with watchers
-- Reduces bugs from stale closures
-- Makes components easier to reason about
-
-**When `watch()` is acceptable:**
-
-- Syncing with external systems (localStorage, browser APIs)
-- Triggering animations or side effects that are truly reactive in nature
+- **Type guards:** Always use utilities from `lib/checks/checks.ts` (`hasValue`, `isDefined`, `hasElements`, `ensure`) instead of manual null/undefined checks. See `.claude/rules/code-quality.md` for details.
+- **No `as` casts:** Never use `as` type casting in tests or production code.
+- **No `watch()`:** Prefer keyed components over `watch()` for query data. See `.claude/rules/code-quality.md` for rationale and exceptions.
 
 ## Common Patterns
 
@@ -413,78 +130,24 @@ src/features/<feature-name>/
 4. Add routes in `src/router/index.ts` with appropriate `depth` meta
 5. Apply `beforeEnter: checkClubAccess` guard for club-scoped routes
 
-### Testing
-
-- Test files use Vitest with jsdom environment
-- Setup file: `src/tests/setup.ts`
-- Mock Service Worker (MSW) for API mocking: `src/mocks/handlers.ts`
-- Helper utilities in `src/tests/utils.ts`
-- Test data in `src/mocks/data/`
-- Coverage excludes mocks and test directories
-
-## Key Files
-
-**Frontend:**
-
-- `src/main.ts` - Vue app initialization, global components, plugins
-- `src/App.vue` - Root component with router view and transitions
-- `src/router/index.ts` - Route definitions and navigation guards
-- `src/stores/auth.ts` - Authentication state and session management
-- `src/lib/auth-client.ts` - BetterAuth client configuration
-
-**Backend:**
-
-- `netlify/functions/club/index.ts` - Main club API router
-- `netlify/functions/auth.ts` - BetterAuth handler
-- `netlify/functions/member.ts` - Member API endpoints
-- `netlify/functions/utils/router.ts` - Custom routing framework
-- `netlify/functions/utils/database.ts` - Database connection singleton
-- `netlify/functions/utils/auth.ts` - Auth configuration and middleware
-- `netlify/functions/utils/responses.ts` - HTTP response helpers
-- `netlify/functions/utils/validation.ts` - Request validation middleware
-- `netlify/functions/utils/slug.ts` - Slug generation and validation
-- `netlify/functions/utils/email.ts` - Resend email templates
-- `netlify/functions/utils/workDetailsMapper.ts` - Work-to-external-data mapper
-- `netlify/functions/og-image.ts` - Open Graph image generation
-- `netlify/functions/scheduled-db-cleanup.ts` - Scheduled daily cleanup of stale preview databases
-- `netlify/functions/services/SharedReviewService.ts` - Shared review data service
-
-**Shared:**
-
-- `lib/types/generated/db.ts` - Auto-generated database types
-- `lib/types/*.ts` - Shared type definitions (club, movie, reviews, awards, lists, common, watchlist, etc.)
-- `lib/checks/checks.ts` - Utility functions (isDefined, hasValue, ensure, etc.)
-
-**Configuration:**
-
-- `vite.config.ts` - Vite and Vitest configuration
-- `netlify.toml` - Netlify config: redirects, custom plugins (preview-database, auth-config), edge functions (shared-review)
-- `package.json` - Dependencies and scripts
-- `tailwind.config.js` - Tailwind CSS configuration
-
 ## External Services
 
-- **TMDB (The Movie Database)** - Movie metadata API (`netlify/functions/utils/tmdb.ts`)
-- **BetterAuth** - Authentication library with email/password and OAuth support
-- **CockroachDB** - PostgreSQL-compatible distributed database
-- **Cloudinary** - Image hosting for profile photos (`netlify/functions/repositories/ImageRepository.ts`)
-- **Resend** - Transactional email service for verification and password reset emails
+- **TMDB** — Movie metadata API (`netlify/functions/utils/tmdb.ts`)
+- **BetterAuth** — Authentication (email/password + Google OAuth)
+- **CockroachDB** — PostgreSQL-compatible distributed database
+- **Cloudinary** — Image hosting for profile photos
+- **Resend** — Transactional email (verification, password reset)
 
 ## Environment Variables
 
 Required environment variables (documented in Cobresun Notion):
 
 - `DATABASE_URL` - CockroachDB connection string
-- `AWS_ACCESS_KEY_COCKROACH_BACKUP` - AWS access key for S3 backups
-- `AWS_SECRET_ACCESS_KEY_COCKROACH_BACKUP` - AWS secret key for S3 backups
+- `AWS_ACCESS_KEY_COCKROACH_BACKUP` / `AWS_SECRET_ACCESS_KEY_COCKROACH_BACKUP` - S3 backups
 - `BETTER_AUTH_URL` - Base URL for BetterAuth
-- `GOOGLE_CLIENT_ID` - Google OAuth client ID
-- `GOOGLE_CLIENT_SECRET` - Google OAuth client secret
+- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` - Google OAuth
 - `RESEND_API_KEY` - Resend email API key
 - `CLOUDINARY_URL` - Cloudinary configuration URL
 - `TMDB_API_KEY` - TMDB API key for movie data
 
-Netlify provides automatically:
-
-- `URL` - Production site URL
-- `DEPLOY_PRIME_URL` - Deploy preview URL
+Netlify provides automatically: `URL` (production), `DEPLOY_PRIME_URL` (deploy preview)


### PR DESCRIPTION
## Summary
- Reduce root CLAUDE.md from **490 lines to 153 lines** (under the recommended 200-line max)
- Split detailed architecture docs into 5 path-scoped `.claude/rules/` files that load contextually based on what files are being worked on
- Fix 12 outdated items found during audit (missing tables, repos, API routes, wrong config filename)

### New rules files
| File | Lines | Loads when working in |
|------|-------|-----------------------|
| `code-quality.md` | 75 | All files (unconditional) |
| `frontend-architecture.md` | 92 | `src/**` |
| `backend-architecture.md` | 110 | `netlify/**` |
| `database.md` | 36 | `migrations/**`, `lib/types/**`, `netlify/functions/repositories/**` |
| `testing.md` | 17 | Test files and mocks |

### Corrections applied
- `tailwind.config.js` → `tailwind.config.cjs`
- Added `work_comment` table
- Added `MovieRefreshRepository`, `WorkCommentRepository`
- Added work comment CRUD routes, review shared endpoint, list reorder/date endpoints, member avatar/name endpoints
- Added `scheduled-movie-refresh.ts`, `movieDetailsUpdater.ts`
- Added edge functions and netlify plugins sections
- Added `playwright-cli` and `kysely` to skills list

## Test plan
- [ ] Verify `CLAUDE.md` is under 200 lines
- [ ] Verify all 5 rules files exist in `.claude/rules/`
- [ ] Spot-check that path-scoped rules load correctly when working on matching files

🤖 Generated with [Claude Code](https://claude.com/claude-code)