### PR TITLE
Add club text reviews/comments to the share link page

### DIFF
--- a/lib/types/lists.ts
+++ b/lib/types/lists.ts
@@ -63,6 +63,7 @@ export interface SharedReviewResponse {
     score: number;
     created_date: string;
   }[];
+  comments: WorkCommentDto[];
   work: DetailedReviewListItem;
   clubName: string;
 }

--- a/netlify/functions/services/SharedReviewService.ts
+++ b/netlify/functions/services/SharedReviewService.ts
@@ -2,6 +2,7 @@ import ClubRepository from "../repositories/ClubRepository";
 import ListRepository from "../repositories/ListRepository";
 import ReviewRepository from "../repositories/ReviewRepository";
 import UserRepository from "../repositories/UserRepository";
+import WorkCommentRepository from "../repositories/WorkCommentRepository";
 import { overviewToExternalData } from "../utils/workDetailsMapper";
 
 class SharedReviewService {
@@ -17,11 +18,12 @@ class SharedReviewService {
    * @returns Shared review data if work exists, null otherwise
    */
   async getSharedReviewData(clubId: string, workId: string) {
-    const [reviews, members, workDetails, club] = await Promise.all([
+    const [reviews, members, workDetails, club, comments] = await Promise.all([
       ReviewRepository.getReviewsByWorkId(clubId, workId),
       UserRepository.getMembersByClubId(clubId),
       ListRepository.getWorkDetails(workId),
       ClubRepository.getById(clubId),
+      WorkCommentRepository.getByWorkAndClub(workId, clubId),
     ]);
 
     if (!workDetails) {
@@ -40,6 +42,7 @@ class SharedReviewService {
     return {
       reviews,
       members,
+      comments,
       work,
       clubName: club?.name ?? "Movie Club",
     };

--- a/src/features/reviews/components/SharedReviewComments.vue
+++ b/src/features/reviews/components/SharedReviewComments.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="space-y-3">
+    <h3 class="text-sm font-medium text-gray-400">Reviews</h3>
+    <div
+      v-for="comment in comments"
+      :key="comment.id"
+      class="rounded-lg bg-slate-800 p-4"
+    >
+      <div class="flex items-center gap-2">
+        <v-avatar
+          :name="comment.userName"
+          :src="comment.userImage"
+          :size="28"
+        />
+        <div class="flex flex-1 items-center gap-1 text-xs text-gray-400">
+          <span class="font-medium text-gray-300">{{ comment.userName }}</span>
+          <span>&middot;</span>
+          <span>{{ formatRelativeTime(comment.createdDate) }}</span>
+          <span v-if="comment.spoiler" class="text-yellow-500">
+            &middot; Spoiler
+          </span>
+        </div>
+      </div>
+      <div class="mt-2">
+        <p
+          v-if="comment.spoiler && !revealedSpoilers.has(comment.id)"
+          class="cursor-pointer select-none whitespace-pre-wrap text-left text-sm text-gray-200 blur-sm transition-all"
+          @click="revealedSpoilers.add(comment.id)"
+        >
+          {{ comment.content }}
+        </p>
+        <p v-else class="whitespace-pre-wrap text-left text-sm text-gray-200">
+          {{ comment.content }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { DateTime } from "luxon";
+import { reactive } from "vue";
+
+import { WorkCommentDto } from "../../../../lib/types/lists";
+
+import VAvatar from "@/common/components/VAvatar.vue";
+
+defineProps<{
+  comments: WorkCommentDto[];
+}>();
+
+const revealedSpoilers = reactive(new Set<string>());
+
+const formatRelativeTime = (dateString: string) => {
+  return DateTime.fromISO(dateString).toRelative() ?? dateString;
+};
+</script>

--- a/src/features/reviews/views/SharedReviewView.vue
+++ b/src/features/reviews/views/SharedReviewView.vue
@@ -116,6 +116,12 @@
           </div>
         </div>
       </div>
+
+      <!-- Comments Section -->
+      <SharedReviewComments
+        v-if="hasElements(data.comments)"
+        :comments="data.comments"
+      />
     </div>
 
     <!-- Fixed Call-to-Action Banner -->
@@ -149,8 +155,11 @@ import { DateTime } from "luxon";
 import { computed, ref, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 
+import { hasElements } from "../../../../lib/checks/checks.js";
+
 import LoadingSpinner from "@/common/components/LoadingSpinner.vue";
 import VAvatar from "@/common/components/VAvatar.vue";
+import SharedReviewComments from "@/features/reviews/components/SharedReviewComments.vue";
 import { useSharedReview } from "@/service/useList";
 import { useAuthStore } from "@/stores/auth";
 


### PR DESCRIPTION
Include work comments in the shared review API response and display
them on the public share page below the member scores. Spoiler comments
are blurred by default with click-to-reveal.

https://claude.ai/code/session_016efzbgZxtWQGBuAD51kszB