### PR TITLE
feat: Add movie collection tabs with Load More pagination

### DIFF
--- a/src/common/components/MovieSearchCard.vue
+++ b/src/common/components/MovieSearchCard.vue
@@ -4,7 +4,12 @@
     @click="emit('select')"
   >
     <div class="flex h-full flex-col rounded-lg bg-slate-700">
-      <img v-if="posterUrl" v-lazy-load :src="posterUrl" class="rounded-t-lg" />
+      <img
+        v-if="hasValue(posterUrl)"
+        v-lazy-load
+        :src="posterUrl"
+        class="rounded-t-lg"
+      />
       <div
         v-else
         class="flex h-56 items-center justify-center rounded-t-lg bg-slate-600"
@@ -17,13 +22,17 @@
         <h3 class="text-center font-semibold" style="height: min-content">
           {{ title }}
         </h3>
-        <p v-if="year" class="text-sm italic text-gray-400">{{ year }}</p>
+        <p v-if="hasValue(year)" class="text-sm italic text-gray-400">
+          {{ year }}
+        </p>
       </div>
     </div>
   </button>
 </template>
 
 <script setup lang="ts">
+import { hasValue } from "../../../lib/checks/checks";
+
 defineProps<{
   title: string;
   year: string;

--- a/src/common/components/MovieSearchCard.vue
+++ b/src/common/components/MovieSearchCard.vue
@@ -1,0 +1,36 @@
+<template>
+  <button
+    class="mb-4 w-40 rounded-lg text-left transition-all duration-100 hover:ring-2 hover:ring-primary"
+    @click="emit('select')"
+  >
+    <div class="flex h-full flex-col rounded-lg bg-slate-700">
+      <img v-if="posterUrl" v-lazy-load :src="posterUrl" class="rounded-t-lg" />
+      <div
+        v-else
+        class="flex h-56 items-center justify-center rounded-t-lg bg-slate-600"
+      >
+        <mdicon name="movie-outline" :size="48" class="text-slate-400" />
+      </div>
+      <div
+        class="flex flex-grow flex-col items-center justify-center px-2 py-2"
+      >
+        <h3 class="text-center font-semibold" style="height: min-content">
+          {{ title }}
+        </h3>
+        <p v-if="year" class="text-sm italic text-gray-400">{{ year }}</p>
+      </div>
+    </div>
+  </button>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  title: string;
+  year: string;
+  posterUrl: string;
+}>();
+
+const emit = defineEmits<{
+  (e: "select"): void;
+}>();
+</script>

--- a/src/common/components/MovieSearchCard.vue
+++ b/src/common/components/MovieSearchCard.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="mb-4 w-40 rounded-lg text-left transition-all duration-100 hover:ring-2 hover:ring-primary"
+    class="mb-4 w-32 rounded-lg text-left transition-all duration-100 hover:ring-2 hover:ring-primary"
     @click="emit('select')"
   >
     <div class="flex h-full flex-col rounded-lg bg-slate-700">

--- a/src/common/components/MovieSearchPrompt.vue
+++ b/src/common/components/MovieSearchPrompt.vue
@@ -8,26 +8,24 @@
     <div class="mt-3 overflow-y-auto">
       <p v-if="noResults">Sorry, your search did not return any results</p>
       <div v-if="filteredDefaultList.length > 0">
-        <h5 class="float-left font-bold">
+        <h5 class="text-left font-bold">
           {{ defaultListTitle }}
         </h5>
-        <movie-table
-          :data="filteredDefaultList"
-          :headers="defaultListHeaders"
-          :header="false"
-          :selectable="true"
-          @click-row="selectFromDefaultList"
-        >
-          <template #item-title="{ item, head }">
-            <p>
-              <b>{{ item[head.value] }}</b
-              ><i> ({{ getReleaseYear(item.release_date) }})</i>
-            </p>
-          </template>
-          <template #item-add>
-            <mdicon name="plus" />
-          </template>
-        </movie-table>
+        <div class="mt-2 grid grid-cols-auto justify-items-center">
+          <MovieSearchCard
+            v-for="item in filteredDefaultList"
+            :key="item.id"
+            :title="item.title"
+            :year="getReleaseYear(item.release_date)"
+            :poster-url="getPosterUrl(item.poster_path)"
+            @select="selectFromDefaultList(item)"
+          />
+        </div>
+        <div v-if="showLoadMore" class="mt-3 flex justify-center">
+          <v-btn :disabled="loadingMore" @click="onLoadMore?.()">
+            {{ loadingMore ? "Loading..." : "Load More" }}
+          </v-btn>
+        </div>
       </div>
       <div
         v-if="
@@ -36,24 +34,17 @@
           searchData.results.length > 0
         "
       >
-        <h5 class="float-left font-bold">Search</h5>
-        <movie-table
-          :data="searchData.results"
-          :headers="searchHeaders"
-          :header="false"
-          :selectable="true"
-          @click-row="selectFromSearch"
-        >
-          <template #item-title="{ item, head }">
-            <p>
-              <b>{{ item[head.value] }}</b
-              ><i> ({{ getReleaseYear(item.release_date) }})</i>
-            </p>
-          </template>
-          <template #item-add>
-            <mdicon name="plus" />
-          </template>
-        </movie-table>
+        <h5 class="text-left font-bold">Search</h5>
+        <div class="mt-2 grid grid-cols-auto justify-items-center">
+          <MovieSearchCard
+            v-for="item in searchData.results"
+            :key="item.id"
+            :title="item.title"
+            :year="getReleaseYear(item.release_date)"
+            :poster-url="getPosterUrl(item.poster_path)"
+            @select="selectFromSearch(item)"
+          />
+        </div>
       </div>
       <loading-spinner
         v-if="includeSearch && loadingSearch"
@@ -69,18 +60,27 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 
+import MovieSearchCard from "./MovieSearchCard.vue";
+import { isDefined } from "../../../lib/checks/checks";
 import { MovieSearchIndex } from "../../../lib/types/movie";
 
+import { BASE_IMAGE_URL } from "@/service/useList";
 import { useSearch } from "@/service/useTMDB";
 
 const {
   defaultList,
   defaultListTitle,
   includeSearch = true,
+  onLoadMore,
+  loadingMore = false,
+  hasMore = false,
 } = defineProps<{
   defaultList: MovieSearchIndex[];
   defaultListTitle: string;
   includeSearch?: boolean;
+  onLoadMore?: () => void;
+  loadingMore?: boolean;
+  hasMore?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -89,19 +89,11 @@ const emit = defineEmits<{
   (e: "close"): void;
 }>();
 
-const defaultListHeaders = [
-  {
-    value: "title",
-    style: "text-left pl-4",
-  },
-];
-
-const searchHeaders = [
-  {
-    value: "title",
-    style: "text-left pl-4",
-  },
-];
+const getPosterUrl = (posterPath: string): string => {
+  if (!posterPath) return "";
+  if (posterPath.startsWith("http")) return posterPath;
+  return `${BASE_IMAGE_URL}${posterPath}`;
+};
 
 const getReleaseYear = (date: string) => {
   if (date !== undefined && date.length > 4) {
@@ -122,6 +114,11 @@ const { data: searchData, isLoading: loadingSearch } = useSearch(
   searchText,
   includeSearch,
 );
+
+const showLoadMore = computed(() => {
+  const hasNoSearchText = searchText.value.trim().length === 0;
+  return isDefined(onLoadMore) && hasMore && hasNoSearchText;
+});
 
 const noResults = computed(() => {
   // Don't show "no results" if the user hasn't typed anything

--- a/src/common/components/MovieSearchPrompt.vue
+++ b/src/common/components/MovieSearchPrompt.vue
@@ -64,7 +64,7 @@
 import { ref, computed } from "vue";
 
 import MovieSearchCard from "./MovieSearchCard.vue";
-import { isDefined } from "../../../lib/checks/checks";
+import { hasValue, isDefined } from "../../../lib/checks/checks";
 import { MovieSearchIndex } from "../../../lib/types/movie";
 
 import { BASE_IMAGE_URL } from "@/service/useList";
@@ -92,13 +92,13 @@ const emit = defineEmits<{
 }>();
 
 const getPosterUrl = (posterPath: string): string => {
-  if (!posterPath) return "";
+  if (!hasValue(posterPath)) return "";
   if (posterPath.startsWith("http")) return posterPath;
   return `${BASE_IMAGE_URL}${posterPath}`;
 };
 
 const getReleaseYear = (date: string) => {
-  if (date !== undefined && date.length > 4) {
+  if (hasValue(date) && date.length > 4) {
     return date.substring(0, 4);
   } else {
     return "";

--- a/src/common/components/MovieSearchPrompt.vue
+++ b/src/common/components/MovieSearchPrompt.vue
@@ -51,9 +51,6 @@
         class="mt-3 self-center"
       />
     </div>
-    <div class="mt-auto flex justify-between pt-2">
-      <v-btn @click="emit('close')"> Cancel </v-btn>
-    </div>
   </div>
 </template>
 
@@ -86,7 +83,6 @@ const {
 const emit = defineEmits<{
   (e: "select-from-default", movie: MovieSearchIndex): void;
   (e: "select-from-search", movie: MovieSearchIndex): void;
-  (e: "close"): void;
 }>();
 
 const getPosterUrl = (posterPath: string): string => {

--- a/src/common/components/MovieSearchPrompt.vue
+++ b/src/common/components/MovieSearchPrompt.vue
@@ -11,7 +11,10 @@
         <h5 class="text-left font-bold">
           {{ defaultListTitle }}
         </h5>
-        <div class="mt-2 grid grid-cols-auto justify-items-center">
+        <div
+          class="mt-2 grid justify-items-center"
+          style="grid-template-columns: repeat(auto-fill, minmax(136px, 1fr))"
+        >
           <MovieSearchCard
             v-for="item in filteredDefaultList"
             :key="item.id"
@@ -35,7 +38,10 @@
         "
       >
         <h5 class="text-left font-bold">Search</h5>
-        <div class="mt-2 grid grid-cols-auto justify-items-center">
+        <div
+          class="mt-2 grid justify-items-center"
+          style="grid-template-columns: repeat(auto-fill, minmax(136px, 1fr))"
+        >
           <MovieSearchCard
             v-for="item in searchData.results"
             :key="item.id"

--- a/src/common/components/VModal.vue
+++ b/src/common/components/VModal.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 
 import VBackdrop from "./VBackdrop.vue";
 import VBottomSheet from "./VBottomSheet.vue";
@@ -63,6 +63,18 @@ const handleClose = () => {
 const onTransitionEnd = () => {
   emit("close");
 };
+
+const onEscapeKey = (e: KeyboardEvent) => {
+  if (e.key !== "Escape") return;
+  if (isDesktop.value) {
+    handleClose();
+  } else {
+    emit("close");
+  }
+};
+
+onMounted(() => document.addEventListener("keydown", onEscapeKey));
+onUnmounted(() => document.removeEventListener("keydown", onEscapeKey));
 
 useBodyScrollLock(isVisible, isDesktop);
 

--- a/src/features/awards/views/NominationsView.vue
+++ b/src/features/awards/views/NominationsView.vue
@@ -8,7 +8,6 @@
           :default-list-title="`${year} Reviews`"
           :include-search="false"
           @select-from-default="addNomination"
-          @close="closePrompt"
         />
       </div>
     </div>

--- a/src/features/awards/views/NominationsView.vue
+++ b/src/features/awards/views/NominationsView.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-modal v-if="currentAward" @close="closePrompt">
+  <v-modal v-if="currentAward" size="lg" @close="closePrompt">
     <div class="flex h-full flex-col">
       <h3 class="mb-2 text-left text-xl font-bold">{{ currentAward.title }}</h3>
       <div class="flex-grow overflow-auto">

--- a/src/features/reviews/components/AddReviewPrompt.vue
+++ b/src/features/reviews/components/AddReviewPrompt.vue
@@ -5,7 +5,6 @@
       v-else
       default-list-title="From Watch List"
       :default-list="watchlistSearchIndex"
-      @close="emit('close')"
       @select-from-default="selectFromWatchList"
       @select-from-search="selectFromSearch"
     />

--- a/src/features/reviews/components/AddReviewPrompt.vue
+++ b/src/features/reviews/components/AddReviewPrompt.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-modal @close="emit('close')">
+  <v-modal size="lg" @close="emit('close')">
     <loading-spinner v-if="loading" class="self-center" />
     <movie-search-prompt
       v-else

--- a/src/features/reviews/tests/ReviewView.spec.ts
+++ b/src/features/reviews/tests/ReviewView.spec.ts
@@ -31,8 +31,7 @@ describe("ReviewView", () => {
     await user.click(openButton);
     expect(await screen.findByText("From Watch List")).toBeInTheDocument();
 
-    const backdrop = document.querySelector(".fixed.inset-0") as HTMLElement;
-    await user.click(backdrop);
+    await user.keyboard("{Escape}");
     expect(screen.queryByText("From Watch List")).not.toBeInTheDocument();
   });
 

--- a/src/features/reviews/tests/ReviewView.spec.ts
+++ b/src/features/reviews/tests/ReviewView.spec.ts
@@ -31,8 +31,8 @@ describe("ReviewView", () => {
     await user.click(openButton);
     expect(await screen.findByText("From Watch List")).toBeInTheDocument();
 
-    const cancelButton = screen.getByRole("button", { name: "Cancel" });
-    await user.click(cancelButton);
+    const backdrop = document.querySelector(".fixed.inset-0") as HTMLElement;
+    await user.click(backdrop);
     expect(screen.queryByText("From Watch List")).not.toBeInTheDocument();
   });
 

--- a/src/features/watch-list/components/AddMovieToListModal.vue
+++ b/src/features/watch-list/components/AddMovieToListModal.vue
@@ -1,22 +1,42 @@
 <template>
-  <v-modal @close="emit('close')">
+  <v-modal size="lg" @close="emit('close')">
     <loading-spinner v-if="loading" class="self-center" />
-    <movie-search-prompt
-      v-else
-      default-list-title="Trending"
-      :default-list="trending ? trending.results : []"
-      @close="$emit('close')"
-      @select-from-default="selectFromSearch"
-      @select-from-search="selectFromSearch"
-    />
+    <div v-else class="flex h-full flex-col">
+      <div class="mb-2 flex gap-1 overflow-x-auto">
+        <button
+          v-for="tab in collectionTabs"
+          :key="tab.key"
+          class="shrink-0 rounded-full px-3 py-1 text-sm font-medium transition-colors"
+          :class="
+            activeCollection === tab.key
+              ? 'bg-primary text-white'
+              : 'bg-slate-700 text-gray-300 hover:bg-slate-600'
+          "
+          @click="activeCollection = tab.key"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+      <movie-search-prompt
+        class="min-h-0 flex-1"
+        :default-list-title="activeTabLabel"
+        :default-list="collectionResults"
+        :on-load-more="() => fetchNextPage()"
+        :loading-more="isFetchingNextPage"
+        :has-more="hasNextPage === true"
+        @close="$emit('close')"
+        @select-from-default="selectFromSearch"
+        @select-from-search="selectFromSearch"
+      />
+    </div>
   </v-modal>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useToast } from "vue-toastification";
 
-import { isTrue } from "../../../../lib/checks/checks.js";
+import { isDefined, isTrue } from "../../../../lib/checks/checks.js";
 import { WorkListType, WorkType } from "../../../../lib/types/generated/db";
 import { MovieSearchIndex } from "../../../../lib/types/movie";
 import { WatchListItem } from "../../../../lib/types/watchlist";
@@ -25,7 +45,14 @@ import MovieSearchPrompt from "../../../common/components/MovieSearchPrompt.vue"
 import { useClubSlug } from "@/service/useClub";
 import { BASE_IMAGE_URL, useList } from "@/service/useList";
 import { useAddListItem } from "@/service/useList";
-import { useTrending } from "@/service/useTMDB";
+import { TMDBCollection, useInfiniteCollection } from "@/service/useTMDB";
+
+const collectionTabs: { key: TMDBCollection; label: string }[] = [
+  { key: "popular", label: "Popular" },
+  { key: "now_playing", label: "Now Playing" },
+  { key: "upcoming", label: "Upcoming" },
+  { key: "top_rated", label: "Top Rated" },
+];
 
 const { listType } = defineProps<{
   listType: WorkListType.backlog | WorkListType.watchlist;
@@ -41,7 +68,32 @@ const listLabel = computed(() =>
 
 const clubSlug = useClubSlug();
 
-const { isLoading: loadingTrending, data: trending } = useTrending();
+const activeCollection = ref<TMDBCollection>("popular");
+const activeTabLabel = computed(
+  () =>
+    collectionTabs.find((t) => t.key === activeCollection.value)?.label ??
+    "Popular",
+);
+
+const {
+  isLoading: loadingCollection,
+  data: collectionData,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+} = useInfiniteCollection(activeCollection);
+
+const collectionResults = computed<MovieSearchIndex[]>(() => {
+  if (!isDefined(collectionData.value)) return [];
+  return collectionData.value.pages.flatMap((page) =>
+    page.results.map((movie) => ({
+      title: movie.title,
+      release_date: movie.release_date,
+      id: movie.id,
+      poster_path: movie.poster_path,
+    })),
+  );
+});
 
 const { isPending: loadingAdd, mutate: addListItem } = useAddListItem(
   clubSlug,
@@ -74,6 +126,6 @@ const selectFromSearch = (movie: MovieSearchIndex) => {
 };
 
 const loading = computed(
-  () => loadingTrending.value || loadingList.value || loadingAdd.value,
+  () => loadingCollection.value || loadingList.value || loadingAdd.value,
 );
 </script>

--- a/src/features/watch-list/components/AddMovieToListModal.vue
+++ b/src/features/watch-list/components/AddMovieToListModal.vue
@@ -24,7 +24,6 @@
         :on-load-more="() => fetchNextPage()"
         :loading-more="isFetchingNextPage"
         :has-more="hasNextPage === true"
-        @close="$emit('close')"
         @select-from-default="selectFromSearch"
         @select-from-search="selectFromSearch"
       />

--- a/src/service/useTMDB.ts
+++ b/src/service/useTMDB.ts
@@ -1,10 +1,16 @@
-import { useQuery } from "@tanstack/vue-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/vue-query";
 import axios from "axios";
 import { Ref } from "vue";
 
 import { TMDBPageResponse } from "../../lib/types/movie";
 
 const key = import.meta.env.VITE_TMDB_API_KEY;
+
+export type TMDBCollection =
+  | "popular"
+  | "now_playing"
+  | "upcoming"
+  | "top_rated";
 
 export function useSearch(query: Ref<string>, enabled: boolean) {
   return useQuery<TMDBPageResponse>({
@@ -20,14 +26,28 @@ export function useSearch(query: Ref<string>, enabled: boolean) {
   });
 }
 
-export function useTrending() {
+export function useCollection(collection: Ref<TMDBCollection>) {
   return useQuery<TMDBPageResponse>({
-    queryKey: ["tmdb", "trending"],
+    queryKey: ["tmdb", "collection", collection],
     queryFn: async () =>
       (
         await axios.get<TMDBPageResponse>(
-          `https://api.themoviedb.org/3/trending/movie/week?api_key=${key}`,
+          `https://api.themoviedb.org/3/movie/${collection.value}?api_key=${key}&language=en-US`,
         )
       ).data,
+  });
+}
+
+export function useInfiniteCollection(collection: Ref<TMDBCollection>) {
+  return useInfiniteQuery<TMDBPageResponse>({
+    queryKey: ["tmdb", "collection", "infinite", collection],
+    queryFn: async ({ pageParam = 1 }) =>
+      (
+        await axios.get<TMDBPageResponse>(
+          `https://api.themoviedb.org/3/movie/${collection.value}?api_key=${key}&language=en-US&page=${pageParam}`,
+        )
+      ).data,
+    getNextPageParam: (lastPage) =>
+      lastPage.page < lastPage.total_pages ? lastPage.page + 1 : undefined,
   });
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -12,7 +12,7 @@ module.exports = {
         text: "#FFFFFF",
       },
       gridTemplateColumns: {
-        auto: "repeat( auto-fill, minmax(168px, 1fr) )",
+        auto: "repeat( auto-fill, minmax(136px, 1fr) )",
         centerHeader: "1fr auto 1fr",
         leftHeader: "auto 1fr",
       },

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -12,7 +12,7 @@ module.exports = {
         text: "#FFFFFF",
       },
       gridTemplateColumns: {
-        auto: "repeat( auto-fill, minmax(136px, 1fr) )",
+        auto: "repeat( auto-fill, minmax(168px, 1fr) )",
         centerHeader: "1fr auto 1fr",
         leftHeader: "auto 1fr",
       },


### PR DESCRIPTION
## Summary
- Redesign Add Movie modal with **collection tabs** (Popular, Now Playing, Upcoming, Top Rated) replacing the single trending list
- Add **Load More** pagination using `useInfiniteQuery` to browse beyond the first 20 results per collection
- Replace table-based movie list with **poster card grid** layout using new `MovieSearchCard` component
- Upgrade movie search modals (Add Review, Nominations) to use larger modal size

## Test plan
- [ ] Open Add Movie modal from watchlist or backlog — verify 4 collection tabs appear
- [ ] Click each tab — verify movies load and switch correctly
- [ ] Click "Load More" — verify additional movies append below existing ones
- [ ] Switch tabs after loading more — verify pagination resets to page 1
- [ ] Type in search box — verify "Load More" button hides while filtering
- [ ] Load all pages for a collection — verify "Load More" button disappears
- [ ] Open Add Review prompt — verify it still works (no Load More button)
- [ ] Open Nominations view — verify it still works (no Load More button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)