### PR TITLE
Remove delete functionality from watch list item cards

### DIFF
--- a/src/features/watch-list/components/ClubBacklog.vue
+++ b/src/features/watch-list/components/ClubBacklog.vue
@@ -71,9 +71,7 @@
           :movie-title="movie.title"
           :movie-poster-url="movie.imageUrl ?? ''"
           :highlighted="selectedMovieId === movie.id"
-          show-delete
           @click="openMovieDetails(movie.id)"
-          @delete="() => deleteBacklogItem(movie.id)"
         >
           <v-btn
             class="flex justify-center"

--- a/src/features/watch-list/components/WatchList.vue
+++ b/src/features/watch-list/components/WatchList.vue
@@ -71,9 +71,7 @@
             work.id === OPTIMISTIC_WORK_ID ||
             (loadingAddReview && reviewedWork?.toString() === work.externalId)
           "
-          :show-delete="work.id !== OPTIMISTIC_WORK_ID"
           @click="openMovieDetails(work.id)"
-          @delete="() => deleteWatchlistItem(work.id)"
         >
           <div class="grid grid-cols-2 gap-2">
             <v-btn class="flex justify-center" @click.stop="reviewMovie(work)">


### PR DESCRIPTION
## Summary
Removed the delete action capability from watch list item cards in both the ClubBacklog and WatchList components. The delete button and associated event handlers have been removed from the UI.

## Key Changes
- **ClubBacklog.vue**: Removed `show-delete` prop and `@delete` event handler from the movie card component
- **WatchList.vue**: Removed `:show-delete` prop binding and `@delete` event handler from the work card component

## Implementation Details
The changes remove the inline delete functionality from the card components while keeping the click handlers for opening movie/work details intact. The `deleteBacklogItem()` and `deleteWatchlistItem()` methods are no longer triggered from these card interactions, suggesting the delete functionality may be moved elsewhere or deprecated.

https://claude.ai/code/session_01BB82MPW7mzht5gKn43jZtK