### PR TITLE
Improve responsive padding and grid layout on watch list

### DIFF
--- a/src/features/watch-list/views/WatchListView.vue
+++ b/src/features/watch-list/views/WatchListView.vue
@@ -121,7 +121,7 @@ const shareList = async (listId: string) => {
         <section
           v-for="list in userLists"
           :key="list.id"
-          class="rounded-lg border border-slate-700 bg-slate-900/40 p-3"
+          class="rounded-lg border border-slate-700 bg-slate-900/40 p-2 sm:p-3"
         >
           <div class="flex items-center justify-between gap-2">
             <div class="flex min-w-0 items-center gap-2">

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -12,7 +12,7 @@ module.exports = {
         text: "#FFFFFF",
       },
       gridTemplateColumns: {
-        auto: "repeat( auto-fill, minmax(168px, 1fr) )",
+        auto: "repeat( auto-fill, minmax(160px, 1fr) )",
         centerHeader: "1fr auto 1fr",
         leftHeader: "auto 1fr",
       },


### PR DESCRIPTION
## Summary
Adjusts responsive spacing and grid sizing on the watch list view to improve layout consistency across screen sizes.

## Changes
- **WatchListView.vue**: Updated section padding from fixed `p-3` to responsive `p-2 sm:p-3`, reducing padding on mobile devices while maintaining the original spacing on larger screens
- **tailwind.config.cjs**: Decreased grid column minimum width from `168px` to `160px` to allow better content fitting and more flexible grid layouts

## Details
These changes improve the mobile experience by reducing excessive padding on smaller screens while preserving the original spacing on desktop. The grid adjustment provides more flexibility for content layout across different viewport sizes.

https://claude.ai/code/session_01X8NYXFyuDmDdYaqHWpEimq