### PR TITLE
Extract VSideDrawer and PosterImage shared components

### DIFF
--- a/src/common/components/PosterImage.vue
+++ b/src/common/components/PosterImage.vue
@@ -1,0 +1,32 @@
+<template>
+  <div
+    class="overflow-hidden rounded-lg bg-lowBackground"
+    :class="{ 'animate-pulse': !loaded && hasPoster }"
+    style="aspect-ratio: 2 / 3"
+  >
+    <img
+      v-if="hasPoster"
+      :src="`https://image.tmdb.org/t/p/w500/${posterPath}`"
+      :alt="alt"
+      decoding="async"
+      loading="eager"
+      class="h-full w-full object-cover transition-opacity duration-300"
+      :class="loaded ? 'opacity-100' : 'opacity-0'"
+      @load="loaded = true"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+import { hasValue } from "../../../lib/checks/checks.js";
+
+const props = withDefaults(
+  defineProps<{ posterPath?: string | null; alt?: string }>(),
+  { posterPath: null, alt: "Movie poster" },
+);
+
+const loaded = ref(false);
+const hasPoster = computed(() => hasValue(props.posterPath));
+</script>

--- a/src/common/components/PosterImage.vue
+++ b/src/common/components/PosterImage.vue
@@ -1,8 +1,7 @@
 <template>
   <div
-    class="overflow-hidden rounded-lg bg-lowBackground"
+    class="aspect-[2/3] overflow-hidden rounded-lg bg-lowBackground"
     :class="{ 'animate-pulse': !loaded && hasPoster }"
-    style="aspect-ratio: 2 / 3"
   >
     <img
       v-if="hasPoster"

--- a/src/common/components/VSideDrawer.vue
+++ b/src/common/components/VSideDrawer.vue
@@ -1,0 +1,76 @@
+<template>
+  <div>
+    <v-backdrop :z-index="backdropZIndex" @close="handleClose" />
+
+    <Transition name="slide-in-right" appear @after-leave="onTransitionEnd">
+      <div
+        v-if="isVisible"
+        class="fixed inset-y-0 right-0 z-50 w-[35vw] max-w-full bg-background will-change-transform md:border-l md:border-gray-700 md:shadow-xl"
+        @click.stop
+      >
+        <div class="relative h-full overflow-y-auto px-4 pt-8">
+          <slot />
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+
+type ZIndex = "40" | "50" | "60";
+
+const props = withDefaults(defineProps<{ zIndex?: ZIndex }>(), {
+  zIndex: "50",
+});
+
+const emit = defineEmits<{
+  (e: "close"): void;
+}>();
+
+const backdropZIndex = computed<ZIndex>(() =>
+  props.zIndex === "60" ? "50" : props.zIndex === "50" ? "40" : "40",
+);
+
+const isVisible = ref(true);
+
+const handleClose = () => {
+  isVisible.value = false;
+};
+
+const onTransitionEnd = () => {
+  emit("close");
+};
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (event.key === "Escape" && isVisible.value) {
+    handleClose();
+  }
+};
+
+onMounted(() => {
+  window.addEventListener("keydown", onKeydown);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", onKeydown);
+});
+</script>
+
+<style scoped>
+.slide-in-right-enter-active,
+.slide-in-right-leave-active {
+  transition: transform 280ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.slide-in-right-enter-from,
+.slide-in-right-leave-to {
+  transform: translateX(100%);
+}
+
+.slide-in-right-enter-to,
+.slide-in-right-leave-from {
+  transform: translateX(0);
+}
+</style>

--- a/src/features/reviews/components/GalleryView.vue
+++ b/src/features/reviews/components/GalleryView.vue
@@ -1,10 +1,6 @@
 <template>
   <div ref="galleryContainerRef" class="flex">
-    <!-- Main content that will shrink -->
-    <div
-      :class="['w-full', { 'md:pr-[35vw]': isDefined(selectedMovie) }]"
-      class="md:px-6"
-    >
+    <div class="w-full md:px-6">
       <div class="relative mb-4 flex max-w-full flex-wrap gap-2">
         <Listbox v-model="selectedSort">
           <ListboxButton
@@ -237,7 +233,6 @@ const openMovieDetails = async (row: Row<DetailedReviewListItem>) => {
       clickedElement.scrollIntoView({
         behavior: "smooth",
         block: "center",
-        inline: "center",
       });
     } else {
       selectedMovieId.value = undefined;
@@ -260,7 +255,6 @@ watch(selectedMovieId, async (newValue, oldValue) => {
       selectedElement.scrollIntoView({
         behavior: "smooth",
         block: "center",
-        inline: "center",
       });
     }
   }

--- a/src/features/reviews/components/MovieDetailsContent.vue
+++ b/src/features/reviews/components/MovieDetailsContent.vue
@@ -9,10 +9,9 @@
     <!-- Desktop layout -->
     <template v-if="isDesktop">
       <div class="flex flex-col items-center">
-        <img
-          :src="`https://image.tmdb.org/t/p/w500/${movie.original.externalData?.poster_path}`"
-          class="mb-8 w-1/2 rounded-lg"
-          alt="Movie poster"
+        <PosterImage
+          :poster-path="movie.original.externalData?.poster_path"
+          class="mb-8 w-1/2"
         />
         <div class="flex w-full flex-col items-center">
           <h2 class="text-center text-xl font-bold">
@@ -133,11 +132,9 @@
     <template v-else>
       <!-- Compact header: poster + title + date -->
       <div class="flex gap-4">
-        <img
-          :src="`https://image.tmdb.org/t/p/w500/${movie.original.externalData?.poster_path}`"
-          class="w-20 flex-shrink-0 rounded-lg object-cover"
-          :style="{ aspectRatio: '2/3' }"
-          alt="Movie poster"
+        <PosterImage
+          :poster-path="movie.original.externalData?.poster_path"
+          class="w-20 flex-shrink-0"
         />
         <div class="flex flex-col justify-center">
           <h2 class="text-xl font-bold">
@@ -281,6 +278,7 @@ import { DetailedReviewListItem } from "../../../../lib/types/lists";
 import DeleteConfirmationModal from "@/common/components/DeleteConfirmationModal.vue";
 import MovieDescription from "@/common/components/MovieDescription.vue";
 import MovieMetadataGrid from "@/common/components/MovieMetadataGrid.vue";
+import PosterImage from "@/common/components/PosterImage.vue";
 import { useShare } from "@/common/composables/useShare";
 import { useClub, useClubSlug } from "@/service/useClub";
 import { useReviewsListId, useUpdateAddedDate } from "@/service/useList";

--- a/src/features/reviews/components/MovieDetailsDrawer.vue
+++ b/src/features/reviews/components/MovieDetailsDrawer.vue
@@ -19,31 +19,20 @@
     </v-bottom-sheet>
 
     <!-- Desktop Drawer (side panel) -->
-    <div
-      v-if="isDesktop"
-      class="fixed inset-y-0 right-0 z-50 w-[35vw] max-w-full transform bg-background md:border-l md:border-gray-700 md:shadow-xl"
-      @click.stop
-    >
-      <div class="relative h-full overflow-y-auto px-4 pt-8">
-        <!-- Close button (desktop only) -->
-        <button class="absolute right-4 top-4 z-10" @click="close">
-          <mdicon name="close" />
-        </button>
-
-        <MovieDetailsContent
-          :movie="movie"
-          :review-table="reviewTable"
-          :delete-review="deleteReview"
-          :revealed-movie-ids="revealedMovieIds"
-          :has-rated="hasRated"
-          :current-user-id="currentUserId"
-          :blur-scores-enabled="blurScoresEnabled"
-          :is-desktop="isDesktop"
-          @close="close"
-          @toggle-reveal="toggleMovieReveal"
-        />
-      </div>
-    </div>
+    <VSideDrawer v-if="isDesktop" @close="close">
+      <MovieDetailsContent
+        :movie="movie"
+        :review-table="reviewTable"
+        :delete-review="deleteReview"
+        :revealed-movie-ids="revealedMovieIds"
+        :has-rated="hasRated"
+        :current-user-id="currentUserId"
+        :blur-scores-enabled="blurScoresEnabled"
+        :is-desktop="isDesktop"
+        @close="close"
+        @toggle-reveal="toggleMovieReveal"
+      />
+    </VSideDrawer>
   </div>
 </template>
 
@@ -54,6 +43,7 @@ import MovieDetailsContent from "./MovieDetailsContent.vue";
 import { DetailedReviewListItem } from "../../../../lib/types/lists";
 import VBottomSheet from "../../../common/components/VBottomSheet.vue";
 
+import VSideDrawer from "@/common/components/VSideDrawer.vue";
 import { useIsDesktop } from "@/common/composables/useIsDesktop.js";
 
 defineProps<{

--- a/src/features/watch-list/components/ListItemDetailsContent.vue
+++ b/src/features/watch-list/components/ListItemDetailsContent.vue
@@ -9,10 +9,9 @@
     <!-- Desktop layout -->
     <template v-if="isDesktop">
       <div class="flex flex-col items-center">
-        <img
-          :src="`https://image.tmdb.org/t/p/w500/${movie.externalData?.poster_path}`"
-          class="mb-8 w-1/2 rounded-lg"
-          alt="Movie poster"
+        <PosterImage
+          :poster-path="movie.externalData?.poster_path"
+          class="mb-8 w-1/2"
         />
         <div class="flex w-full flex-col items-center">
           <h2 class="text-center text-xl font-bold">
@@ -48,11 +47,9 @@
     <!-- Mobile layout -->
     <template v-else>
       <div class="flex gap-4">
-        <img
-          :src="`https://image.tmdb.org/t/p/w500/${movie.externalData?.poster_path}`"
-          class="w-20 flex-shrink-0 rounded-lg object-cover"
-          :style="{ aspectRatio: '2/3' }"
-          alt="Movie poster"
+        <PosterImage
+          :poster-path="movie.externalData?.poster_path"
+          class="w-20 flex-shrink-0"
         />
         <div class="flex flex-col justify-center">
           <h2 class="text-xl font-bold">
@@ -145,6 +142,7 @@ import { DetailedWorkListItem } from "../../../../lib/types/lists";
 import DeleteConfirmationModal from "@/common/components/DeleteConfirmationModal.vue";
 import MovieDescription from "@/common/components/MovieDescription.vue";
 import MovieMetadataGrid from "@/common/components/MovieMetadataGrid.vue";
+import PosterImage from "@/common/components/PosterImage.vue";
 
 const { isNextWork } = defineProps<{
   movie: DetailedWorkListItem;

--- a/src/features/watch-list/components/ListItemDetailsDrawer.vue
+++ b/src/features/watch-list/components/ListItemDetailsDrawer.vue
@@ -20,31 +20,21 @@
     </v-bottom-sheet>
 
     <!-- Desktop Drawer (side panel) -->
-    <div
-      v-if="isDesktop"
-      class="fixed inset-y-0 right-0 z-50 w-[35vw] max-w-full transform bg-background md:border-l md:border-gray-700 md:shadow-xl"
-      @click.stop
-    >
-      <div class="relative h-full overflow-y-auto px-4 pt-8">
-        <button class="absolute right-4 top-4 z-10" @click="close">
-          <mdicon name="close" />
-        </button>
-
-        <ListItemDetailsContent
-          :movie="movie"
-          :is-next-work="isNextWork"
-          :is-desktop="isDesktop"
-          :can-review="canReview"
-          :other-lists="otherLists"
-          @close="close"
-          @review="emit('review')"
-          @set-next-work="emit('set-next-work')"
-          @clear-next-work="emit('clear-next-work')"
-          @delete="emit('delete')"
-          @move-to-list="(id) => emit('move-to-list', id)"
-        />
-      </div>
-    </div>
+    <VSideDrawer v-if="isDesktop" @close="close">
+      <ListItemDetailsContent
+        :movie="movie"
+        :is-next-work="isNextWork"
+        :is-desktop="isDesktop"
+        :can-review="canReview"
+        :other-lists="otherLists"
+        @close="close"
+        @review="emit('review')"
+        @set-next-work="emit('set-next-work')"
+        @clear-next-work="emit('clear-next-work')"
+        @delete="emit('delete')"
+        @move-to-list="(id) => emit('move-to-list', id)"
+      />
+    </VSideDrawer>
   </div>
 </template>
 
@@ -53,6 +43,7 @@ import ListItemDetailsContent from "./ListItemDetailsContent.vue";
 import { DetailedWorkListItem } from "../../../../lib/types/lists";
 
 import VBottomSheet from "@/common/components/VBottomSheet.vue";
+import VSideDrawer from "@/common/components/VSideDrawer.vue";
 import { useIsDesktop } from "@/common/composables/useIsDesktop.js";
 
 defineProps<{

--- a/src/features/watch-list/components/ListItems.vue
+++ b/src/features/watch-list/components/ListItems.vue
@@ -15,7 +15,7 @@
       message="Add movies to this list to see them here."
     />
     <template v-else>
-      <div :class="['w-full', { 'md:pr-[35vw]': isDefined(selectedItem) }]">
+      <div class="w-full">
         <VueDraggableNext
           v-model="draggableItems"
           tag="div"


### PR DESCRIPTION
## Summary
- Consolidates duplicated desktop drawer markup from `MovieDetailsDrawer.vue` and `ListItemDetailsDrawer.vue` into a shared `VSideDrawer` with a real slide-in/out transition, Escape-to-close, and a coupled backdrop.
- Extracts the TMDB poster `<img>` pattern into a shared `PosterImage` that renders a 2:3 aspect-ratio skeleton (`animate-pulse`) and fades the image in on load; cleanly handles missing posters.
- Drops the `md:pr-[35vw]` grid shrink in `GalleryView.vue` and `ListItems.vue` so the drawer overlays the grid instead of reflowing it. Removes the now-unnecessary `inline: "center"` from `scrollIntoView` calls.

Note: the manual `X` close button inside the drawer was removed; close affordances are Escape, backdrop click, and any `@close` emitted from the slot content.

## Test plan
- [ ] Open a review's details on desktop — drawer slides in, grid does not reflow, image fades in.
- [ ] Press Escape, click the backdrop, and close from inside the content — all three dismiss the drawer with a slide-out animation.
- [ ] Repeat the same checks on a watch-list / backlog item.
- [ ] Mobile bottom-sheet path still works (unchanged code path, but smoke-test both features).
- [ ] Movies without a `poster_path` render the skeleton placeholder without a broken image.
- [ ] Confirm `scrollIntoView` still keeps the selected card visible after the inline-center removal (vertical centering should be enough now that the grid isn't shrinking horizontally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)