### PR TITLE
Split Claude Code hooks: format on PostToolUse, lint+types on Stop

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,8 +6,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npm run format && npm run type-check && npm run lint",
-            "timeout": 120000
+            "command": "npm run format",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npm run type-check && npm run lint",
+            "timeout": 180000
           }
         ]
       }


### PR DESCRIPTION
## Summary
- `PostToolUse` now runs only `npm run format` (30 s timeout) so edits stay tidy in real time without slowing each tool call.
- `Stop` runs `npm run type-check && npm run lint` (180 s timeout) once when Claude finishes responding, so all checks still run before handoff.

This trades a little in-loop type-safety feedback for a much faster inner iteration loop. Issues are still caught before the session ends.

## Test plan
- [ ] Make a trivial edit and confirm only `npm run format` runs (fast).
- [ ] Let the session end and confirm `npm run type-check && npm run lint` runs on `Stop`.
- [ ] Introduce a deliberate lint error in a session and confirm it is reported at Stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)