### PR TITLE
Polish movie drawer: backdrop hero, sticky actions, priority fixes

### DIFF
--- a/src/common/components/MoviePosterHero.vue
+++ b/src/common/components/MoviePosterHero.vue
@@ -1,0 +1,99 @@
+<template>
+  <!-- Desktop hero: full-bleed backdrop banner, poster + title overlap from below -->
+  <div v-if="isDesktop" class="-mx-4 -mt-8 mb-6">
+    <div class="relative h-44 overflow-hidden bg-lowBackground">
+      <img
+        v-if="hasBackdrop"
+        :src="`https://image.tmdb.org/t/p/w780/${backdropPath}`"
+        alt=""
+        decoding="async"
+        loading="eager"
+        class="h-full w-full object-cover transition-opacity duration-500"
+        :class="backdropLoaded ? 'opacity-60' : 'opacity-0'"
+        @load="backdropLoaded = true"
+      />
+      <div
+        class="absolute inset-0 bg-gradient-to-b from-black/30 via-background/40 to-background"
+      ></div>
+    </div>
+
+    <div class="relative -mt-20 flex flex-col items-center px-4">
+      <div class="w-2/5 max-w-[180px] shadow-2xl">
+        <PosterImage :poster-path="posterPath" />
+      </div>
+      <h2 class="mt-3 text-center text-xl font-bold">
+        {{ title
+        }}<span v-if="year" class="font-normal text-gray-300">
+          ({{ year }})</span
+        >
+      </h2>
+      <div class="mt-1 text-center text-sm text-gray-400">
+        <slot name="date">{{ dateLabel }}</slot>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mobile hero: shorter backdrop, compact poster + title row sits on it -->
+  <div v-else class="-mx-4 mb-4">
+    <div class="relative h-28 overflow-hidden bg-lowBackground">
+      <img
+        v-if="hasBackdrop"
+        :src="`https://image.tmdb.org/t/p/w780/${backdropPath}`"
+        alt=""
+        decoding="async"
+        loading="eager"
+        class="h-full w-full object-cover transition-opacity duration-500"
+        :class="backdropLoaded ? 'opacity-50' : 'opacity-0'"
+        @load="backdropLoaded = true"
+      />
+      <div
+        class="absolute inset-0 bg-gradient-to-b from-black/20 via-background/40 to-background"
+      ></div>
+    </div>
+
+    <div class="relative -mt-14 flex items-end gap-3 px-4">
+      <div class="w-20 flex-shrink-0 shadow-lg">
+        <PosterImage :poster-path="posterPath" />
+      </div>
+      <div class="flex min-w-0 flex-col pb-1">
+        <h2 class="text-xl font-bold leading-tight">
+          {{ title
+          }}<span v-if="year" class="font-normal text-gray-300">
+            ({{ year }})</span
+          >
+        </h2>
+        <div class="mt-1 text-sm text-gray-400">
+          <slot name="date">{{ dateLabel }}</slot>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+import { hasValue } from "../../../lib/checks/checks.js";
+
+import PosterImage from "@/common/components/PosterImage.vue";
+
+const props = withDefaults(
+  defineProps<{
+    posterPath?: string | null;
+    backdropPath?: string | null;
+    title: string;
+    year?: string | number;
+    dateLabel?: string;
+    isDesktop: boolean;
+  }>(),
+  {
+    posterPath: null,
+    backdropPath: null,
+    year: undefined,
+    dateLabel: "",
+  },
+);
+
+const backdropLoaded = ref(false);
+const hasBackdrop = computed(() => hasValue(props.backdropPath));
+</script>

--- a/src/common/components/MoviePosterHero.vue
+++ b/src/common/components/MoviePosterHero.vue
@@ -9,11 +9,11 @@
         decoding="async"
         loading="eager"
         class="h-full w-full object-cover transition-opacity duration-500"
-        :class="backdropLoaded ? 'opacity-60' : 'opacity-0'"
+        :class="backdropLoaded ? 'opacity-100' : 'opacity-0'"
         @load="backdropLoaded = true"
       />
       <div
-        class="absolute inset-0 bg-gradient-to-b from-black/30 via-background/40 to-background"
+        class="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-background"
       ></div>
     </div>
 
@@ -34,8 +34,8 @@
   </div>
 
   <!-- Mobile hero: shorter backdrop, compact poster + title row sits on it -->
-  <div v-else class="-mx-4 mb-4">
-    <div class="relative h-28 overflow-hidden bg-lowBackground">
+  <div v-else class="-mx-4 -mt-8 mb-4">
+    <div class="relative h-44 overflow-hidden bg-lowBackground">
       <img
         v-if="hasBackdrop"
         :src="`https://image.tmdb.org/t/p/w780/${backdropPath}`"
@@ -51,7 +51,7 @@
       ></div>
     </div>
 
-    <div class="relative -mt-14 flex items-end gap-3 px-4">
+    <div class="relative -mt-20 flex items-end gap-3 px-4">
       <div class="w-20 flex-shrink-0 shadow-lg">
         <PosterImage :poster-path="posterPath" />
       </div>

--- a/src/common/components/VBottomSheet.vue
+++ b/src/common/components/VBottomSheet.vue
@@ -17,7 +17,8 @@
         @click.stop=""
       >
         <div
-          class="sticky top-0 z-10 flex h-8 w-full cursor-pointer items-center justify-center bg-background"
+          class="sticky top-0 z-10 flex h-8 w-full cursor-pointer items-center justify-center"
+          :class="{ 'bg-background': !transparentHandle }"
           @touchstart="handleTouchStart"
           @touchmove="handleTouchMove"
           @touchend="handleTouchEnd"
@@ -45,10 +46,12 @@ const props = withDefaults(
   defineProps<{
     contentClass?: string;
     zIndex?: ZIndex;
+    transparentHandle?: boolean;
   }>(),
   {
     contentClass: "px-4 pb-8",
     zIndex: "50",
+    transparentHandle: false,
   },
 );
 

--- a/src/features/reviews/components/MovieDetailsContent.vue
+++ b/src/features/reviews/components/MovieDetailsContent.vue
@@ -8,81 +8,80 @@
 
     <!-- Desktop layout -->
     <template v-if="isDesktop">
-      <div class="flex flex-col items-center">
-        <PosterImage
-          :poster-path="movie.original.externalData?.poster_path"
-          class="mb-8 w-1/2"
-        />
-        <div class="flex w-full flex-col items-center">
-          <h2 class="text-center text-xl font-bold">
-            {{ movie.renderValue("title") }}
-          </h2>
-          <div class="mt-2 text-center text-sm text-gray-400">
-            <template v-if="!isEditingDate">
-              <span
-                class="inline-flex cursor-pointer items-center gap-1 text-gray-400 hover:text-primary hover:underline"
-                @click="openDateEditor"
-              >
-                {{ formatDate(movie.original.createdDate) }}
-                <mdicon name="pencil" size="14" class="text-current" />
-              </span>
-            </template>
-            <template v-else>
-              <div class="flex items-center justify-center gap-1.5 px-2">
-                <input
-                  v-model="editedDate"
-                  type="date"
-                  class="rounded border border-gray-600 bg-background px-1.5 py-0.5 text-xs text-white sm:px-2 sm:py-1 sm:text-sm"
-                  @keypress.enter="saveDateChange"
-                />
-                <button
-                  class="whitespace-nowrap rounded bg-primary px-1.5 py-0.5 text-xs text-white sm:px-2 sm:py-1 sm:text-sm"
-                  @click="saveDateChange"
-                >
-                  Save
-                </button>
-                <button
-                  class="whitespace-nowrap rounded bg-gray-600 px-1.5 py-0.5 text-xs text-white sm:px-2 sm:py-1 sm:text-sm"
-                  @click="cancelDateEdit"
-                >
-                  Cancel
-                </button>
-              </div>
-            </template>
-          </div>
-          <div
-            class="mt-4 grid grid-cols-1 gap-x-4 gap-y-2 text-sm md:grid-cols-2"
-          >
-            <MovieMetadataGrid
-              :release-date="movie.original.externalData?.release_date"
-              :runtime="movie.original.externalData?.runtime"
-              :genres="movie.original.externalData?.genres"
-              :directors="movie.original.externalData?.directors"
-              :actors="movie.original.externalData?.actors"
-            />
-            <div
-              v-if="movie.original.externalData?.vote_average"
-              :class="{
-                'cursor-pointer select-none blur filter': shouldBlurTmdbScore,
-              }"
-              @click="shouldBlurTmdbScore && toggleMovieReveal(movie.id)"
+      <MoviePosterHero
+        :poster-path="movie.original.externalData?.poster_path"
+        :backdrop-path="movie.original.externalData?.backdrop_path"
+        :title="movieTitle"
+        :year="releaseYear"
+        :is-desktop="isDesktop"
+      >
+        <template #date>
+          <template v-if="!isEditingDate">
+            <span
+              class="inline-flex cursor-pointer items-center gap-1 hover:text-primary hover:underline"
+              @click="openDateEditor"
             >
-              <span class="text-gray-400">TMDB Rating: </span>
-              <span>{{ movie.original.externalData.vote_average }}/10</span>
+              {{ formatDate(movie.original.createdDate) }}
+              <mdicon name="pencil" size="14" class="text-current" />
+            </span>
+          </template>
+          <template v-else>
+            <div class="flex items-center justify-center gap-1.5 px-2">
+              <input
+                v-model="editedDate"
+                type="date"
+                class="rounded border border-gray-600 bg-background px-1.5 py-0.5 text-xs text-white sm:px-2 sm:py-1 sm:text-sm"
+                @keypress.enter="saveDateChange"
+              />
+              <button
+                class="whitespace-nowrap rounded bg-primary px-1.5 py-0.5 text-xs text-white sm:px-2 sm:py-1 sm:text-sm"
+                @click="saveDateChange"
+              >
+                Save
+              </button>
+              <button
+                class="whitespace-nowrap rounded bg-gray-600 px-1.5 py-0.5 text-xs text-white sm:px-2 sm:py-1 sm:text-sm"
+                @click="cancelDateEdit"
+              >
+                Cancel
+              </button>
             </div>
-          </div>
+          </template>
+        </template>
+      </MoviePosterHero>
+
+      <div class="grid grid-cols-1 gap-x-4 gap-y-2 text-sm md:grid-cols-2">
+        <MovieMetadataGrid
+          :release-date="movie.original.externalData?.release_date"
+          :runtime="movie.original.externalData?.runtime"
+          :genres="movie.original.externalData?.genres"
+          :directors="movie.original.externalData?.directors"
+          :actors="movie.original.externalData?.actors"
+        />
+        <div
+          v-if="movie.original.externalData?.vote_average"
+          :class="{ 'select-none blur filter': shouldBlurTmdbScore }"
+        >
+          <span class="text-gray-400">TMDB Rating: </span>
+          <span>{{ movie.original.externalData.vote_average }}/10</span>
         </div>
       </div>
 
-      <div class="mt-6 grid grid-cols-2 gap-4">
+      <div v-if="showRevealPill" class="mt-6 flex justify-center">
+        <button
+          class="flex items-center gap-2 rounded-full bg-lowBackground px-4 py-1.5 text-sm text-gray-300 transition hover:brightness-110"
+          @click="toggleMovieReveal(movie.id)"
+        >
+          <mdicon name="eye-outline" size="16" />
+          <span>Reveal club scores</span>
+        </button>
+      </div>
+
+      <div class="mt-4 grid grid-cols-2 gap-4">
         <div
           v-for="cell in getVisibleCells(movie)"
           :key="cell.id"
-          class="flex cursor-pointer items-center rounded-xl bg-lowBackground p-2"
-          @click="
-            shouldBlurScore(movie.id, cell.column.id) &&
-            toggleMovieReveal(movie.id)
-          "
+          class="flex items-center rounded-xl bg-lowBackground p-2"
         >
           <FlexRender
             :render="cell.column.columnDef.header"
@@ -110,82 +109,88 @@
 
       <ReviewChat :work-id="movie.original.id" :club-slug="clubId" />
 
-      <div class="mt-6 flex w-full gap-3">
-        <button
-          class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-500/20 py-3 text-red-500"
-          @click="showDeleteConfirmation = true"
-        >
-          <mdicon name="delete" />
-          <span>Delete</span>
-        </button>
-        <button
-          class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary/20 py-3 text-primary"
-          @click="shareReview(movie.original.id)"
-        >
-          <mdicon name="share" />
-          <span>Share</span>
-        </button>
+      <div
+        class="sticky bottom-0 -mx-4 mt-6 border-t border-gray-700/60 bg-background px-4 pb-2 pt-3"
+      >
+        <div class="flex w-full gap-3">
+          <button
+            class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-500/20 py-3 text-red-500"
+            @click="showDeleteConfirmation = true"
+          >
+            <mdicon name="delete" />
+            <span>Delete</span>
+          </button>
+          <button
+            class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary/20 py-3 text-primary"
+            @click="shareReview(movie.original.id)"
+          >
+            <mdicon name="share" />
+            <span>Share</span>
+          </button>
+        </div>
       </div>
     </template>
 
     <!-- Mobile layout -->
     <template v-else>
-      <!-- Compact header: poster + title + date -->
-      <div class="flex gap-4">
-        <PosterImage
-          :poster-path="movie.original.externalData?.poster_path"
-          class="w-20 flex-shrink-0"
-        />
-        <div class="flex flex-col justify-center">
-          <h2 class="text-xl font-bold">
-            {{ movie.renderValue("title") }}
-          </h2>
-          <div class="mt-1 text-sm text-gray-400">
-            <template v-if="!isEditingDate">
-              <span
-                class="inline-flex cursor-pointer items-center gap-1 text-gray-400 hover:text-primary hover:underline"
-                @click="openDateEditor"
+      <MoviePosterHero
+        :poster-path="movie.original.externalData?.poster_path"
+        :backdrop-path="movie.original.externalData?.backdrop_path"
+        :title="movieTitle"
+        :year="releaseYear"
+        :is-desktop="isDesktop"
+      >
+        <template #date>
+          <template v-if="!isEditingDate">
+            <span
+              class="inline-flex cursor-pointer items-center gap-1 hover:text-primary hover:underline"
+              @click="openDateEditor"
+            >
+              {{ formatDate(movie.original.createdDate) }}
+              <mdicon name="pencil" size="14" class="text-current" />
+            </span>
+          </template>
+          <template v-else>
+            <div class="flex items-center gap-1.5">
+              <input
+                v-model="editedDate"
+                type="date"
+                class="rounded border border-gray-600 bg-background px-1.5 py-0.5 text-xs text-white"
+                @keypress.enter="saveDateChange"
+              />
+              <button
+                class="whitespace-nowrap rounded bg-primary px-1.5 py-0.5 text-xs text-white"
+                @click="saveDateChange"
               >
-                {{ formatDate(movie.original.createdDate) }}
-                <mdicon name="pencil" size="14" class="text-current" />
-              </span>
-            </template>
-            <template v-else>
-              <div class="flex items-center gap-1.5">
-                <input
-                  v-model="editedDate"
-                  type="date"
-                  class="rounded border border-gray-600 bg-background px-1.5 py-0.5 text-xs text-white"
-                  @keypress.enter="saveDateChange"
-                />
-                <button
-                  class="whitespace-nowrap rounded bg-primary px-1.5 py-0.5 text-xs text-white"
-                  @click="saveDateChange"
-                >
-                  Save
-                </button>
-                <button
-                  class="whitespace-nowrap rounded bg-gray-600 px-1.5 py-0.5 text-xs text-white"
-                  @click="cancelDateEdit"
-                >
-                  Cancel
-                </button>
-              </div>
-            </template>
-          </div>
-        </div>
+                Save
+              </button>
+              <button
+                class="whitespace-nowrap rounded bg-gray-600 px-1.5 py-0.5 text-xs text-white"
+                @click="cancelDateEdit"
+              >
+                Cancel
+              </button>
+            </div>
+          </template>
+        </template>
+      </MoviePosterHero>
+
+      <div v-if="showRevealPill" class="mt-2 flex justify-center">
+        <button
+          class="flex items-center gap-2 rounded-full bg-lowBackground px-4 py-1.5 text-sm text-gray-300 transition hover:brightness-110"
+          @click="toggleMovieReveal(movie.id)"
+        >
+          <mdicon name="eye-outline" size="16" />
+          <span>Reveal club scores</span>
+        </button>
       </div>
 
       <!-- Scores grid (prioritized on mobile) -->
-      <div class="mt-4 grid grid-cols-2 gap-4">
+      <div class="mt-3 grid grid-cols-2 gap-4">
         <div
           v-for="cell in getVisibleCells(movie)"
           :key="cell.id"
-          class="flex cursor-pointer items-center rounded-xl bg-lowBackground p-2"
-          @click="
-            shouldBlurScore(movie.id, cell.column.id) &&
-            toggleMovieReveal(movie.id)
-          "
+          class="flex items-center rounded-xl bg-lowBackground p-2"
         >
           <FlexRender
             :render="cell.column.columnDef.header"
@@ -225,10 +230,7 @@
           />
           <div
             v-if="movie.original.externalData?.vote_average"
-            :class="{
-              'cursor-pointer select-none blur filter': shouldBlurTmdbScore,
-            }"
-            @click="shouldBlurTmdbScore && toggleMovieReveal(movie.id)"
+            :class="{ 'select-none blur filter': shouldBlurTmdbScore }"
           >
             <span class="text-gray-400">TMDB Rating: </span>
             <span>{{ movie.original.externalData.vote_average }}/10</span>
@@ -244,22 +246,26 @@
 
       <ReviewChat :work-id="movie.original.id" :club-slug="clubId" />
 
-      <!-- Action buttons -->
-      <div class="mt-6 flex w-full gap-3">
-        <button
-          class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-500/20 py-3 text-red-500"
-          @click="showDeleteConfirmation = true"
-        >
-          <mdicon name="delete" />
-          <span>Delete</span>
-        </button>
-        <button
-          class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary/20 py-3 text-primary"
-          @click="shareReview(movie.original.id)"
-        >
-          <mdicon name="share" />
-          <span>Share</span>
-        </button>
+      <!-- Sticky action footer -->
+      <div
+        class="sticky bottom-0 -mx-4 mt-6 border-t border-gray-700/60 bg-background px-4 pb-2 pt-3"
+      >
+        <div class="flex w-full gap-3">
+          <button
+            class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-500/20 py-3 text-red-500"
+            @click="showDeleteConfirmation = true"
+          >
+            <mdicon name="delete" />
+            <span>Delete</span>
+          </button>
+          <button
+            class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary/20 py-3 text-primary"
+            @click="shareReview(movie.original.id)"
+          >
+            <mdicon name="share" />
+            <span>Share</span>
+          </button>
+        </div>
       </div>
     </template>
   </div>
@@ -278,7 +284,7 @@ import { DetailedReviewListItem } from "../../../../lib/types/lists";
 import DeleteConfirmationModal from "@/common/components/DeleteConfirmationModal.vue";
 import MovieDescription from "@/common/components/MovieDescription.vue";
 import MovieMetadataGrid from "@/common/components/MovieMetadataGrid.vue";
-import PosterImage from "@/common/components/PosterImage.vue";
+import MoviePosterHero from "@/common/components/MoviePosterHero.vue";
 import { useShare } from "@/common/composables/useShare";
 import { useClub, useClubSlug } from "@/service/useClub";
 import { useReviewsListId, useUpdateAddedDate } from "@/service/useList";
@@ -348,6 +354,15 @@ const saveDateChange = () => {
 const cancelDateEdit = () => {
   isEditingDate.value = false;
 };
+
+const movieTitle = computed(() => String(props.movie.renderValue("title")));
+
+const releaseYear = computed(() => {
+  const releaseDate = props.movie.original.externalData?.release_date;
+  if (!hasValue(releaseDate)) return undefined;
+  const year = DateTime.fromISO(releaseDate).year;
+  return Number.isNaN(year) ? undefined : year;
+});
 
 const CUSTOM_RENDERED_COLUMNS = ["title", "imageUrl", "createdDate"];
 
@@ -426,6 +441,16 @@ const shouldBlurTmdbScore = computed(() => {
   ) {
     return false;
   }
+  return true;
+});
+
+const showRevealPill = computed(() => {
+  if (!props.blurScoresEnabled) return false;
+  if (
+    props.hasRated(props.movie.id) ||
+    props.revealedMovieIds.has(props.movie.id)
+  )
+    return false;
   return true;
 });
 </script>

--- a/src/features/reviews/components/MovieDetailsContent.vue
+++ b/src/features/reviews/components/MovieDetailsContent.vue
@@ -60,21 +60,48 @@
         />
         <div
           v-if="movie.original.externalData?.vote_average"
-          :class="{ 'select-none blur filter': shouldBlurTmdbScore }"
+          class="flex items-center gap-2"
+          :class="{
+            'cursor-pointer hover:opacity-80': shouldBlurTmdbScore,
+          }"
+          @click="revealTmdb"
         >
           <span class="text-gray-400">TMDB Rating: </span>
-          <span>{{ movie.original.externalData.vote_average }}/10</span>
+          <span
+            class="transition-[filter] duration-500 ease-out"
+            :class="
+              shouldBlurTmdbScore ? 'select-none blur' : 'select-auto blur-none'
+            "
+            >{{ movie.original.externalData.vote_average }}/10</span
+          >
+          <mdicon
+            v-if="shouldBlurTmdbScore"
+            name="eye-outline"
+            size="14"
+            class="text-gray-400"
+          />
         </div>
       </div>
 
-      <div v-if="showRevealPill" class="mt-6 flex justify-center">
-        <button
-          class="flex items-center gap-2 rounded-full bg-lowBackground px-4 py-1.5 text-sm text-gray-300 transition hover:brightness-110"
-          @click="toggleMovieReveal(movie.id)"
-        >
-          <mdicon name="eye-outline" size="16" />
-          <span>Reveal club scores</span>
-        </button>
+      <div
+        :inert="!showRevealPill"
+        :aria-hidden="!showRevealPill || undefined"
+        class="overflow-hidden transition-all duration-300 ease-out"
+        :style="{
+          maxHeight: showRevealPill ? '4rem' : '0px',
+          marginTop: showRevealPill ? '1.5rem' : '0px',
+          opacity: showRevealPill ? 1 : 0,
+        }"
+      >
+        <div class="flex justify-center">
+          <button
+            class="flex items-center gap-2 rounded-full bg-lowBackground px-4 py-1.5 text-sm text-gray-300 transition hover:brightness-110"
+            @click="toggleMovieReveal(movie.id)"
+          >
+            <mdicon name="eye-outline" size="16" />
+            <span>Reveal club scores</span>
+          </button>
+        </div>
       </div>
 
       <div class="mt-4 grid grid-cols-2 gap-4">
@@ -87,13 +114,15 @@
             :render="cell.column.columnDef.header"
             :props="cell.getContext()"
           />
-          <div class="ml-2 flex-grow">
+          <div
+            class="ml-2 flex-grow transition-[filter] duration-500 ease-out"
+            :class="
+              shouldBlurScore(movie.id, cell.column.id) ? 'blur' : 'blur-none'
+            "
+          >
             <FlexRender
               :render="cell.column.columnDef.cell"
               :props="cell.getContext()"
-              :class="{
-                'blur filter': shouldBlurScore(movie.id, cell.column.id),
-              }"
             />
           </div>
         </div>
@@ -175,14 +204,25 @@
         </template>
       </MoviePosterHero>
 
-      <div v-if="showRevealPill" class="mt-2 flex justify-center">
-        <button
-          class="flex items-center gap-2 rounded-full bg-lowBackground px-4 py-1.5 text-sm text-gray-300 transition hover:brightness-110"
-          @click="toggleMovieReveal(movie.id)"
-        >
-          <mdicon name="eye-outline" size="16" />
-          <span>Reveal club scores</span>
-        </button>
+      <div
+        :inert="!showRevealPill"
+        :aria-hidden="!showRevealPill || undefined"
+        class="overflow-hidden transition-all duration-300 ease-out"
+        :style="{
+          maxHeight: showRevealPill ? '4rem' : '0px',
+          marginTop: showRevealPill ? '0.5rem' : '0px',
+          opacity: showRevealPill ? 1 : 0,
+        }"
+      >
+        <div class="flex justify-center">
+          <button
+            class="flex items-center gap-2 rounded-full bg-lowBackground px-4 py-1.5 text-sm text-gray-300 transition hover:brightness-110"
+            @click="toggleMovieReveal(movie.id)"
+          >
+            <mdicon name="eye-outline" size="16" />
+            <span>Reveal club scores</span>
+          </button>
+        </div>
       </div>
 
       <!-- Scores grid (prioritized on mobile) -->
@@ -196,13 +236,15 @@
             :render="cell.column.columnDef.header"
             :props="cell.getContext()"
           />
-          <div class="ml-2 flex-grow">
+          <div
+            class="ml-2 flex-grow transition-[filter] duration-500 ease-out"
+            :class="
+              shouldBlurScore(movie.id, cell.column.id) ? 'blur' : 'blur-none'
+            "
+          >
             <FlexRender
               :render="cell.column.columnDef.cell"
               :props="cell.getContext()"
-              :class="{
-                'blur filter': shouldBlurScore(movie.id, cell.column.id),
-              }"
             />
           </div>
         </div>
@@ -230,10 +272,22 @@
           />
           <div
             v-if="movie.original.externalData?.vote_average"
-            :class="{ 'select-none blur filter': shouldBlurTmdbScore }"
+            class="flex items-center gap-2"
+            :class="{
+              'cursor-pointer hover:opacity-80': shouldBlurTmdbScore,
+            }"
+            @click="revealTmdb"
           >
             <span class="text-gray-400">TMDB Rating: </span>
-            <span>{{ movie.original.externalData.vote_average }}/10</span>
+            <span :class="{ 'select-none blur filter': shouldBlurTmdbScore }"
+              >{{ movie.original.externalData.vote_average }}/10</span
+            >
+            <mdicon
+              v-if="shouldBlurTmdbScore"
+              name="eye-outline"
+              size="14"
+              class="text-gray-400"
+            />
           </div>
           <MovieDescription
             v-if="movie.original.externalData?.overview"
@@ -431,17 +485,12 @@ const shouldBlurScore = (rowId: string, columnId: string) => {
   return columnId.startsWith("member_") || columnId === "score_average";
 };
 
-const shouldBlurTmdbScore = computed(() => {
-  if (!props.blurScoresEnabled) {
-    return false;
-  }
-  if (
-    props.hasRated(props.movie.id) ||
-    props.revealedMovieIds.has(props.movie.id)
-  ) {
-    return false;
-  }
-  return true;
+const hasClubScoresToReveal = computed(() => {
+  return getVisibleCells(props.movie).some((cell) => {
+    const colId = cell.column.id;
+    if (colId === `member_${props.currentUserId}`) return false;
+    return colId.startsWith("member_") || colId === "score_average";
+  });
 });
 
 const showRevealPill = computed(() => {
@@ -451,6 +500,20 @@ const showRevealPill = computed(() => {
     props.revealedMovieIds.has(props.movie.id)
   )
     return false;
+  return hasClubScoresToReveal.value;
+});
+
+const tmdbRevealed = ref(false);
+
+const shouldBlurTmdbScore = computed(() => {
+  if (!props.blurScoresEnabled) return false;
+  if (props.hasRated(props.movie.id) || tmdbRevealed.value) return false;
   return true;
 });
+
+const revealTmdb = () => {
+  if (shouldBlurTmdbScore.value) {
+    tmdbRevealed.value = true;
+  }
+};
 </script>

--- a/src/features/reviews/components/MovieDetailsDrawer.vue
+++ b/src/features/reviews/components/MovieDetailsDrawer.vue
@@ -1,21 +1,19 @@
 <template>
   <div>
     <!-- Mobile Bottom Sheet -->
-    <v-bottom-sheet v-if="!isDesktop" @close="close">
-      <div class="flex-grow px-4 pb-8">
-        <MovieDetailsContent
-          :movie="movie"
-          :review-table="reviewTable"
-          :delete-review="deleteReview"
-          :revealed-movie-ids="revealedMovieIds"
-          :has-rated="hasRated"
-          :current-user-id="currentUserId"
-          :blur-scores-enabled="blurScoresEnabled"
-          :is-desktop="isDesktop"
-          @close="close"
-          @toggle-reveal="toggleMovieReveal"
-        />
-      </div>
+    <v-bottom-sheet v-if="!isDesktop" transparent-handle @close="close">
+      <MovieDetailsContent
+        :movie="movie"
+        :review-table="reviewTable"
+        :delete-review="deleteReview"
+        :revealed-movie-ids="revealedMovieIds"
+        :has-rated="hasRated"
+        :current-user-id="currentUserId"
+        :blur-scores-enabled="blurScoresEnabled"
+        :is-desktop="isDesktop"
+        @close="close"
+        @toggle-reveal="toggleMovieReveal"
+      />
     </v-bottom-sheet>
 
     <!-- Desktop Drawer (side panel) -->

--- a/src/features/watch-list/components/ListItemDetailsContent.vue
+++ b/src/features/watch-list/components/ListItemDetailsContent.vue
@@ -6,145 +6,113 @@
       @cancel="showDeleteConfirmation = false"
     />
 
-    <!-- Desktop layout -->
-    <template v-if="isDesktop">
-      <div class="flex flex-col items-center">
-        <PosterImage
-          :poster-path="movie.externalData?.poster_path"
-          class="mb-8 w-1/2"
-        />
-        <div class="flex w-full flex-col items-center">
-          <h2 class="text-center text-xl font-bold">
-            {{ movie.title }}
-          </h2>
-          <div class="mt-2 text-center text-sm text-gray-400">
-            {{ formatDate(movie.createdDate) }}
-          </div>
-          <div
-            class="mt-4 grid grid-cols-1 gap-x-4 gap-y-2 text-sm md:grid-cols-2"
-          >
-            <MovieMetadataGrid
-              :release-date="movie.externalData?.release_date"
-              :runtime="movie.externalData?.runtime"
-              :genres="movie.externalData?.genres"
-              :directors="movie.externalData?.directors"
-              :actors="movie.externalData?.actors"
-              :vote-average="movie.externalData?.vote_average"
-            />
-          </div>
-        </div>
-      </div>
+    <MoviePosterHero
+      :poster-path="movie.externalData?.poster_path"
+      :backdrop-path="movie.externalData?.backdrop_path"
+      :title="movie.title"
+      :year="releaseYear"
+      :date-label="formatDate(movie.createdDate)"
+      :is-desktop="isDesktop"
+    />
 
-      <div v-if="movie.externalData" class="mt-6">
-        <MovieDescription
-          v-if="movie.externalData.overview"
-          :key="movie.id"
-          :overview="movie.externalData.overview"
-        />
-      </div>
-    </template>
-
-    <!-- Mobile layout -->
-    <template v-else>
-      <div class="flex gap-4">
-        <PosterImage
-          :poster-path="movie.externalData?.poster_path"
-          class="w-20 flex-shrink-0"
-        />
-        <div class="flex flex-col justify-center">
-          <h2 class="text-xl font-bold">
-            {{ movie.title }}
-          </h2>
-          <div class="mt-1 text-sm text-gray-400">
-            {{ formatDate(movie.createdDate) }}
-          </div>
-        </div>
-      </div>
-
-      <Disclosure v-slot="{ open }">
-        <DisclosureButton
-          class="mt-4 flex w-full items-center justify-between rounded-lg bg-lowBackground px-4 py-2.5 text-sm font-medium text-gray-300"
-        >
-          <span>Movie Details</span>
-          <mdicon
-            name="chevron-down"
-            :class="open ? 'rotate-180 transform' : ''"
-            class="transition-transform duration-200"
-          />
-        </DisclosureButton>
-        <DisclosurePanel class="mt-2 grid grid-cols-1 gap-y-2 px-1 text-sm">
-          <MovieMetadataGrid
-            :release-date="movie.externalData?.release_date"
-            :runtime="movie.externalData?.runtime"
-            :genres="movie.externalData?.genres"
-            :directors="movie.externalData?.directors"
-            :actors="movie.externalData?.actors"
-            :vote-average="movie.externalData?.vote_average"
-          />
-          <MovieDescription
-            v-if="movie.externalData?.overview"
-            :key="movie.id"
-            :overview="movie.externalData.overview"
-            class="mt-2"
-          />
-        </DisclosurePanel>
-      </Disclosure>
-    </template>
-
-    <!-- Action buttons -->
-    <div class="mt-6 flex w-full flex-wrap gap-3">
-      <button
-        v-if="canReview"
-        class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary/20 py-3 text-primary"
-        @click="emit('review')"
-      >
-        <mdicon name="check" />
-        <span>Reviewed</span>
-      </button>
-      <button
-        class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary/20 py-3 text-primary"
-        @click="toggleNextWork"
-      >
-        <mdicon
-          :name="isNextWork ? 'arrow-collapse-down' : 'arrow-collapse-up'"
-        />
-        <span>{{ isNextWork ? "Unpin" : "Up Next" }}</span>
-      </button>
-      <button
-        class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-500/20 py-3 text-red-500"
-        @click="showDeleteConfirmation = true"
-      >
-        <mdicon name="delete" />
-        <span>Delete</span>
-      </button>
+    <div class="grid grid-cols-1 gap-y-2 text-sm md:grid-cols-2 md:gap-x-4">
+      <MovieMetadataGrid
+        :release-date="movie.externalData?.release_date"
+        :runtime="movie.externalData?.runtime"
+        :genres="movie.externalData?.genres"
+        :directors="movie.externalData?.directors"
+        :actors="movie.externalData?.actors"
+        :vote-average="movie.externalData?.vote_average"
+      />
     </div>
 
-    <select
-      v-if="otherLists.length > 0"
-      class="mt-3 w-full cursor-pointer rounded-md bg-slate-800 px-2 py-2 text-sm text-white"
-      @change="onMoveSelect"
+    <div v-if="movie.externalData?.overview" class="mt-4">
+      <MovieDescription
+        :key="movie.id"
+        :overview="movie.externalData.overview"
+      />
+    </div>
+
+    <!-- Sticky action footer -->
+    <div
+      class="sticky bottom-0 -mx-4 mt-6 space-y-2 border-t border-gray-700/60 bg-background px-4 pb-2 pt-3"
     >
-      <option value="">Move to…</option>
-      <option v-for="l in otherLists" :key="l.id" :value="l.id">
-        {{ l.title }}
-      </option>
-    </select>
+      <div class="flex w-full flex-wrap gap-3">
+        <button
+          v-if="canReview"
+          class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary/20 py-3 text-primary"
+          @click="emit('review')"
+        >
+          <mdicon name="check" />
+          <span>Reviewed</span>
+        </button>
+        <button
+          class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary/20 py-3 text-primary"
+          @click="toggleNextWork"
+        >
+          <mdicon
+            :name="isNextWork ? 'arrow-collapse-down' : 'arrow-collapse-up'"
+          />
+          <span>{{ isNextWork ? "Unpin" : "Up Next" }}</span>
+        </button>
+        <button
+          class="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-500/20 py-3 text-red-500"
+          @click="showDeleteConfirmation = true"
+        >
+          <mdicon name="delete" />
+          <span>Delete</span>
+        </button>
+      </div>
+
+      <Listbox
+        v-if="otherLists.length > 0"
+        v-model="moveToValue"
+        @update:model-value="onMoveSelect"
+      >
+        <div class="relative">
+          <ListboxButton
+            class="flex w-full items-center justify-between rounded-lg bg-lowBackground px-4 py-2.5 text-sm text-gray-300"
+          >
+            <span>Move to…</span>
+            <mdicon name="chevron-down" />
+          </ListboxButton>
+          <ListboxOptions
+            class="absolute bottom-full left-0 z-10 mb-1 w-full rounded-lg border border-gray-700 bg-background py-1 shadow-lg focus:outline-none"
+          >
+            <ListboxOption
+              v-for="list in otherLists"
+              :key="list.id"
+              :value="list.id"
+              class="cursor-pointer px-4 py-2 text-sm hover:bg-lowBackground"
+            >
+              {{ list.title }}
+            </ListboxOption>
+          </ListboxOptions>
+        </div>
+      </Listbox>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { Disclosure, DisclosureButton, DisclosurePanel } from "@headlessui/vue";
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from "@headlessui/vue";
 import { DateTime } from "luxon";
-import { ref } from "vue";
+import { computed, nextTick, ref } from "vue";
 
+import { hasValue } from "../../../../lib/checks/checks.js";
 import { DetailedWorkListItem } from "../../../../lib/types/lists";
 
 import DeleteConfirmationModal from "@/common/components/DeleteConfirmationModal.vue";
 import MovieDescription from "@/common/components/MovieDescription.vue";
 import MovieMetadataGrid from "@/common/components/MovieMetadataGrid.vue";
-import PosterImage from "@/common/components/PosterImage.vue";
+import MoviePosterHero from "@/common/components/MoviePosterHero.vue";
 
-const { isNextWork } = defineProps<{
+const props = defineProps<{
   movie: DetailedWorkListItem;
   isNextWork: boolean;
   isDesktop: boolean;
@@ -169,21 +137,30 @@ const confirmDelete = () => {
 };
 
 const toggleNextWork = () => {
-  if (isNextWork) {
+  if (props.isNextWork) {
     emit("clear-next-work");
   } else {
     emit("set-next-work");
   }
 };
 
-const onMoveSelect = (e: Event) => {
-  const target = e.target as HTMLSelectElement;
-  if (target.value === "") return;
-  emit("move-to-list", target.value);
-  target.value = "";
+const moveToValue = ref<string | null>(null);
+const onMoveSelect = async (value: string | null) => {
+  if (hasValue(value)) {
+    emit("move-to-list", value);
+  }
+  await nextTick();
+  moveToValue.value = null;
 };
 
 const formatDate = (dateString: string) => {
   return DateTime.fromISO(dateString).toLocaleString(DateTime.DATE_MED);
 };
+
+const releaseYear = computed(() => {
+  const releaseDate = props.movie.externalData?.release_date;
+  if (!hasValue(releaseDate)) return undefined;
+  const year = DateTime.fromISO(releaseDate).year;
+  return Number.isNaN(year) ? undefined : year;
+});
 </script>

--- a/src/features/watch-list/components/ListItemDetailsDrawer.vue
+++ b/src/features/watch-list/components/ListItemDetailsDrawer.vue
@@ -1,22 +1,20 @@
 <template>
   <div>
     <!-- Mobile Bottom Sheet -->
-    <v-bottom-sheet v-if="!isDesktop" @close="close">
-      <div class="flex-grow px-4 pb-8">
-        <ListItemDetailsContent
-          :movie="movie"
-          :is-next-work="isNextWork"
-          :is-desktop="isDesktop"
-          :can-review="canReview"
-          :other-lists="otherLists"
-          @close="close"
-          @review="emit('review')"
-          @set-next-work="emit('set-next-work')"
-          @clear-next-work="emit('clear-next-work')"
-          @delete="emit('delete')"
-          @move-to-list="(id) => emit('move-to-list', id)"
-        />
-      </div>
+    <v-bottom-sheet v-if="!isDesktop" transparent-handle @close="close">
+      <ListItemDetailsContent
+        :movie="movie"
+        :is-next-work="isNextWork"
+        :is-desktop="isDesktop"
+        :can-review="canReview"
+        :other-lists="otherLists"
+        @close="close"
+        @review="emit('review')"
+        @set-next-work="emit('set-next-work')"
+        @clear-next-work="emit('clear-next-work')"
+        @delete="emit('delete')"
+        @move-to-list="(id) => emit('move-to-list', id)"
+      />
     </v-bottom-sheet>
 
     <!-- Desktop Drawer (side panel) -->


### PR DESCRIPTION
## Summary
Stacks on top of #344. Sharpens what each drawer context emphasizes — reviews leads with scores + chat, watchlist/backlog leads with overview + metadata — and gives both a cinematic backdrop hero so the panel feels like a movie surface rather than a flat dialog.

- New `MoviePosterHero` with a backdrop-image banner, gradient fade, and the poster overlapping upward; responsive desktop / mobile variants.
- Year shown inline with the title, extracted from `release_date`.
- Action footer is now `sticky bottom-0` so primary actions stay reachable when chat or metadata scrolls.
- Watchlist mobile drawer no longer hides its own overview + metadata behind a collapsed `<Disclosure>` — that info is the whole reason for opening the drawer in that context.
- `"Move to…"` native `<select>` replaced with a Headless UI `Listbox` styled to match the rest of the drawer; pops upward (`bottom-full`) since it sits in the footer.
- Score-blur reveal collapses from N per-cell taps into a single "Reveal club scores" pill above the scores grid.

## Test plan
- [ ] **Reviews drawer, desktop**: open a review — hero shows backdrop with gradient fade, poster sits below hero centered, title includes year, scores grid and chat below, action footer sticks to bottom while content scrolls.
- [ ] **Reviews drawer, mobile**: bottom sheet slides up — backdrop hero spans top, compact poster + title + year row sits on it, scores grid first, metadata disclosure still works, action buttons pinned to bottom of sheet while chat scrolls.
- [ ] **Reveal pill** (with `blurScoresEnabled` on, current user has not rated): single tap on the pill reveals all member scores + TMDB rating at once; per-cell click no longer reveals.
- [ ] **Watchlist / backlog drawer, mobile**: overview and metadata visible immediately — no "Movie Details" toggle to expand.
- [ ] **`Listbox` "Move to…"**: opens upward, stays inside the drawer, selecting a list fires the move and the button resets to "Move to…".
- [ ] **Missing `backdrop_path`**: hero falls back to solid `bg-lowBackground` instead of a broken image.
- [ ] **Missing `poster_path`**: `PosterImage` skeleton renders inside the hero.
- [ ] Esc, backdrop click, and any in-content close still dismiss the drawer with the PR #344 slide-out animation; date editor, delete confirmation, Up Next toggle all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)