### PR TITLE
Refetch invalidated queries on remount

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,9 @@ const vueQueryOptions: VueQueryPluginOptions = {
       queries: {
         refetchOnWindowFocus: false,
         refetchOnMount: (query) => {
+          if (query.state.isInvalidated) {
+            return true;
+          }
           const refetchTimes = fetchedMap.get(query.queryHash);
           if (isDefined(refetchTimes) && refetchTimes > 1) {
             return false;

--- a/src/service/useClub.ts
+++ b/src/service/useClub.ts
@@ -151,7 +151,7 @@ export function useRemoveMember(clubSlug: string) {
         .invalidateQueries({
           queryKey: reviewsListKey(clubSlug),
         })
-        .catch(console.error); // TODO: this isn't working and refreshing scores
+        .catch(console.error);
     },
   });
 }


### PR DESCRIPTION
The custom refetchOnMount predicate in main.ts stopped returning true
after a query had mounted twice, which caused mutations' invalidations
to be silently dropped when the user navigated away and back. Honor
query.state.isInvalidated so invalidations always trigger a refetch on
the next mount.

https://claude.ai/code/session_01DZz3PPrrzwzqGTFRcwfHLo