### PR TITLE
Fix unclickable review button on next watch in watchlist

### DIFF
--- a/src/features/watch-list/components/ListItems.vue
+++ b/src/features/watch-list/components/ListItems.vue
@@ -25,7 +25,7 @@
           :animation="200"
           handle=".drag-handle"
           filter=".no-drag"
-          :prevent-on-filter="true"
+          :prevent-on-filter="false"
           :move="onDragMove"
           @end="onDragEnd"
         >


### PR DESCRIPTION
The next watch item has the `no-drag` class, and VueDraggableNext was
configured with `prevent-on-filter="true"`. SortableJS calls
`preventDefault()` on the mousedown event for filtered elements, which
suppresses the subsequent click event on the buttons inside. Drag
prevention is still handled by the missing `.drag-handle` and the
`onDragMove` guard, so disabling `prevent-on-filter` is safe.

https://claude.ai/code/session_01RzhmLwegTfaFkpWmfnQWko