### PR TITLE
Add experimental AI discussion questions feature for movie reviews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,5 +149,6 @@ Required environment variables (documented in Cobresun Notion):
 - `RESEND_API_KEY` - Resend email API key
 - `CLOUDINARY_URL` - Cloudinary configuration URL
 - `TMDB_API_KEY` - TMDB API key for movie data
+- `GEMINI_API_KEY` - Google AI Studio key used by the experimental "discussion questions" feature (calls the `gemini-3.1-flash-lite` model). **This is a Netlify-console-only secret and is NOT synced to your local `.env`.** To exercise the feature locally, generate your own key at https://aistudio.google.com/apikey and add `GEMINI_API_KEY=<your-key>` to `.env`. Deploys read the value from the Netlify console.
 
 Netlify provides automatically: `URL` (production), `DEPLOY_PRIME_URL` (deploy preview)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,6 @@ Required environment variables (documented in Cobresun Notion):
 - `RESEND_API_KEY` - Resend email API key
 - `CLOUDINARY_URL` - Cloudinary configuration URL
 - `TMDB_API_KEY` - TMDB API key for movie data
-- `GEMINI_API_KEY` - Google AI Studio key used by the experimental "discussion questions" feature (calls the `gemini-3.1-flash-lite` model). **This is a Netlify-console-only secret and is NOT synced to your local `.env`.** To exercise the feature locally, generate your own key at https://aistudio.google.com/apikey and add `GEMINI_API_KEY=<your-key>` to `.env`. Deploys read the value from the Netlify console.
+- `GEMINI_API_KEY` - Google AI Studio key used by the experimental "discussion questions" feature (calls the `gemini-3.5-flash` model). **This is a Netlify-console-only secret and is NOT synced to your local `.env`.** To exercise the feature locally, generate your own key at https://aistudio.google.com/apikey and add `GEMINI_API_KEY=<your-key>` to `.env`. Deploys read the value from the Netlify console.
 
 Netlify provides automatically: `URL` (production), `DEPLOY_PRIME_URL` (deploy preview)

--- a/netlify/functions/club/reviews.ts
+++ b/netlify/functions/club/reviews.ts
@@ -3,9 +3,11 @@ import { z } from "zod";
 import { hasValue } from "../../../lib/checks/checks.js";
 import ListRepository from "../repositories/ListRepository";
 import ReviewRepository from "../repositories/ReviewRepository";
+import SettingsRepository from "../repositories/SettingsRepository";
 import WorkCommentRepository from "../repositories/WorkCommentRepository";
 import SharedReviewService from "../services/SharedReviewService";
 import { secured } from "../utils/auth";
+import { generateDiscussionQuestions } from "../utils/gemini";
 import { badRequest, ok, unauthorized } from "../utils/responses";
 import { Router } from "../utils/router";
 import { ClubRequest } from "../utils/validation";
@@ -150,6 +152,39 @@ router.delete(
     }
     await WorkCommentRepository.deleteById(params.commentId);
     return res(ok());
+  },
+);
+
+const discussionQuestionsSchema = z.object({
+  title: z.string().min(1).max(300),
+  releaseYear: z
+    .string()
+    .regex(/^\d{4}$/)
+    .optional(),
+});
+
+router.post(
+  "/:workId/discussion-questions",
+  secured,
+  async ({ clubId, params, event }, res) => {
+    if (!hasValue(params.workId)) {
+      return res(badRequest("No workId provided"));
+    }
+
+    const settings = await SettingsRepository.getSettings(clubId);
+    if (settings.features.discussionQuestions !== true) {
+      return res(badRequest("Feature not enabled"));
+    }
+
+    if (!hasValue(event.body)) return res(badRequest("No body provided"));
+    const body = discussionQuestionsSchema.safeParse(JSON.parse(event.body));
+    if (!body.success) return res(badRequest("Invalid body"));
+
+    const questions = await generateDiscussionQuestions(
+      body.data.title,
+      body.data.releaseYear,
+    );
+    return res(ok(JSON.stringify({ questions })));
   },
 );
 

--- a/netlify/functions/club/reviews.ts
+++ b/netlify/functions/club/reviews.ts
@@ -5,6 +5,7 @@ import ListRepository from "../repositories/ListRepository";
 import ReviewRepository from "../repositories/ReviewRepository";
 import SettingsRepository from "../repositories/SettingsRepository";
 import WorkCommentRepository from "../repositories/WorkCommentRepository";
+import WorkRepository from "../repositories/WorkRepository";
 import SharedReviewService from "../services/SharedReviewService";
 import { secured } from "../utils/auth";
 import { generateDiscussionQuestions } from "../utils/gemini";
@@ -155,18 +156,10 @@ router.delete(
   },
 );
 
-const discussionQuestionsSchema = z.object({
-  title: z.string().min(1).max(300),
-  releaseYear: z
-    .string()
-    .regex(/^\d{4}$/)
-    .optional(),
-});
-
 router.post(
   "/:workId/discussion-questions",
   secured,
-  async ({ clubId, params, event }, res) => {
+  async ({ clubId, params }, res) => {
     if (!hasValue(params.workId)) {
       return res(badRequest("No workId provided"));
     }
@@ -176,13 +169,20 @@ router.post(
       return res(badRequest("Feature not enabled"));
     }
 
-    if (!hasValue(event.body)) return res(badRequest("No body provided"));
-    const body = discussionQuestionsSchema.safeParse(JSON.parse(event.body));
-    if (!body.success) return res(badRequest("Invalid body"));
+    // Resolve the movie's title/year server-side from the workId so the prompt
+    // can't be poisoned by client-supplied input.
+    const work = await WorkRepository.getDiscussionContext(
+      clubId,
+      params.workId,
+    );
+    if (!work) {
+      return res(badRequest("Work not found"));
+    }
 
+    const releaseYear = work.release_date?.getFullYear().toString();
     const questions = await generateDiscussionQuestions(
-      body.data.title,
-      body.data.releaseYear,
+      work.title,
+      releaseYear,
     );
     return res(ok(JSON.stringify({ questions })));
   },

--- a/netlify/functions/club/settings.ts
+++ b/netlify/functions/club/settings.ts
@@ -20,6 +20,7 @@ const updateSettingsSchema = z.object({
     .object({
       blurScores: z.boolean(),
       awards: z.boolean(),
+      discussionQuestions: z.boolean(),
     })
     .partial()
     .optional(),

--- a/netlify/functions/repositories/SettingsRepository.ts
+++ b/netlify/functions/repositories/SettingsRepository.ts
@@ -4,6 +4,7 @@ export interface ClubSettings {
   features: {
     blurScores: boolean;
     awards: boolean;
+    discussionQuestions: boolean;
   };
 }
 
@@ -11,6 +12,7 @@ const DEFAULT_SETTINGS: ClubSettings = {
   features: {
     blurScores: true,
     awards: false,
+    discussionQuestions: false,
   },
 };
 

--- a/netlify/functions/repositories/WorkRepository.ts
+++ b/netlify/functions/repositories/WorkRepository.ts
@@ -76,6 +76,20 @@ class WorkRepository {
     return insertedWork;
   }
 
+  async getDiscussionContext(clubId: string, workId: string) {
+    return db
+      .selectFrom("work")
+      .leftJoin(
+        "movie_details",
+        "movie_details.external_id",
+        "work.external_id",
+      )
+      .where("work.id", "=", workId)
+      .where("work.club_id", "=", clubId)
+      .select(["work.title", "movie_details.release_date"])
+      .executeTakeFirst();
+  }
+
   async delete(clubId: string, workId: string) {
     return db
       .deleteFrom("work")

--- a/netlify/functions/utils/gemini.ts
+++ b/netlify/functions/utils/gemini.ts
@@ -1,0 +1,65 @@
+import axios from "axios";
+import { z } from "zod";
+
+import { hasValue } from "../../../lib/checks/checks.js";
+
+const GEMINI_MODEL = "gemini-3.1-flash-lite";
+const GEMINI_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`;
+
+const questionsSchema = z.object({
+  questions: z.array(z.string().min(1)).min(3).max(5),
+});
+
+interface GeminiResponse {
+  candidates?: {
+    content?: { parts?: { text?: string }[] };
+  }[];
+}
+
+export async function generateDiscussionQuestions(
+  title: string,
+  releaseYear?: string,
+): Promise<string[]> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!hasValue(apiKey)) {
+    throw new Error("GEMINI_API_KEY is not configured");
+  }
+
+  const filmLabel = hasValue(releaseYear) ? `${title} (${releaseYear})` : title;
+  const prompt = `Generate 3 to 5 thought-provoking discussion questions for a movie club discussing the film "${filmLabel}". The questions should encourage interpretation, debate, and personal reflection rather than plot recall. Avoid yes/no questions.`;
+
+  const response = await axios.post<GeminiResponse>(
+    `${GEMINI_ENDPOINT}?key=${apiKey}`,
+    {
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: {
+        temperature: 0.9,
+        responseMimeType: "application/json",
+        responseSchema: {
+          type: "object",
+          properties: {
+            questions: {
+              type: "array",
+              items: { type: "string" },
+              minItems: 3,
+              maxItems: 5,
+            },
+          },
+          required: ["questions"],
+        },
+      },
+    },
+  );
+
+  const rawText = response.data.candidates?.[0]?.content?.parts?.[0]?.text;
+  if (!hasValue(rawText)) {
+    throw new Error("Gemini returned no text content");
+  }
+
+  const parsed = questionsSchema.safeParse(JSON.parse(rawText));
+  if (!parsed.success) {
+    throw new Error(`Gemini returned malformed JSON: ${parsed.error.message}`);
+  }
+
+  return parsed.data.questions;
+}

--- a/netlify/functions/utils/gemini.ts
+++ b/netlify/functions/utils/gemini.ts
@@ -3,11 +3,11 @@ import { z } from "zod";
 
 import { hasValue } from "../../../lib/checks/checks.js";
 
-const GEMINI_MODEL = "gemini-3.1-flash-lite";
+const GEMINI_MODEL = "gemini-3.5-flash";
 const GEMINI_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`;
 
 const questionsSchema = z.object({
-  questions: z.array(z.string().min(1)).min(3).max(5),
+  questions: z.array(z.string().min(1)).max(5),
 });
 
 interface GeminiResponse {
@@ -28,11 +28,11 @@ export async function generateDiscussionQuestions(
   const filmLabel = hasValue(releaseYear) ? `${title} (${releaseYear})` : title;
   const prompt = `Generate 3 to 5 discussion prompts for a movie club rewatching "${filmLabel}". Every prompt must be specific to THIS film — naming its actual characters, scenes, lines, or moments — never a generic question that could apply to any movie.
 
-Match the tone to the film itself: a horror film should produce darker prompts, a comedy lighter, a drama more serious. Do not impose a single tone across every movie.
-
 Order the prompts by depth: the first should be casual and easy to answer — a low-stakes entry point. Each subsequent prompt should be more thought-provoking than the last, with the final one being substantial — a real book-club-worthy question, adapted for film.
 
-Whenever the film supports it, frame prompts as debates: questions with defensible answers on more than one side, designed to spark disagreement among friends rather than consensus. Decide the right length for each prompt yourself based on what the question needs.`;
+Whenever the film supports it, frame prompts as debates: questions with defensible answers on more than one side, designed to spark disagreement among friends rather than consensus. Keep each prompt succinct — one clear, concise question with no preamble.
+
+If you do not recognize this film or cannot confirm it is a real movie, return 0 questions.`;
 
   const response = await axios.post<GeminiResponse>(
     `${GEMINI_ENDPOINT}?key=${apiKey}`,
@@ -47,7 +47,6 @@ Whenever the film supports it, frame prompts as debates: questions with defensib
             questions: {
               type: "array",
               items: { type: "string" },
-              minItems: 3,
               maxItems: 5,
             },
           },

--- a/netlify/functions/utils/gemini.ts
+++ b/netlify/functions/utils/gemini.ts
@@ -26,9 +26,13 @@ export async function generateDiscussionQuestions(
   }
 
   const filmLabel = hasValue(releaseYear) ? `${title} (${releaseYear})` : title;
-  const prompt = `Generate 3 to 5 short, punchy discussion prompts for a movie club rewatching "${filmLabel}". Every prompt must be specific to THIS film — naming its actual characters, scenes, lines, or moments — never a generic question that could apply to any movie. Lean playful and casual; avoid academic, literary, or essay-style framing.
+  const prompt = `Generate 3 to 5 discussion prompts for a movie club rewatching "${filmLabel}". Every prompt must be specific to THIS film — naming its actual characters, scenes, lines, or moments — never a generic question that could apply to any movie.
 
-Each prompt should be a single short phrase, ideally under 8 words. The goal is to spark fun debate or disagreement among friends, not deep analysis.`;
+Match the tone to the film itself: a horror film should produce darker prompts, a comedy lighter, a drama more serious. Do not impose a single tone across every movie.
+
+Order the prompts by depth: the first should be casual and easy to answer — a low-stakes entry point. Each subsequent prompt should be more thought-provoking than the last, with the final one being substantial — a real book-club-worthy question, adapted for film.
+
+Whenever the film supports it, frame prompts as debates: questions with defensible answers on more than one side, designed to spark disagreement among friends rather than consensus. Decide the right length for each prompt yourself based on what the question needs.`;
 
   const response = await axios.post<GeminiResponse>(
     `${GEMINI_ENDPOINT}?key=${apiKey}`,

--- a/netlify/functions/utils/gemini.ts
+++ b/netlify/functions/utils/gemini.ts
@@ -26,7 +26,9 @@ export async function generateDiscussionQuestions(
   }
 
   const filmLabel = hasValue(releaseYear) ? `${title} (${releaseYear})` : title;
-  const prompt = `Generate 3 to 5 thought-provoking discussion questions for a movie club discussing the film "${filmLabel}". The questions should encourage interpretation, debate, and personal reflection rather than plot recall. Avoid yes/no questions.`;
+  const prompt = `Generate 3 to 5 short, punchy discussion prompts for a movie club rewatching "${filmLabel}". Every prompt must be specific to THIS film — naming its actual characters, scenes, lines, or moments — never a generic question that could apply to any movie. Lean playful and casual; avoid academic, literary, or essay-style framing.
+
+Each prompt should be a single short phrase, ideally under 8 words. The goal is to spark fun debate or disagreement among friends, not deep analysis.`;
 
   const response = await axios.post<GeminiResponse>(
     `${GEMINI_ENDPOINT}?key=${apiKey}`,

--- a/src/features/reviews/components/DiscussionQuestions.vue
+++ b/src/features/reviews/components/DiscussionQuestions.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="mt-6">
+    <Transition name="fade" mode="out-in">
+      <div
+        v-if="hasQuestions"
+        key="loaded"
+        class="rounded-xl bg-lowBackground p-4"
+      >
+        <div class="mb-3 flex items-center gap-2 text-sm text-gray-300">
+          <mdicon name="creation" size="18" class="text-purple-300" />
+          <span class="font-semibold">Discussion questions</span>
+        </div>
+        <ol class="flex flex-col gap-2">
+          <li
+            v-for="(question, index) in questions"
+            :key="index"
+            class="flex gap-3 rounded-lg bg-background/60 p-3 text-sm leading-relaxed"
+          >
+            <span class="font-bold text-purple-300">{{ index + 1 }}.</span>
+            <span>{{ question }}</span>
+          </li>
+        </ol>
+        <div class="mt-3 flex justify-end">
+          <button
+            class="text-xs text-gray-400 underline-offset-2 hover:text-gray-200 hover:underline"
+            :disabled="isLoading"
+            @click="regenerate"
+          >
+            Regenerate
+          </button>
+        </div>
+      </div>
+
+      <div v-else-if="isError" key="error" class="flex flex-col gap-2">
+        <p class="text-sm text-red-400">
+          Couldn't generate questions. Please try again.
+        </p>
+        <button
+          class="ai-shimmer-button flex items-center justify-center gap-2 rounded-lg py-3 text-sm font-semibold text-white"
+          :class="{ loading: isLoading }"
+          @click="regenerate"
+        >
+          <mdicon name="creation" />
+          <span>Try again</span>
+        </button>
+      </div>
+
+      <button
+        v-else
+        key="idle"
+        class="ai-shimmer-button flex w-full items-center justify-center gap-2 rounded-lg py-3 text-sm font-semibold text-white"
+        :class="{ loading: isLoading }"
+        :disabled="isLoading"
+        @click="regenerate"
+      >
+        <mdicon name="creation" />
+        <span>{{
+          isLoading ? "Generating questions…" : "Generate discussion questions"
+        }}</span>
+      </button>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { useDiscussionQuestions } from "@/service/useDiscussionQuestions";
+
+const props = defineProps<{
+  clubSlug: string;
+  workId: string;
+  title: string;
+  releaseYear?: string;
+}>();
+
+const { data, isFetching, isError, refetch } = useDiscussionQuestions(
+  props.clubSlug,
+  props.workId,
+  props.title,
+  props.releaseYear,
+);
+
+const questions = computed(() => data.value ?? []);
+const hasQuestions = computed(() => questions.value.length > 0);
+const isLoading = computed(() => isFetching.value);
+
+const regenerate = () => {
+  void refetch();
+};
+</script>
+
+<style scoped>
+@property --ai-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+.ai-shimmer-button {
+  position: relative;
+  background: #222831; /* theme background */
+  z-index: 0;
+  isolation: isolate;
+  transition: filter 0.2s ease;
+}
+
+.ai-shimmer-button::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  z-index: -1;
+  border-radius: inherit;
+  padding: 2px;
+  background: conic-gradient(
+    from var(--ai-angle),
+    #ff4ecd,
+    #6e7bff,
+    #4ecdff,
+    #b14eff,
+    #ff4ecd
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  animation: ai-spin 4s linear infinite;
+}
+
+.ai-shimmer-button.loading::before {
+  animation-duration: 1.4s;
+}
+
+.ai-shimmer-button:hover:not(:disabled) {
+  filter: brightness(1.15);
+}
+
+.ai-shimmer-button:disabled {
+  cursor: not-allowed;
+}
+
+@keyframes ai-spin {
+  to {
+    --ai-angle: 360deg;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ai-shimmer-button::before {
+    animation: none;
+  }
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/features/reviews/components/DiscussionQuestions.vue
+++ b/src/features/reviews/components/DiscussionQuestions.vue
@@ -43,6 +43,24 @@
         </div>
       </div>
 
+      <div
+        v-else-if="isUnrecognized"
+        key="unrecognized"
+        class="flex flex-col gap-2"
+      >
+        <p class="text-sm text-red-400">
+          We couldn't recognize "{{ title }}", so we couldn't generate
+          discussion questions for it.
+        </p>
+        <button
+          class="ai-shimmer-button flex items-center justify-center gap-2 rounded-lg py-3 text-sm font-semibold text-white"
+          disabled
+        >
+          <mdicon name="creation" />
+          <span>Generate discussion questions</span>
+        </button>
+      </div>
+
       <div v-else-if="isError" key="error" class="flex flex-col gap-2">
         <p class="text-sm text-red-400">
           Couldn't generate questions. Please try again.
@@ -95,6 +113,12 @@ const { data, isFetching, isError, refetch } = useDiscussionQuestions(
 
 const questions = computed(() => data.value ?? []);
 const hasQuestions = computed(() => questions.value.length > 0);
+// A defined-but-empty result means the request succeeded but the model didn't
+// recognize the film (the query is disabled until refetch, so `data` is
+// undefined until a fetch completes).
+const isUnrecognized = computed(
+  () => data.value !== undefined && questions.value.length === 0,
+);
 const isLoading = computed(() => isFetching.value);
 
 const regenerate = () => {

--- a/src/features/reviews/components/DiscussionQuestions.vue
+++ b/src/features/reviews/components/DiscussionQuestions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mt-6">
+  <div class="mt-6 w-full text-left">
     <Transition name="fade" mode="out-in">
       <div
         v-if="hasQuestions"

--- a/src/features/reviews/components/DiscussionQuestions.vue
+++ b/src/features/reviews/components/DiscussionQuestions.vue
@@ -49,8 +49,8 @@
         class="flex flex-col gap-2"
       >
         <p class="text-sm text-red-400">
-          We couldn't recognize "{{ title }}", so we couldn't generate
-          discussion questions for it.
+          We couldn't recognize this movie, so we couldn't generate discussion
+          questions for it.
         </p>
         <button
           class="ai-shimmer-button flex items-center justify-center gap-2 rounded-lg py-3 text-sm font-semibold text-white"
@@ -100,15 +100,11 @@ import { useDiscussionQuestions } from "@/service/useDiscussionQuestions";
 const props = defineProps<{
   clubSlug: string;
   workId: string;
-  title: string;
-  releaseYear?: string;
 }>();
 
 const { data, isFetching, isError, refetch } = useDiscussionQuestions(
   props.clubSlug,
   props.workId,
-  props.title,
-  props.releaseYear,
 );
 
 const questions = computed(() => data.value ?? []);

--- a/src/features/reviews/components/DiscussionQuestions.vue
+++ b/src/features/reviews/components/DiscussionQuestions.vue
@@ -10,7 +10,10 @@
           <mdicon name="creation" size="18" class="text-purple-300" />
           <span class="font-semibold">Discussion questions</span>
         </div>
-        <ol class="flex flex-col gap-2">
+        <ol
+          class="flex flex-col gap-2 transition-opacity"
+          :class="{ 'opacity-50': isLoading }"
+        >
           <li
             v-for="(question, index) in questions"
             :key="index"
@@ -20,13 +23,22 @@
             <span>{{ question }}</span>
           </li>
         </ol>
+        <p v-if="isError" class="mt-3 text-xs text-red-400">
+          Couldn't regenerate. Showing the previous questions.
+        </p>
         <div class="mt-3 flex justify-end">
           <button
-            class="text-xs text-gray-400 underline-offset-2 hover:text-gray-200 hover:underline"
+            class="flex items-center gap-1.5 text-xs text-gray-400 underline-offset-2 hover:text-gray-200 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
             :disabled="isLoading"
             @click="regenerate"
           >
-            Regenerate
+            <mdicon
+              v-if="isLoading"
+              name="loading"
+              size="14"
+              class="animate-spin"
+            />
+            <span>{{ isLoading ? "Regenerating…" : "Regenerate" }}</span>
           </button>
         </div>
       </div>

--- a/src/features/reviews/components/MovieDetailsContent.vue
+++ b/src/features/reviews/components/MovieDetailsContent.vue
@@ -143,6 +143,14 @@
 
       <ReviewChat :work-id="movie.original.id" :club-slug="clubId" />
 
+      <DiscussionQuestions
+        v-if="discussionQuestionsEnabled"
+        :club-slug="clubId"
+        :work-id="movie.original.id"
+        :title="movieTitle"
+        :release-year="movieReleaseYear"
+      />
+
       <div
         class="sticky bottom-0 -mx-4 mt-6 border-t border-gray-700/60 bg-background px-4 pb-2 pt-3"
       >
@@ -310,6 +318,14 @@
 
       <ReviewChat :work-id="movie.original.id" :club-slug="clubId" />
 
+      <DiscussionQuestions
+        v-if="discussionQuestionsEnabled"
+        :club-slug="clubId"
+        :work-id="movie.original.id"
+        :title="movieTitle"
+        :release-year="movieReleaseYear"
+      />
+
       <!-- Sticky action footer -->
       <div
         class="sticky bottom-0 -mx-4 mt-6 border-t border-gray-700/60 bg-background px-4 pb-2 pt-3"
@@ -341,6 +357,7 @@ import { FlexRender, Row, Table } from "@tanstack/vue-table";
 import { DateTime } from "luxon";
 import { computed, ref } from "vue";
 
+import DiscussionQuestions from "./DiscussionQuestions.vue";
 import ReviewChat from "./ReviewChat.vue";
 import { hasValue, isDefined } from "../../../../lib/checks/checks.js";
 import { DetailedReviewListItem } from "../../../../lib/types/lists";
@@ -351,7 +368,7 @@ import MovieDescription from "@/common/components/MovieDescription.vue";
 import MovieMetadataGrid from "@/common/components/MovieMetadataGrid.vue";
 import MoviePosterHero from "@/common/components/MoviePosterHero.vue";
 import { useShare } from "@/common/composables/useShare";
-import { useClub, useClubSlug } from "@/service/useClub";
+import { useClub, useClubSettings, useClubSlug } from "@/service/useClub";
 import { useReviewsListId, useUpdateAddedDate } from "@/service/useList";
 
 const props = defineProps<{
@@ -383,10 +400,20 @@ const confirmDelete = () => {
 // Date editing state
 const clubId = useClubSlug();
 const { data: club } = useClub(clubId);
+const { data: clubSettings } = useClubSettings(clubId);
 const { data: reviewsListId } = useReviewsListId(clubId);
 const { mutate: updateAddedDate } = useUpdateAddedDate(clubId);
 const isEditingDate = ref(false);
 const editedDate = ref("");
+
+const discussionQuestionsEnabled = computed(
+  () => clubSettings.value?.features?.discussionQuestions === true,
+);
+const movieTitle = computed(() => String(props.movie.renderValue("title")));
+const movieReleaseYear = computed(() => {
+  const releaseDate = props.movie.original.externalData?.release_date;
+  return hasValue(releaseDate) ? releaseDate.slice(0, 4) : undefined;
+});
 
 const formattedDateForInput = computed(() => {
   return DateTime.fromISO(props.movie.original.createdDate).toFormat(
@@ -419,8 +446,6 @@ const saveDateChange = () => {
 const cancelDateEdit = () => {
   isEditingDate.value = false;
 };
-
-const movieTitle = computed(() => String(props.movie.renderValue("title")));
 
 const releaseYear = computed(() => {
   const releaseDate = props.movie.original.externalData?.release_date;

--- a/src/features/reviews/components/MovieDetailsContent.vue
+++ b/src/features/reviews/components/MovieDetailsContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex-grow">
+  <div class="flex-grow text-left">
     <delete-confirmation-modal
       :show="showDeleteConfirmation"
       @confirm="confirmDelete"

--- a/src/features/reviews/components/MovieDetailsContent.vue
+++ b/src/features/reviews/components/MovieDetailsContent.vue
@@ -147,8 +147,6 @@
         v-if="discussionQuestionsEnabled"
         :club-slug="clubId"
         :work-id="movie.original.id"
-        :title="movieTitle"
-        :release-year="movieReleaseYear"
       />
 
       <div
@@ -322,8 +320,6 @@
         v-if="discussionQuestionsEnabled"
         :club-slug="clubId"
         :work-id="movie.original.id"
-        :title="movieTitle"
-        :release-year="movieReleaseYear"
       />
 
       <!-- Sticky action footer -->
@@ -410,10 +406,6 @@ const discussionQuestionsEnabled = computed(
   () => clubSettings.value?.features?.discussionQuestions === true,
 );
 const movieTitle = computed(() => String(props.movie.renderValue("title")));
-const movieReleaseYear = computed(() => {
-  const releaseDate = props.movie.original.externalData?.release_date;
-  return hasValue(releaseDate) ? releaseDate.slice(0, 4) : undefined;
-});
 
 const formattedDateForInput = computed(() => {
   return DateTime.fromISO(props.movie.original.createdDate).toFormat(

--- a/src/features/reviews/components/MovieDetailsDrawer.vue
+++ b/src/features/reviews/components/MovieDetailsDrawer.vue
@@ -3,6 +3,7 @@
     <!-- Mobile Bottom Sheet -->
     <v-bottom-sheet v-if="!isDesktop" transparent-handle @close="close">
       <MovieDetailsContent
+        :key="movie.id"
         :movie="movie"
         :review-table="reviewTable"
         :delete-review="deleteReview"
@@ -19,6 +20,7 @@
     <!-- Desktop Drawer (side panel) -->
     <VSideDrawer v-if="isDesktop" @close="close">
       <MovieDetailsContent
+        :key="movie.id"
         :movie="movie"
         :review-table="reviewTable"
         :delete-review="deleteReview"

--- a/src/features/settings/views/ClubSettingsView.vue
+++ b/src/features/settings/views/ClubSettingsView.vue
@@ -71,6 +71,24 @@
               @update:model-value="updateAwardsFeature"
             />
           </div>
+          <div class="mt-3 flex items-center justify-between gap-4">
+            <div class="flex-1">
+              <h4 class="font-medium">AI Discussion Questions</h4>
+              <p class="mt-1 text-sm text-gray-400">
+                Add an AI-powered button to each review that generates
+                discussion questions to spark conversation
+              </p>
+              <p class="mt-1 text-sm text-yellow-500">
+                This feature is experimental and may change in the future.
+              </p>
+            </div>
+            <v-switch
+              :model-value="discussionQuestionsEnabled"
+              color="primary"
+              class="ml-5 flex-shrink-0"
+              @update:model-value="updateDiscussionQuestionsFeature"
+            />
+          </div>
         </div>
       </div>
 
@@ -339,6 +357,9 @@ const blurScoresEnabled = computed(
   () => settings.value?.features?.blurScores === true,
 );
 const awardsEnabled = computed(() => settings.value?.features?.awards === true);
+const discussionQuestionsEnabled = computed(
+  () => settings.value?.features?.discussionQuestions === true,
+);
 
 const saveClubName = () => {
   if (!hasNameChanged.value) return;
@@ -428,6 +449,16 @@ const updateAwardsFeature = (value: boolean) => {
 const updateBlurScoresFeature = (value: boolean) => {
   updateSettings(
     { features: { blurScores: value } },
+    {
+      onSuccess: () => toast.success("Settings updated successfully"),
+      onError: () => toast.error("Failed to update settings"),
+    },
+  );
+};
+
+const updateDiscussionQuestionsFeature = (value: boolean) => {
+  updateSettings(
+    { features: { discussionQuestions: value } },
     {
       onSuccess: () => toast.success("Settings updated successfully"),
       onError: () => toast.error("Failed to update settings"),

--- a/src/features/watch-list/components/ListItemDetailsContent.vue
+++ b/src/features/watch-list/components/ListItemDetailsContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex-grow">
+  <div class="flex-grow text-left">
     <delete-confirmation-modal
       :show="showDeleteConfirmation"
       @confirm="confirmDelete"

--- a/src/service/useClub.ts
+++ b/src/service/useClub.ts
@@ -172,6 +172,7 @@ interface ClubSettings {
   features: {
     blurScores: boolean;
     awards: boolean;
+    discussionQuestions: boolean;
   };
 }
 

--- a/src/service/useDiscussionQuestions.ts
+++ b/src/service/useDiscussionQuestions.ts
@@ -6,19 +6,13 @@ interface DiscussionQuestionsResponse {
   questions: string[];
 }
 
-export function useDiscussionQuestions(
-  clubSlug: string,
-  workId: string,
-  title: string,
-  releaseYear?: string,
-) {
+export function useDiscussionQuestions(clubSlug: string, workId: string) {
   const auth = useAuthStore();
   return useQuery<string[]>({
-    queryKey: ["discussion-questions", clubSlug, workId, title, releaseYear],
+    queryKey: ["discussion-questions", clubSlug, workId],
     queryFn: async () => {
       const response = await auth.request.post<DiscussionQuestionsResponse>(
         `/api/club/${clubSlug}/reviews/${workId}/discussion-questions`,
-        { title, releaseYear },
       );
       return response.data.questions;
     },

--- a/src/service/useDiscussionQuestions.ts
+++ b/src/service/useDiscussionQuestions.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/vue-query";
+
+import { useAuthStore } from "@/stores/auth";
+
+interface DiscussionQuestionsResponse {
+  questions: string[];
+}
+
+export function useDiscussionQuestions(
+  clubSlug: string,
+  workId: string,
+  title: string,
+  releaseYear?: string,
+) {
+  const auth = useAuthStore();
+  return useQuery<string[]>({
+    queryKey: ["discussion-questions", clubSlug, workId, title, releaseYear],
+    queryFn: async () => {
+      const response = await auth.request.post<DiscussionQuestionsResponse>(
+        `/api/club/${clubSlug}/reviews/${workId}/discussion-questions`,
+        { title, releaseYear },
+      );
+      return response.data.questions;
+    },
+    enabled: false,
+    staleTime: Infinity,
+    cacheTime: 1000 * 60 * 60 * 24 * 7,
+    retry: false,
+  });
+}


### PR DESCRIPTION
## Summary

- New per-club experimental feature flag (`features.discussionQuestions`, off by default) adds a shimmering "Generate discussion questions" button to the movie review drawer that calls Gemini (`gemini-3.1-flash-lite`) and renders 3–5 thought-provoking questions to spark club conversation.
- Backend proxies the call so `GEMINI_API_KEY` stays server-side; the endpoint re-checks the feature flag and rejects with `400 "Feature not enabled"` if the UI is bypassed.
- Caching is client-side only via TanStack Query's existing `createSyncStoragePersister` (1-week `maxAge` already configured in `src/main.ts`). Reopening the drawer — or hard-refreshing — hits the cache, not the API.

## Implementation notes

- **No DB migration needed.** `club_settings.value` is already JSONB and `SettingsRepository.getSettings` spread-merges over `DEFAULT_SETTINGS.features`, so existing clubs gracefully pick up the new key as `false`.
- **AI shimmer border** uses a `conic-gradient` driven by an animated `@property --ai-angle` for a smooth rotation with no jank, plus a `prefers-reduced-motion` fallback that freezes the gradient.
- **Drawer keying fix:** added `:key="movie.id"` to `MovieDetailsContent` invocations in `MovieDetailsDrawer.vue`. The composable captures props at setup time, so without keying the cached questions would persist across review switches. Aligns with the existing `.claude/rules/code-quality.md` "Prefer Keyed Components" guidance.
- **Server-side enforcement** of the flag runs before request-body parsing — a disabled flag short-circuits cheaply.
- Trusts the client to send the movie title/year in the request body rather than re-querying `movie_details` server-side. Bounded by membership + flag; worst case is questions for the wrong movie, no leakage risk.

## Local setup gotcha

`GEMINI_API_KEY` is a Netlify-console secret and is **not** synced to local `.env`. To exercise the feature locally, devs must generate their own key at https://aistudio.google.com/apikey and add `GEMINI_API_KEY=<key>` to `.env`. This is now documented in `CLAUDE.md`.

## Known limitations

- `workId` in the URL isn't validated against an actual review record server-side. Bounded by club membership and the feature flag; acceptable for an experimental feature, worth a follow-up if it goes GA.
- Gemini model is pinned to `gemini-3.1-flash-lite` via a single constant in `netlify/functions/utils/gemini.ts`; swap as needed if Google deprecates or releases newer.

## Test plan

- [ ] Add `GEMINI_API_KEY=<your key>` to local `.env`, run `netlify dev`
- [ ] Open Club Settings → toggle "AI Discussion Questions (experimental)" on → confirm the POST to `/api/club/<slug>/settings` carries `features.discussionQuestions: true` and survives reload
- [ ] Open a movie review drawer → confirm the shimmering "Generate discussion questions" button appears below the chat and above Delete/Share
- [ ] Click the button → confirm 3–5 numbered questions appear with the expansion transition
- [ ] Close the drawer + reopen the same review → questions appear instantly with **no** network call (TanStack persistence)
- [ ] Hard-refresh the page → questions still appear instantly on reopen (localStorage rehydration)
- [ ] Open review A, generate, close → open review B → confirm B starts in idle state (validates the `:key="movie.id"` fix)
- [ ] Toggle the feature off → button disappears; manually `curl` the endpoint → returns `400 "Feature not enabled"`
- [ ] Test on a movie with an unusual title (apostrophes, non-ASCII) to confirm prompt & JSON parsing are robust
- [ ] (Optional) Enable "Reduce motion" in macOS Accessibility → confirm shimmer freezes

🤖 Generated with [Claude Code](https://claude.com/claude-code)