### PR TITLE
Add comments to watch-list movie details

### DIFF
--- a/src/common/components/CommentThread.vue
+++ b/src/common/components/CommentThread.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mt-6">
-    <h3 class="mb-3 text-sm font-medium text-gray-400">Reviews</h3>
+    <h3 class="mb-3 text-sm font-medium text-gray-400">Comments</h3>
 
     <delete-confirmation-modal
       :show="showDeleteConfirmation"
@@ -123,14 +123,14 @@
     </div>
 
     <p v-else class="mb-4 text-sm text-gray-500">
-      No written reviews yet. Be the first to share your thoughts!
+      No comments yet. Be the first to share your thoughts!
     </p>
 
     <div>
       <textarea
         v-model="newComment"
         :maxlength="MAX_LENGTH"
-        placeholder="Write your review…"
+        placeholder="Write a comment…"
         class="w-full resize-none rounded-lg border border-gray-600 bg-lowBackground px-3 py-2 text-left text-sm text-white placeholder-gray-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
         rows="3"
       />
@@ -172,8 +172,8 @@
 import { DateTime } from "luxon";
 import { nextTick, reactive, ref } from "vue";
 
-import { hasElements, hasValue } from "../../../../lib/checks/checks.js";
-import { WorkCommentDto } from "../../../../lib/types/lists";
+import { hasElements, hasValue } from "../../../lib/checks/checks.js";
+import { WorkCommentDto } from "../../../lib/types/lists";
 
 import DeleteConfirmationModal from "@/common/components/DeleteConfirmationModal.vue";
 import {

--- a/src/features/reviews/components/MovieDetailsContent.vue
+++ b/src/features/reviews/components/MovieDetailsContent.vue
@@ -145,7 +145,7 @@
         />
       </div>
 
-      <ReviewChat :work-id="movie.original.id" :club-slug="clubId" />
+      <CommentThread :work-id="movie.original.id" :club-slug="clubId" />
 
       <DiscussionQuestions
         v-if="discussionQuestionsEnabled"
@@ -319,7 +319,7 @@
         </DisclosurePanel>
       </Disclosure>
 
-      <ReviewChat :work-id="movie.original.id" :club-slug="clubId" />
+      <CommentThread :work-id="movie.original.id" :club-slug="clubId" />
 
       <DiscussionQuestions
         v-if="discussionQuestionsEnabled"
@@ -359,10 +359,10 @@ import { DateTime } from "luxon";
 import { computed, ref } from "vue";
 
 import DiscussionQuestions from "./DiscussionQuestions.vue";
-import ReviewChat from "./ReviewChat.vue";
 import { hasValue, isDefined } from "../../../../lib/checks/checks.js";
 import { DetailedReviewListItem } from "../../../../lib/types/lists";
 
+import CommentThread from "@/common/components/CommentThread.vue";
 import DeleteConfirmationModal from "@/common/components/DeleteConfirmationModal.vue";
 import ExternalLink from "@/common/components/ExternalLink.vue";
 import MovieDescription from "@/common/components/MovieDescription.vue";

--- a/src/features/watch-list/components/ListItemDetailsContent.vue
+++ b/src/features/watch-list/components/ListItemDetailsContent.vue
@@ -34,6 +34,8 @@
       />
     </div>
 
+    <CommentThread :work-id="movie.id" :club-slug="clubSlug" />
+
     <!-- Sticky action footer -->
     <div
       class="sticky bottom-0 -mx-4 mt-6 space-y-2 border-t border-gray-700/60 bg-background px-4 pb-2 pt-3"
@@ -108,6 +110,7 @@ import { computed, nextTick, ref } from "vue";
 import { hasValue } from "../../../../lib/checks/checks.js";
 import { DetailedWorkListItem } from "../../../../lib/types/lists";
 
+import CommentThread from "@/common/components/CommentThread.vue";
 import DeleteConfirmationModal from "@/common/components/DeleteConfirmationModal.vue";
 import MovieDescription from "@/common/components/MovieDescription.vue";
 import MovieMetadataGrid from "@/common/components/MovieMetadataGrid.vue";
@@ -116,6 +119,7 @@ import WatchProviders from "@/common/components/WatchProviders.vue";
 
 const props = defineProps<{
   movie: DetailedWorkListItem;
+  clubSlug: string;
   isNextWork: boolean;
   isDesktop: boolean;
   canReview: boolean;

--- a/src/features/watch-list/components/ListItemDetailsDrawer.vue
+++ b/src/features/watch-list/components/ListItemDetailsDrawer.vue
@@ -4,6 +4,7 @@
     <v-bottom-sheet v-if="!isDesktop" transparent-handle @close="close">
       <ListItemDetailsContent
         :movie="movie"
+        :club-slug="clubSlug"
         :is-next-work="isNextWork"
         :is-desktop="isDesktop"
         :can-review="canReview"
@@ -21,6 +22,7 @@
     <VSideDrawer v-if="isDesktop" @close="close">
       <ListItemDetailsContent
         :movie="movie"
+        :club-slug="clubSlug"
         :is-next-work="isNextWork"
         :is-desktop="isDesktop"
         :can-review="canReview"
@@ -46,6 +48,7 @@ import { useIsDesktop } from "@/common/composables/useIsDesktop.js";
 
 defineProps<{
   movie: DetailedWorkListItem;
+  clubSlug: string;
   isNextWork: boolean;
   canReview: boolean;
   otherLists: { id: string; title: string }[];

--- a/src/features/watch-list/components/ListItems.vue
+++ b/src/features/watch-list/components/ListItems.vue
@@ -87,6 +87,7 @@
       <ListItemDetailsDrawer
         v-if="isDefined(selectedItem)"
         :movie="selectedItem"
+        :club-slug="props.clubSlug"
         :is-next-work="selectedItem.id === nextWorkId"
         :can-review="canReview && listId !== reviewsListId"
         :other-lists="otherLists"


### PR DESCRIPTION
Surface the existing work-comment thread on watch-list movie details so
members can write comments before a movie is watched. Comments are keyed
by work + club (not by list), so they automatically carry over when the
movie is later reviewed.

Generalize ReviewChat into a shared CommentThread component, relabel the
thread as "Comments" in both the watch list and the reviews page, and
thread clubSlug through the watch-list detail drawer.

https://claude.ai/code/session_01BJREqgBQ1HGSgfBdGFNvAr