### PR TITLE
Native-like mobile bottom sheets (CSS scroll-snap + detents)

### DIFF
--- a/src/common/components/VBackdrop.vue
+++ b/src/common/components/VBackdrop.vue
@@ -1,8 +1,9 @@
 <template>
   <Transition name="fade" appear>
     <div
-      class="fixed inset-0 touch-none overscroll-none bg-black bg-opacity-50"
-      :class="zIndexClass"
+      class="fixed inset-0 touch-none overscroll-none bg-black"
+      :class="[zIndexClass, { 'bg-opacity-50': !isControlled }]"
+      :style="controlledStyle"
       @click="handleClose"
       @touchmove.prevent
       @wheel.prevent
@@ -11,12 +12,21 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
+
 const props = withDefaults(
   defineProps<{
     zIndex?: "40" | "50" | "60";
+    /**
+     * When provided (0–1), the scrim opacity is driven by the parent — used by
+     * the bottom sheet to fade the backdrop continuously with the drag
+     * position. When omitted, the default static 50% scrim is used.
+     */
+    opacity?: number;
   }>(),
   {
     zIndex: "50",
+    opacity: undefined,
   },
 );
 
@@ -26,6 +36,14 @@ const emit = defineEmits<{
 
 const zIndexClass =
   props.zIndex === "40" ? "z-40" : props.zIndex === "60" ? "z-[60]" : "z-50";
+
+const isControlled = computed(() => props.opacity !== undefined);
+
+const controlledStyle = computed(() =>
+  props.opacity !== undefined
+    ? { backgroundColor: `rgba(0, 0, 0, ${props.opacity})` }
+    : undefined,
+);
 
 const handleClose = () => {
   emit("close");

--- a/src/common/components/VBottomSheet.vue
+++ b/src/common/components/VBottomSheet.vue
@@ -1,44 +1,85 @@
 <template>
-  <div>
-    <v-backdrop :z-index="backdropZIndex" @close="handleClose" />
+  <Teleport to="body">
+    <v-backdrop
+      :z-index="backdropZIndex"
+      :opacity="backdropOpacity"
+      @close="requestClose"
+    />
 
-    <Transition name="slide-up" appear @after-leave="onTransitionEnd">
+    <div
+      ref="hostRef"
+      class="sheet-host fixed inset-0 overflow-y-scroll overscroll-contain"
+      :class="[
+        contentZIndexClass,
+        snapEnabled ? 'snap-y snap-mandatory' : 'snap-none',
+      ]"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="ariaLabel"
+      tabindex="-1"
+    >
+      <!--
+        Transparent runway above the panel. It is the scrim region (the backdrop
+        shows through it), it dismisses on tap, and it hosts the zero-height snap
+        markers whose offsets define the rest positions:
+          top: 0        -> dismissed (panel below the fold)
+          top: halfTop  -> half revealed
+          top: fullTop  -> fully revealed
+      -->
+      <div class="relative h-full w-full" @click="requestClose">
+        <div class="absolute inset-x-0 top-0 h-0 snap-start"></div>
+        <div
+          v-if="hasHalfDetent"
+          class="absolute inset-x-0 h-0 snap-start"
+          :style="{ top: `${halfTop}px` }"
+        ></div>
+        <div
+          class="absolute inset-x-0 h-0 snap-start"
+          :style="{ top: `${fullTop}px` }"
+        ></div>
+      </div>
+
+      <!-- The visible sheet panel. -->
       <div
-        v-if="isVisible"
-        ref="sheetRef"
-        class="fixed inset-x-0 bottom-0 max-h-[90vh] w-full overflow-y-auto rounded-t-2xl bg-background"
-        :class="[
-          contentZIndexClass,
-          {
-            'transition-transform duration-200 ease-in-out': !isDragging,
-          },
-        ]"
-        :style="sheetStyle"
-        @click.stop=""
+        class="relative flex max-h-[90%] w-full flex-col rounded-t-2xl bg-background"
       >
         <div
-          class="sticky top-0 z-10 flex h-8 w-full cursor-pointer items-center justify-center"
+          class="flex h-8 w-full shrink-0 cursor-grab items-center justify-center"
           :class="{ 'bg-background': !transparentHandle }"
-          @touchstart="handleTouchStart"
-          @touchmove="handleTouchMove"
-          @touchend="handleTouchEnd"
         >
           <div class="h-1.5 w-12 rounded-full bg-gray-400"></div>
         </div>
 
-        <div :class="contentClass">
+        <!--
+          expand-to-scroll: content only scrolls at the full detent, so a
+          swipe-up at the half detent unambiguously expands the sheet rather than
+          scrolling content (and mandatory snap never fights a mid-content rest).
+        -->
+        <div
+          class="min-h-0 flex-1"
+          :class="[
+            contentClass,
+            atFull ? 'overflow-y-auto' : 'overflow-hidden',
+          ]"
+        >
           <slot />
         </div>
       </div>
-    </Transition>
-  </div>
+    </div>
+  </Teleport>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 
 import VBackdrop from "./VBackdrop.vue";
 import { useBodyScrollLock } from "../composables/useBodyScrollLock.js";
+import {
+  useBottomSheetSnap,
+  type Detent,
+  type SnapState,
+} from "../composables/useBottomSheetSnap.js";
+import { useFocusTrap } from "../composables/useFocusTrap.js";
 
 type ZIndex = "40" | "50" | "60";
 
@@ -47,126 +88,83 @@ const props = withDefaults(
     contentClass?: string;
     zIndex?: ZIndex;
     transparentHandle?: boolean;
+    /** Enabled rest positions. Defaults to a single open ("full") state. */
+    detents?: Detent[];
+    /** Which detent to open at. */
+    initialDetent?: Detent;
+    /** Accessible name for the dialog. */
+    ariaLabel?: string;
   }>(),
   {
     contentClass: "px-4 pb-8",
     zIndex: "50",
     transparentHandle: false,
+    detents: () => ["full"],
+    initialDetent: "full",
+    ariaLabel: undefined,
   },
 );
 
 const emit = defineEmits<{
   (e: "close"): void;
+  (e: "snap-change", state: SnapState): void;
 }>();
 
-const backdropZIndex = computed(() => {
-  // Backdrop should be one level lower than content
-  return props.zIndex === "60" ? "50" : props.zIndex === "50" ? "40" : "40";
-});
+const backdropZIndex = computed<ZIndex>(() =>
+  props.zIndex === "60" ? "50" : "40",
+);
 
 const contentZIndexClass = computed(() =>
   props.zIndex === "40" ? "z-40" : props.zIndex === "60" ? "z-[60]" : "z-50",
 );
 
-const isVisible = ref(true);
-const onTransitionEnd = () => {
-  emit("close");
-};
+const hasHalfDetent = computed(() => props.detents.includes("half"));
 
-useBodyScrollLock(isVisible);
+const hostRef = ref<HTMLElement | null>(null);
 
-const handleClose = (immediate = false) => {
-  if (immediate) {
-    emit("close");
-  } else {
-    isVisible.value = false;
-  }
-};
+// Stays true for the component's lifetime; the parent's v-if mounts/unmounts us,
+// so locking on mount and releasing on unmount is exactly the desired behavior.
+const isActive = ref(true);
+useBodyScrollLock(isActive);
+useFocusTrap(hostRef, isActive);
 
-const touchStartY = ref<number | null>(null);
-const touchStartTime = ref<number | null>(null);
-const dragOffset = ref(0);
-const isDragging = ref(false);
-
-const handleTouchStart = (event: TouchEvent) => {
-  event.preventDefault();
-  event.stopPropagation();
-
-  if (event.touches.length === 1) {
-    touchStartY.value = event.touches[0].clientY;
-    touchStartTime.value = Date.now();
-    isDragging.value = true;
-    dragOffset.value = 0;
-  }
-};
-
-const handleTouchMove = (event: TouchEvent) => {
-  event.preventDefault();
-  event.stopPropagation();
-
-  if (touchStartY.value !== null && event.touches.length === 1) {
-    const currentY = event.touches[0].clientY;
-    const deltaY = currentY - touchStartY.value;
-    if (deltaY > 0) {
-      dragOffset.value = deltaY * 0.8;
-    } else {
-      dragOffset.value = 0;
-    }
-  }
-};
-
-const handleTouchEnd = (event: TouchEvent) => {
-  event.preventDefault();
-  event.stopPropagation();
-
-  if (
-    touchStartY.value !== null &&
-    touchStartTime.value !== null &&
-    event.changedTouches.length === 1
-  ) {
-    const touchEndY = event.changedTouches[0].clientY;
-    const touchEndTime = Date.now();
-    const deltaY = touchEndY - touchStartY.value;
-    const deltaTime = touchEndTime - touchStartTime.value;
-    const velocity = deltaY / deltaTime;
-
-    const shouldClose = deltaY > 100 || (deltaY > 50 && velocity > 0.3);
-
-    if (shouldClose) {
-      handleClose(true);
-    } else {
-      dragOffset.value = 0;
-    }
-  }
-
-  isDragging.value = false;
-  touchStartY.value = null;
-  touchStartTime.value = null;
-};
-
-const sheetStyle = computed(() => {
-  if (isDragging.value || dragOffset.value > 0) {
-    return {
-      transform: `translateY(${Math.max(0, dragOffset.value)}px)`,
-    };
-  }
-  return {};
+const {
+  snapEnabled,
+  backdropOpacity,
+  atFull,
+  halfTop,
+  fullTop,
+  open,
+  requestClose,
+} = useBottomSheetSnap({
+  host: hostRef,
+  detents: () => props.detents,
+  initialDetent: () => props.initialDetent,
+  onClose: () => emit("close"),
+  onSnapChange: (state) => emit("snap-change", state),
 });
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (event.key === "Escape") requestClose();
+};
+
+onMounted(() => {
+  open();
+  document.addEventListener("keydown", onKeydown);
+});
+
+onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 </script>
 
 <style scoped>
-.slide-up-enter-active,
-.slide-up-leave-active {
-  transition: transform 200ms ease-in-out;
+/* Hide the host's scrollbar — the scroll position is an interaction mechanism,
+   not something the user should see a track for. */
+.sheet-host {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 
-.slide-up-enter-from,
-.slide-up-leave-to {
-  transform: translateY(100%);
-}
-
-.slide-up-enter-to,
-.slide-up-leave-from {
-  transform: translateY(0);
+.sheet-host::-webkit-scrollbar {
+  display: none;
 }
 </style>

--- a/src/common/composables/useBottomSheetSnap.ts
+++ b/src/common/composables/useBottomSheetSnap.ts
@@ -1,0 +1,246 @@
+import { computed, onUnmounted, ref } from "vue";
+import type { Ref } from "vue";
+
+export type Detent = "half" | "full";
+export type SnapState = "dismissed" | "half" | "full";
+
+interface SnapTarget {
+  state: SnapState;
+  top: number;
+}
+
+interface UseBottomSheetSnapOptions {
+  /** The fixed, full-viewport scroll container. */
+  host: Ref<HTMLElement | null>;
+  /** Reactive getter for the enabled detents (e.g. ["half", "full"]). */
+  detents: () => Detent[];
+  /** Reactive getter for the detent to open at. */
+  initialDetent: () => Detent;
+  /** Called once the sheet has fully collapsed and should be unmounted. */
+  onClose: () => void;
+  /** Called when the settled detent changes. */
+  onSnapChange?: (state: SnapState) => void;
+}
+
+const MAX_SCRIM_OPACITY = 0.5;
+// Time with no scroll events before we treat the gesture as settled. iOS
+// momentum keeps firing scroll events, so this fires once the flick comes to
+// rest — a cross-browser substitute for the (patchily supported) `scrollend`.
+const SETTLE_DELAY_MS = 120;
+// Safety net so a missed settle during the closing animation can never leave
+// the parent's v-if stuck open.
+const CLOSE_FALLBACK_MS = 400;
+const HALF_VIEWPORT_FRACTION = 0.5;
+// If full and half would land closer than this, the content is too short to
+// justify a distinct half detent — collapse them into a single open state.
+const MIN_DETENT_GAP_PX = 48;
+
+/**
+ * Drives a bottom sheet using the browser's native scroll-snap mechanics rather
+ * than hand-rolled touch tracking. The host is a fixed, full-viewport scroll
+ * container; the sheet sits at the bottom of its scrollable content, so
+ * `scrollTop` maps directly to how far the sheet is revealed:
+ *
+ *   scrollTop 0          -> panel below the fold        -> "dismissed"
+ *   scrollTop H/2        -> panel half revealed         -> "half"
+ *   scrollTop scrollMax  -> panel fully in view         -> "full"
+ *
+ * Zero-height marker elements with `scroll-snap-align: start` placed at those
+ * offsets make the browser snap (with native momentum) to each state. This
+ * composable measures the targets, animates open/close, fades the backdrop with
+ * the scroll position, and reports the settled detent.
+ */
+export function useBottomSheetSnap(options: UseBottomSheetSnapOptions) {
+  const { host, detents, initialDetent, onClose, onSnapChange } = options;
+
+  // Toggled off during programmatic (open/close) scrolls so mandatory snapping
+  // doesn't fight the smooth animation; the template binds it to the host's
+  // `scroll-snap-type`.
+  const snapEnabled = ref(false);
+  const backdropProgress = ref(0); // 0..1, where 1 = fully open
+  const currentState = ref<SnapState>("dismissed");
+
+  // Content offsets of the half/full snap markers, bound as `top` in the
+  // template. The dismiss marker is always at 0.
+  const halfTop = ref(0);
+  const fullTop = ref(0);
+
+  let mode: "opening" | "idle" | "closing" = "opening";
+  let settleTimer: ReturnType<typeof setTimeout> | null = null;
+  let closeFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+  let closed = false;
+
+  const backdropOpacity = computed(
+    () => backdropProgress.value * MAX_SCRIM_OPACITY,
+  );
+  const atFull = computed(() => currentState.value === "full");
+
+  const snapTargets = (): SnapTarget[] => {
+    const targets: SnapTarget[] = [{ state: "dismissed", top: 0 }];
+    const hasRoomForHalf = fullTop.value - halfTop.value >= MIN_DETENT_GAP_PX;
+    if (detents().includes("half") && hasRoomForHalf) {
+      targets.push({ state: "half", top: halfTop.value });
+    }
+    targets.push({ state: "full", top: fullTop.value });
+    return targets;
+  };
+
+  // Backdrop reaches full scrim at the lowest open detent and stays there above
+  // it; below that it fades toward transparent as you drag to dismiss.
+  const minOpenTop = (): number => {
+    const open = snapTargets().filter((t) => t.state !== "dismissed");
+    const tops = open.map((t) => t.top);
+    return tops.length > 0 ? Math.max(1, Math.min(...tops)) : 1;
+  };
+
+  const measure = () => {
+    const hostEl = host.value;
+    if (!hostEl) return;
+    const viewport = hostEl.clientHeight;
+    fullTop.value = Math.max(0, hostEl.scrollHeight - viewport);
+    halfTop.value = Math.min(
+      Math.round(viewport * HALF_VIEWPORT_FRACTION),
+      fullTop.value,
+    );
+  };
+
+  const targetTopFor = (state: SnapState): number => {
+    const match = snapTargets().find((t) => t.state === state);
+    return match ? match.top : fullTop.value;
+  };
+
+  const nearestTarget = (scrollTop: number): SnapTarget =>
+    snapTargets().reduce((closest, t) =>
+      Math.abs(t.top - scrollTop) < Math.abs(closest.top - scrollTop)
+        ? t
+        : closest,
+    );
+
+  const updateBackdrop = () => {
+    const hostEl = host.value;
+    if (!hostEl) return;
+    backdropProgress.value = Math.min(
+      1,
+      Math.max(0, hostEl.scrollTop / minOpenTop()),
+    );
+  };
+
+  const finishClose = () => {
+    if (closed) return;
+    closed = true;
+    cleanup();
+    onClose();
+  };
+
+  const setState = (state: SnapState) => {
+    if (state === currentState.value) return;
+    currentState.value = state;
+    onSnapChange?.(state);
+  };
+
+  const handleSettle = () => {
+    const hostEl = host.value;
+    if (!hostEl) return;
+
+    if (mode === "opening") {
+      mode = "idle";
+      snapEnabled.value = true;
+      setState(nearestTarget(hostEl.scrollTop).state);
+      return;
+    }
+    if (mode === "closing") return; // resolved by scrollTo + fallback timer
+
+    const target = nearestTarget(hostEl.scrollTop);
+    if (target.state === "dismissed") {
+      finishClose();
+    } else {
+      setState(target.state);
+    }
+  };
+
+  const onScroll = () => {
+    updateBackdrop();
+
+    // Crisp finish: collapse animation reached the top.
+    if (mode === "closing" && (host.value?.scrollTop ?? 0) <= 2) {
+      finishClose();
+      return;
+    }
+
+    if (settleTimer) clearTimeout(settleTimer);
+    settleTimer = setTimeout(handleSettle, SETTLE_DELAY_MS);
+  };
+
+  // `scrollTo` is the only browser API the engine depends on; jsdom (tests) and
+  // any environment without it fall back to an instant jump so the component is
+  // inert-but-safe rather than throwing.
+  const scrollHostTo = (top: number, behavior: ScrollBehavior) => {
+    const hostEl = host.value;
+    if (!hostEl) return;
+    if (typeof hostEl.scrollTo === "function") {
+      hostEl.scrollTo({ top, behavior });
+    } else {
+      hostEl.scrollTop = top;
+    }
+  };
+
+  const onResize = () => {
+    if (!host.value || mode !== "idle") return;
+    const state = currentState.value;
+    measure();
+    scrollHostTo(targetTopFor(state), "auto");
+  };
+
+  function cleanup() {
+    host.value?.removeEventListener("scroll", onScroll);
+    window.removeEventListener("resize", onResize);
+    if (settleTimer) clearTimeout(settleTimer);
+    if (closeFallbackTimer) clearTimeout(closeFallbackTimer);
+  }
+
+  /** Mount the sheet off-screen, then animate up to the initial detent. */
+  const open = () => {
+    const hostEl = host.value;
+    if (!hostEl) return;
+
+    measure();
+    mode = "opening";
+    snapEnabled.value = false;
+    closed = false;
+    backdropProgress.value = 0;
+    hostEl.scrollTop = 0;
+
+    hostEl.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onResize);
+
+    requestAnimationFrame(() => {
+      scrollHostTo(targetTopFor(initialDetent()), "smooth");
+    });
+  };
+
+  /** Animate the sheet down and unmount once collapsed. */
+  const requestClose = () => {
+    if (!host.value || closed) return;
+    mode = "closing";
+    snapEnabled.value = false;
+    scrollHostTo(0, "smooth");
+    closeFallbackTimer = setTimeout(finishClose, CLOSE_FALLBACK_MS);
+  };
+
+  onUnmounted(cleanup);
+
+  return {
+    /** Bind to the host's `scroll-snap-type`. */
+    snapEnabled,
+    /** 0..0.5 — bind to <v-backdrop :opacity>. */
+    backdropOpacity,
+    /** The currently settled detent. */
+    currentState,
+    /** True only while resting at the full detent (drives expand-to-scroll). */
+    atFull,
+    halfTop,
+    fullTop,
+    open,
+    requestClose,
+  };
+}

--- a/src/common/composables/useFocusTrap.ts
+++ b/src/common/composables/useFocusTrap.ts
@@ -1,0 +1,100 @@
+import { onUnmounted, watch } from "vue";
+import type { Ref } from "vue";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+/**
+ * Trap keyboard focus within a container while it is active, restoring focus to
+ * the previously focused element when it deactivates or the component unmounts.
+ *
+ * Used by overlay components (bottom sheet, modal, drawer) so that Tab cycling
+ * stays inside the surface and screen-reader users are not stranded in the page
+ * behind the backdrop.
+ *
+ * @param container - The element to trap focus within
+ * @param isActive - Reactive flag that toggles the trap on/off
+ *
+ * @example
+ * const sheetRef = ref<HTMLElement | null>(null);
+ * const isOpen = ref(true);
+ * useFocusTrap(sheetRef, isOpen);
+ */
+export function useFocusTrap(
+  container: Ref<HTMLElement | null>,
+  isActive: Ref<boolean>,
+) {
+  let previouslyFocused: HTMLElement | null = null;
+
+  const focusableElements = (): HTMLElement[] => {
+    const root = container.value;
+    if (!root) return [];
+    return Array.from(
+      root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+    ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+  };
+
+  const onKeydown = (event: KeyboardEvent) => {
+    if (event.key !== "Tab") return;
+
+    const focusable = focusableElements();
+    if (focusable.length === 0) {
+      // Nothing focusable inside; keep focus on the container itself.
+      event.preventDefault();
+      container.value?.focus();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const activate = () => {
+    previouslyFocused =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    document.addEventListener("keydown", onKeydown, true);
+
+    // Move focus into the surface on the next tick, once its content is mounted.
+    requestAnimationFrame(() => {
+      const focusable = focusableElements();
+      (focusable[0] ?? container.value)?.focus();
+    });
+  };
+
+  const deactivate = () => {
+    document.removeEventListener("keydown", onKeydown, true);
+    previouslyFocused?.focus();
+    previouslyFocused = null;
+  };
+
+  watch(
+    isActive,
+    (active) => {
+      if (active) {
+        activate();
+      } else {
+        deactivate();
+      }
+    },
+    { immediate: true },
+  );
+
+  onUnmounted(deactivate);
+}

--- a/src/common/tests/VBottomSheet.spec.ts
+++ b/src/common/tests/VBottomSheet.spec.ts
@@ -1,0 +1,54 @@
+import { fireEvent, screen } from "@testing-library/vue";
+
+import VBottomSheet from "../components/VBottomSheet.vue";
+
+import { render } from "@/tests/utils";
+
+// jsdom cannot render scroll-snap or layout, so these cover the prop wiring,
+// accessibility contract, and emit behavior — not the native drag physics,
+// which require a real device (see plan verification notes).
+describe("VBottomSheet", () => {
+  it("renders an accessible modal dialog with a backdrop and slot content", () => {
+    render(VBottomSheet, {
+      props: { ariaLabel: "Club switcher" },
+      slots: { default: "<p>Sheet body</p>" },
+    });
+
+    const dialog = screen.getByRole("dialog", { name: "Club switcher" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(screen.getByText("Sheet body")).toBeInTheDocument();
+  });
+
+  it("renders a single open detent by default (dismiss + full markers only)", () => {
+    render(VBottomSheet, { slots: { default: "x" } });
+
+    expect(document.querySelectorAll(".snap-start")).toHaveLength(2);
+  });
+
+  it("adds a half snap marker when the half detent is enabled", () => {
+    render(VBottomSheet, {
+      props: { detents: ["half", "full"], initialDetent: "half" },
+      slots: { default: "x" },
+    });
+
+    expect(document.querySelectorAll(".snap-start")).toHaveLength(3);
+  });
+
+  it("emits close after the sheet collapses on Escape", async () => {
+    vi.useFakeTimers();
+    try {
+      const view = render(VBottomSheet, {
+        slots: { default: "<button>ok</button>" },
+      });
+
+      await fireEvent.keyDown(document, { key: "Escape" });
+      // The collapse animation resolves via the close fallback timer in jsdom
+      // (no real scroll events fire).
+      vi.advanceTimersByTime(400);
+
+      expect(view.emitted().close).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/features/reviews/components/MovieDetailsDrawer.vue
+++ b/src/features/reviews/components/MovieDetailsDrawer.vue
@@ -1,7 +1,13 @@
 <template>
   <div>
     <!-- Mobile Bottom Sheet -->
-    <v-bottom-sheet v-if="!isDesktop" transparent-handle @close="close">
+    <v-bottom-sheet
+      v-if="!isDesktop"
+      transparent-handle
+      :detents="['half', 'full']"
+      initial-detent="half"
+      @close="close"
+    >
       <MovieDetailsContent
         :key="movie.id"
         :movie="movie"

--- a/src/features/watch-list/components/ListItemDetailsDrawer.vue
+++ b/src/features/watch-list/components/ListItemDetailsDrawer.vue
@@ -1,7 +1,13 @@
 <template>
   <div>
     <!-- Mobile Bottom Sheet -->
-    <v-bottom-sheet v-if="!isDesktop" transparent-handle @close="close">
+    <v-bottom-sheet
+      v-if="!isDesktop"
+      transparent-handle
+      :detents="['half', 'full']"
+      initial-detent="half"
+      @close="close"
+    >
       <ListItemDetailsContent
         :movie="movie"
         :is-next-work="isNextWork"


### PR DESCRIPTION
## What & why

Our mobile bottom sheets hand-rolled drag with `@touchstart/move/end` + `preventDefault` + manual velocity math on the main thread, had a single open state, a static backdrop, and no accessibility. Inspired by [viliket/pure-web-bottom-sheet](https://github.com/viliket/pure-web-bottom-sheet) ([writeup](https://viliket.github.io/posts/native-like-bottom-sheets-on-the-web/)), this swaps that for the browser's **native CSS scroll-snap** mechanics — compositor-thread momentum physics and real multi-detent snapping.

`VBottomSheet` is the shared base for **every** mobile sheet (`VModal` on mobile → AuthModal/AddMovieModal/RandomPicker/…, both detail drawers, `ClubSwitcher`), so improving that one component upgrades all of them.

## How it works

A fixed, full-viewport scroll **host** whose `scrollTop` maps to how far the sheet is revealed. Zero-height marker elements with `scroll-snap-align: start` at the dismiss / half / full offsets make the browser rest at each detent with native momentum. Because the panel sits at the bottom of the scroll content, gestures map natively: swipe down → dismiss, swipe up → expand.

- **`useBottomSheetSnap`** (new) — measures detent targets from the host height, animates open/close, drives backdrop opacity from scroll position, and detects dismiss via a debounced settle with a close-timeout fallback (so a missed settle can't leave the sheet stuck open).
- **`detents` / `initialDetent` props** — default `["full"]` keeps existing consumers behavior-compatible; `MovieDetailsDrawer` and `ListItemDetailsDrawer` opt into `["half","full"]`. **expand-to-scroll**: inner content only scrolls at the full detent, so a swipe-up at half unambiguously expands (and `mandatory` snap never fights a mid-content rest).
- **Accessibility** — `role="dialog"`, `aria-modal`, Escape-to-close, and a new **`useFocusTrap`** (focus trapped while open, restored on close).
- **`VBackdrop`** — optional `opacity` prop so the scrim fades continuously with the drag; default static 50% scrim preserved for all other consumers.
- **Teleport to body** — the fixed host escapes the router's `transform` transitions.

## Verification

- `type-check`, `lint`, and `npm test` green (added a `VBottomSheet` spec for prop wiring / dialog contract / close emit — jsdom can't run the scroll physics).
- **Live Chromium @ 390×844**: isolated probe confirms the absolute zero-height markers genuinely snap (250→half, 600→full); the real **AuthModal** sheet opens and rests exactly at the full detent, renders `role=dialog`/`aria-modal`, backdrop tracks scroll (0.5 at full), swipe-to-dismiss removes the sheet, **0 console errors**.

## Still needs on-device QA (cannot be done in CI)

- **Real iOS Safari feel**: momentum, and the nested-scroll handoff at the full detent (drag content to top → collapse). Safari has known scroll-snap re-snap quirks the reference worked around.
- The **half-detent drawers** and `DeleteConfirmationModal` (z-60) stacked over an open sheet — verified structurally/in unit tests, but not driven live (requires auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)