### PR TITLE
Add member attribution to list items

### DIFF
--- a/lib/types/generated/db.ts
+++ b/lib/types/generated/db.ts
@@ -243,6 +243,7 @@ export interface WorkList {
 }
 
 export interface WorkListItem {
+  added_by_user_id: Int8 | null;
   list_id: Int8;
   position: Generated<Int8>;
   time_added: Generated<Timestamp>;

--- a/lib/types/lists.ts
+++ b/lib/types/lists.ts
@@ -18,6 +18,7 @@ export interface WorkListItem {
   createdDate: string;
   externalId?: string;
   imageUrl?: string;
+  addedBy?: string;
 }
 
 export interface ReviewListItem extends WorkListItem {

--- a/migrations/schema/20260606_AddListItemAddedBy.ts
+++ b/migrations/schema/20260606_AddListItemAddedBy.ts
@@ -1,0 +1,26 @@
+import { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>) {
+  await db.schema
+    .alterTable("work_list_item")
+    .addColumn("added_by_user_id", "int8")
+    .execute();
+
+  await db.schema
+    .alterTable("work_list_item")
+    .addForeignKeyConstraint(
+      "fk_work_list_item_added_by_user_id",
+      ["added_by_user_id"],
+      "user",
+      ["id"],
+    )
+    .onDelete("set null")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>) {
+  await db.schema
+    .alterTable("work_list_item")
+    .dropColumn("added_by_user_id")
+    .execute();
+}

--- a/netlify/functions/club/list.ts
+++ b/netlify/functions/club/list.ts
@@ -125,6 +125,7 @@ router.get("/:listId", validListId, async ({ listId }, res) => {
       createdDate: item.time_added.toISOString(),
       imageUrl: item.image_url ?? undefined,
       externalId: item.external_id ?? undefined,
+      addedBy: item.added_by_user_id ?? undefined,
       externalData: hasValue(item.external_id)
         ? externalData.get(item.external_id)
         : undefined,
@@ -173,7 +174,7 @@ router.post(
   "/:listId/items",
   validListId,
   secured<ListRequest>,
-  async ({ listId, clubId, event }, res) => {
+  async ({ listId, clubId, userId, event }, res) => {
     if (!hasValue(event.body)) return res(badRequest("No body provided"));
     const body = listInsertDtoSchema.safeParse(JSON.parse(event.body));
     if (!body.success) return res(badRequest("Invalid body provided"));
@@ -197,7 +198,7 @@ router.post(
     if (exists) {
       return res(badRequest(BadRequest.ItemInList));
     }
-    await ListRepository.insertItemInList(listId, workId);
+    await ListRepository.insertItemInList(listId, workId, userId);
     return res(ok());
   },
 );

--- a/netlify/functions/repositories/ListRepository.ts
+++ b/netlify/functions/repositories/ListRepository.ts
@@ -129,6 +129,7 @@ class ListRepository {
         "work.image_url",
         "work.external_id",
         "work_list_item.time_added",
+        "work_list_item.added_by_user_id",
       ])
       .orderBy("work_list_item.position", "asc")
       .execute();
@@ -143,7 +144,7 @@ class ListRepository {
       .executeTakeFirst());
   }
 
-  async insertItemInList(listId: string, workId: string) {
+  async insertItemInList(listId: string, workId: string, userId: string) {
     const maxResult = await db
       .selectFrom("work_list_item")
       .where("list_id", "=", listId)
@@ -156,6 +157,7 @@ class ListRepository {
         list_id: listId,
         work_id: workId,
         position: maxResult.next_position,
+        added_by_user_id: userId,
       })
       .execute();
   }
@@ -180,11 +182,21 @@ class ListRepository {
     workId: string,
   ) {
     return db.transaction().execute(async (trx) => {
-      const max = await trx
-        .selectFrom("work_list_item")
-        .where("list_id", "=", destinationListId)
-        .select(sql<number>`COALESCE(MAX(position), 0) + 1`.as("next_position"))
-        .executeTakeFirstOrThrow();
+      const [max, source] = await Promise.all([
+        trx
+          .selectFrom("work_list_item")
+          .where("list_id", "=", destinationListId)
+          .select(
+            sql<number>`COALESCE(MAX(position), 0) + 1`.as("next_position"),
+          )
+          .executeTakeFirstOrThrow(),
+        trx
+          .selectFrom("work_list_item")
+          .where("list_id", "=", sourceListId)
+          .where("work_id", "=", workId)
+          .select("added_by_user_id")
+          .executeTakeFirst(),
+      ]);
 
       await trx
         .insertInto("work_list_item")
@@ -192,6 +204,7 @@ class ListRepository {
           list_id: destinationListId,
           work_id: workId,
           position: max.next_position,
+          added_by_user_id: source?.added_by_user_id ?? null,
         })
         .onConflict((oc) => oc.columns(["list_id", "work_id"]).doNothing())
         .execute();

--- a/src/features/watch-list/components/ListItemDetailsContent.vue
+++ b/src/features/watch-list/components/ListItemDetailsContent.vue
@@ -15,6 +15,21 @@
       :is-desktop="isDesktop"
     />
 
+    <div
+      v-if="isDefined(addedByMember)"
+      class="mb-4 flex items-center gap-2 text-sm text-slate-400"
+    >
+      <VAvatar
+        :src="addedByMember.image"
+        :name="addedByMember.name"
+        :size="24"
+      />
+      <span>
+        Added by {{ addedByMember.name }} on
+        {{ formatDate(movie.createdDate) }}
+      </span>
+    </div>
+
     <div class="grid grid-cols-1 gap-y-2 text-sm md:grid-cols-2 md:gap-x-4">
       <MovieMetadataGrid
         v-if="movieData"
@@ -115,13 +130,15 @@ import {
 import { DateTime } from "luxon";
 import { computed, nextTick, ref } from "vue";
 
-import { hasValue } from "../../../../lib/checks/checks.js";
+import { hasValue, isDefined } from "../../../../lib/checks/checks.js";
+import { Member } from "../../../../lib/types/club";
 import { DetailedWorkListItem } from "../../../../lib/types/lists";
 
 import BookMetadataGrid from "@/common/components/BookMetadataGrid.vue";
 import CommentThread from "@/common/components/CommentThread.vue";
 import DeleteConfirmationModal from "@/common/components/DeleteConfirmationModal.vue";
 import MovieMetadataGrid from "@/common/components/MovieMetadataGrid.vue";
+import VAvatar from "@/common/components/VAvatar.vue";
 import WatchProviders from "@/common/components/WatchProviders.vue";
 import WorkDescription from "@/common/components/WorkDescription.vue";
 import WorkPosterHero from "@/common/components/WorkPosterHero.vue";
@@ -139,6 +156,7 @@ const props = defineProps<{
   isDesktop: boolean;
   canReview: boolean;
   otherLists: { id: string; title: string }[];
+  addedByMember?: Member;
 }>();
 
 const emit = defineEmits<{

--- a/src/features/watch-list/components/ListItemDetailsDrawer.vue
+++ b/src/features/watch-list/components/ListItemDetailsDrawer.vue
@@ -9,6 +9,7 @@
         :is-desktop="isDesktop"
         :can-review="canReview"
         :other-lists="otherLists"
+        :added-by-member="addedByMember"
         @close="close"
         @review="emit('review')"
         @set-next-work="emit('set-next-work')"
@@ -27,6 +28,7 @@
         :is-desktop="isDesktop"
         :can-review="canReview"
         :other-lists="otherLists"
+        :added-by-member="addedByMember"
         @close="close"
         @review="emit('review')"
         @set-next-work="emit('set-next-work')"
@@ -40,6 +42,7 @@
 
 <script setup lang="ts">
 import ListItemDetailsContent from "./ListItemDetailsContent.vue";
+import { Member } from "../../../../lib/types/club";
 import { DetailedWorkListItem } from "../../../../lib/types/lists";
 
 import VBottomSheet from "@/common/components/VBottomSheet.vue";
@@ -52,6 +55,7 @@ defineProps<{
   isNextWork: boolean;
   canReview: boolean;
   otherLists: { id: string; title: string }[];
+  addedByMember?: Member;
 }>();
 
 const emit = defineEmits<{

--- a/src/features/watch-list/components/ListItems.vue
+++ b/src/features/watch-list/components/ListItems.vue
@@ -45,6 +45,18 @@
               @select="emit('select', item.id)"
             >
               <div class="mt-2 flex flex-col gap-2">
+                <div
+                  v-if="isDefined(adderFor(item))"
+                  class="flex items-center justify-center gap-1.5 text-xs text-slate-400"
+                  :title="`Added by ${adderFor(item)?.name}`"
+                >
+                  <VAvatar
+                    :src="adderFor(item)?.image"
+                    :name="adderFor(item)?.name ?? ''"
+                    :size="18"
+                  />
+                  <span class="truncate">{{ adderFor(item)?.name }}</span>
+                </div>
                 <div class="grid grid-cols-2 gap-2">
                   <v-btn
                     v-if="canReview && listId !== reviewsListId"
@@ -93,6 +105,7 @@
         :is-next-work="selectedItem.id === nextWorkId"
         :can-review="canReview && listId !== reviewsListId"
         :other-lists="otherLists"
+        :added-by-member="adderFor(selectedItem)"
         @close="emit('deselect')"
         @review="
           onReview(selectedItem.id);
@@ -118,8 +131,10 @@ import { useRouter } from "vue-router";
 import ListItemDetailsDrawer from "./ListItemDetailsDrawer.vue";
 import RandomPickerModal from "./RandomPickerModal.vue";
 import { hasValue, isDefined } from "../../../../lib/checks/checks";
+import { Member } from "../../../../lib/types/club";
 import { DetailedWorkListItem } from "../../../../lib/types/lists";
 
+import VAvatar from "@/common/components/VAvatar.vue";
 import WorkPosterCard from "@/common/components/WorkPosterCard.vue";
 import {
   OPTIMISTIC_WORK_ID,
@@ -140,6 +155,7 @@ const props = defineProps<{
   clubSlug: string;
   listId: string;
   otherLists: { id: string; title: string }[];
+  members: Member[];
   reviewsListId: string | null;
   randomPickerOpen?: boolean;
   selectedItemId: string | null;
@@ -156,6 +172,10 @@ const { listId } = toRefs(props);
 const { data: items, isLoading } = useList(props.clubSlug, listId);
 
 const canReview = computed(() => hasValue(props.reviewsListId));
+
+const memberById = computed(() => new Map(props.members.map((m) => [m.id, m])));
+const adderFor = (item: DetailedWorkListItem) =>
+  hasValue(item.addedBy) ? memberById.value.get(item.addedBy) : undefined;
 
 const { data: nextWorkId } = useNextWork(props.clubSlug);
 const { mutate: setNextWork } = useSetNextWork(props.clubSlug);

--- a/src/features/watch-list/views/WatchListView.vue
+++ b/src/features/watch-list/views/WatchListView.vue
@@ -10,7 +10,7 @@ import ManageListsModal from "../components/ManageListsModal.vue";
 import { useCollapsedLists } from "../composables/useCollapsedLists";
 
 import SearchFilterBar from "@/common/components/SearchFilterBar.vue";
-import { useClubSlug } from "@/service/useClub";
+import { useClubSlug, useMembers } from "@/service/useClub";
 import {
   ClubListSummary,
   useAllUserListItems,
@@ -21,8 +21,10 @@ import {
 const clubSlug = useClubSlug();
 const { data: lists, isLoading } = useClubLists(clubSlug);
 const { data: reviewsListIdData } = useReviewsListId(clubSlug);
+const { data: membersData } = useMembers(clubSlug);
 
 const userLists = computed<ClubListSummary[]>(() => lists.value ?? []);
+const members = computed(() => membersData.value ?? []);
 const reviewsListId = computed<string | null>(
   () => reviewsListIdData.value ?? null,
 );
@@ -154,6 +156,7 @@ const shareList = async (listId: string) => {
               :club-slug="clubSlug"
               :list-id="list.id"
               :other-lists="otherLists(list.id)"
+              :members="members"
               :reviews-list-id="reviewsListId"
               :random-picker-open="randomOpenListId === list.id"
               :selected-item-id="


### PR DESCRIPTION
Track which member adds a movie to a list via a new nullable
added_by_user_id column on work_list_item, and surface it on the
lists page as an avatar + name on each card and an "Added by X on
[date]" line in the item details drawer.

- Migration adds added_by_user_id (FK to user, ON DELETE SET NULL)
- insertItemInList records the current user; moveItem preserves the
  original adder when an item is moved between lists
- getListItems returns the adder as addedBy on WorkListItem; the
  frontend resolves it to a club Member via useMembers
- Existing items have no recorded adder and render without attribution