### PR TITLE
Add circular cast avatars with full-cast modal to movie drawer

### DIFF
--- a/src/common/components/CastAvatar.vue
+++ b/src/common/components/CastAvatar.vue
@@ -1,0 +1,41 @@
+<template>
+  <div
+    v-if="showImage"
+    class="overflow-hidden rounded-full bg-lowBackground"
+    :class="{ 'animate-pulse': !loaded }"
+    :style="{ width: `${size}px`, height: `${size}px` }"
+  >
+    <img
+      :src="src"
+      :alt="name"
+      decoding="async"
+      class="h-full w-full rounded-full object-cover transition-opacity duration-300"
+      :class="loaded ? 'opacity-100' : 'opacity-0'"
+      @load="loaded = true"
+      @error="errored = true"
+    />
+  </div>
+  <v-avatar v-else :name="name" :size="size" />
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+import { isDefined } from "../../../lib/checks/checks";
+import { profileImageUrl } from "../tmdbImages";
+
+interface Props {
+  name: string;
+  profilePath: string | null;
+  size?: number;
+}
+const { name, profilePath, size = 64 } = defineProps<Props>();
+
+const loaded = ref(false);
+const errored = ref(false);
+
+const src = computed(() => profileImageUrl(profilePath));
+// Show the photo unless it's missing or failed to load — otherwise fall back to
+// VAvatar's seeded-colour initials (shown immediately, with no loading skeleton).
+const showImage = computed(() => isDefined(src.value) && !errored.value);
+</script>

--- a/src/common/components/CastList.vue
+++ b/src/common/components/CastList.vue
@@ -1,0 +1,71 @@
+<template>
+  <section v-if="hasElements(allActors)">
+    <div class="mb-3 flex items-center justify-between">
+      <span class="text-gray-400">Cast</span>
+      <button
+        v-if="hasMore"
+        class="text-sm text-primary hover:underline"
+        @click="showAll = true"
+      >
+        See all ({{ allActors.length }})
+      </button>
+    </div>
+
+    <ul class="flex gap-4 overflow-x-auto pb-1">
+      <li
+        v-for="(actor, index) in visibleActors"
+        :key="`${actor.name}-${index}`"
+        class="flex w-16 shrink-0 flex-col items-center gap-1.5 text-center"
+      >
+        <CastAvatar
+          :name="actor.name"
+          :profile-path="actor.profilePath"
+          :size="64"
+        />
+        <span class="line-clamp-2 text-xs leading-tight text-gray-300">
+          {{ actor.name }}
+        </span>
+      </li>
+
+      <li
+        v-if="hasMore"
+        class="flex w-16 shrink-0 flex-col items-center gap-1.5 text-center"
+      >
+        <button
+          class="flex h-16 w-16 items-center justify-center rounded-full bg-lowBackground text-sm font-medium text-gray-300 transition hover:brightness-110"
+          @click="showAll = true"
+        >
+          +{{ remainingCount }}
+        </button>
+        <span class="text-xs leading-tight text-gray-400">More</span>
+      </li>
+    </ul>
+
+    <CastModal v-if="showAll" :actors="allActors" @close="showAll = false" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+import CastAvatar from "./CastAvatar.vue";
+import CastModal from "./CastModal.vue";
+import { hasElements } from "../../../lib/checks/checks";
+
+const props = defineProps<{
+  actors?: { name: string; profilePath: string | null }[];
+}>();
+
+const VISIBLE_ACTORS_COUNT = 5;
+
+const allActors = computed(() => props.actors ?? []);
+const visibleActors = computed(() =>
+  allActors.value.slice(0, VISIBLE_ACTORS_COUNT),
+);
+const hasMore = computed(() => allActors.value.length > VISIBLE_ACTORS_COUNT);
+const remainingCount = computed(
+  () => allActors.value.length - VISIBLE_ACTORS_COUNT,
+);
+
+const showAll = ref(false);
+</script>

--- a/src/common/components/CastModal.vue
+++ b/src/common/components/CastModal.vue
@@ -1,0 +1,43 @@
+<template>
+  <Teleport to="body">
+    <v-modal size="lg" z-index="60" @close="emit('close')">
+      <div class="flex h-full flex-col gap-4 text-left">
+        <h2 class="shrink-0 text-xl font-bold">Cast</h2>
+        <!-- Bounded scroll area: VModal's desktop panel is fixed-height with no
+             internal scroll, so a long cast would otherwise overflow. -->
+        <div class="min-h-0 flex-1 overflow-y-auto">
+          <ul
+            class="grid grid-cols-3 gap-x-3 gap-y-5 sm:grid-cols-4 md:grid-cols-5"
+          >
+            <li
+              v-for="(actor, index) in actors"
+              :key="`${actor.name}-${index}`"
+              class="flex flex-col items-center gap-2 text-center"
+            >
+              <CastAvatar
+                :name="actor.name"
+                :profile-path="actor.profilePath"
+                :size="72"
+              />
+              <span class="line-clamp-2 text-xs text-gray-300">
+                {{ actor.name }}
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </v-modal>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import CastAvatar from "./CastAvatar.vue";
+
+defineProps<{
+  actors: { name: string; profilePath: string | null }[];
+}>();
+
+const emit = defineEmits<{
+  (e: "close"): void;
+}>();
+</script>

--- a/src/common/components/MovieMetadataGrid.vue
+++ b/src/common/components/MovieMetadataGrid.vue
@@ -15,17 +15,6 @@
     <span class="text-gray-400">Director: </span>
     <span>{{ directors.map((d) => d.name).join(", ") }}</span>
   </div>
-  <div v-if="hasElements(actors)" class="col-span-full">
-    <span class="text-gray-400">Cast: </span>
-    <span>{{ displayedActors.join(", ") }}</span>
-    <button
-      v-if="hasMoreActors"
-      class="ml-1 text-xs text-primary"
-      @click="showAllActors = !showAllActors"
-    >
-      {{ showAllActors ? "Show less" : `+${remainingActorsCount} more` }}
-    </button>
-  </div>
   <div v-if="voteAverage">
     <span class="text-gray-400">TMDB Rating: </span>
     <span>{{ voteAverage }}/10</span>
@@ -33,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
 import { hasElements, hasValue } from "../../../lib/checks/checks.js";
 
@@ -42,12 +31,8 @@ const props = defineProps<{
   runtime?: number;
   genres?: string[];
   directors?: { name: string }[];
-  actors?: { name: string }[];
   voteAverage?: number;
 }>();
-
-const VISIBLE_ACTORS_COUNT = 5;
-const showAllActors = ref(false);
 
 const formattedReleaseDate = computed(() => {
   if (!hasValue(props.releaseDate)) return "";
@@ -58,17 +43,4 @@ const formattedReleaseDate = computed(() => {
     day: "numeric",
   });
 });
-
-const allActors = computed(() => (props.actors ?? []).map((a) => a.name));
-const displayedActors = computed(() =>
-  showAllActors.value
-    ? allActors.value
-    : allActors.value.slice(0, VISIBLE_ACTORS_COUNT),
-);
-const hasMoreActors = computed(
-  () => allActors.value.length > VISIBLE_ACTORS_COUNT,
-);
-const remainingActorsCount = computed(
-  () => allActors.value.length - VISIBLE_ACTORS_COUNT,
-);
 </script>

--- a/src/common/tests/CastAvatar.spec.ts
+++ b/src/common/tests/CastAvatar.spec.ts
@@ -1,0 +1,28 @@
+import { screen } from "@testing-library/vue";
+
+import CastAvatar from "../components/CastAvatar.vue";
+
+import { render } from "@/tests/utils";
+
+describe("CastAvatar", () => {
+  it("renders the TMDB profile photo, hidden until it loads", () => {
+    render(CastAvatar, {
+      props: { name: "Al Pacino", profilePath: "/photo.jpg" },
+    });
+
+    const img = screen.getByRole("img", { name: "Al Pacino" });
+    expect(img).toHaveAttribute(
+      "src",
+      "https://image.tmdb.org/t/p/w185/photo.jpg",
+    );
+    // Starts transparent and fades in on @load, so there is no abrupt pop-in.
+    expect(img).toHaveClass("opacity-0");
+  });
+
+  it("falls back to initials (no image) when there is no profile path", () => {
+    render(CastAvatar, { props: { name: "Al Pacino", profilePath: null } });
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.getByText("AP")).toBeInTheDocument();
+  });
+});

--- a/src/common/tests/CastList.spec.ts
+++ b/src/common/tests/CastList.spec.ts
@@ -1,0 +1,53 @@
+import { screen } from "@testing-library/vue";
+
+import CastList from "../components/CastList.vue";
+
+import { render } from "@/tests/utils";
+
+const makeActors = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    name: `Actor ${i + 1}`,
+    profilePath: `/actor-${i + 1}.jpg`,
+  }));
+
+describe("CastList", () => {
+  it("renders every cast member and no 'See all' when there are 5 or fewer", () => {
+    render(CastList, { props: { actors: makeActors(4) } });
+
+    expect(screen.getByText("Actor 1")).toBeInTheDocument();
+    expect(screen.getByText("Actor 4")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /See all/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows only the first 5 plus a '+N' affordance when there are more", () => {
+    render(CastList, { props: { actors: makeActors(7) } });
+
+    expect(screen.getByText("Actor 5")).toBeInTheDocument();
+    // The 6th and 7th members are hidden behind the modal until it is opened.
+    expect(screen.queryByText("Actor 6")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "See all (7)" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "+2" })).toBeInTheDocument();
+  });
+
+  it("opens the full-cast modal when 'See all' is clicked", async () => {
+    const { user } = render(CastList, { props: { actors: makeActors(7) } });
+
+    await user.click(screen.getByRole("button", { name: "See all (7)" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Cast" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Actor 6")).toBeInTheDocument();
+    expect(screen.getByText("Actor 7")).toBeInTheDocument();
+  });
+
+  it("renders nothing when there is no cast", () => {
+    const { container } = render(CastList, { props: { actors: [] } });
+
+    expect(container.querySelector("section")).not.toBeInTheDocument();
+  });
+});

--- a/src/common/tmdbImages.ts
+++ b/src/common/tmdbImages.ts
@@ -1,0 +1,17 @@
+import { isDefined } from "../../lib/checks/checks";
+
+const TMDB_PROFILE_BASE_URL = "https://image.tmdb.org/t/p/w185";
+
+/**
+ * Builds a TMDB profile (cast/crew headshot) image URL.
+ *
+ * Returns `undefined` when no profile path is available so callers can fall back
+ * to an initials placeholder instead of requesting a broken `…/w185null` image.
+ */
+export function profileImageUrl(
+  profilePath: string | null,
+): string | undefined {
+  return isDefined(profilePath)
+    ? `${TMDB_PROFILE_BASE_URL}${profilePath}`
+    : undefined;
+}

--- a/src/features/reviews/components/WorkDetailsContent.vue
+++ b/src/features/reviews/components/WorkDetailsContent.vue
@@ -67,7 +67,7 @@
         />
         <CastList
           v-if="movieData"
-          :actors="movieData.actors"
+          :actors="movieData?.actors"
           class="md:col-span-2"
         />
         <div
@@ -280,7 +280,7 @@
         </div>
       </div>
 
-      <CastList :actors="movie.original.externalData?.actors" class="mt-4" />
+      <CastList :actors="movieData?.actors" class="mt-4" />
 
       <!-- Collapsible metadata -->
       <Disclosure v-slot="{ open }">

--- a/src/features/reviews/components/WorkDetailsContent.vue
+++ b/src/features/reviews/components/WorkDetailsContent.vue
@@ -57,7 +57,6 @@
           :runtime="movieData.runtime"
           :genres="movieData.genres"
           :directors="movieData.directors"
-          :actors="movieData.actors"
         />
         <BookMetadataGrid
           v-else-if="bookData"
@@ -65,6 +64,11 @@
           :first-publish-year="bookData.firstPublishYear"
           :number-of-pages="bookData.numberOfPages"
           :subjects="bookData.subjects"
+        />
+        <CastList
+          v-if="movieData"
+          :actors="movieData.actors"
+          class="md:col-span-2"
         />
         <div
           v-if="movieData?.vote_average"
@@ -276,6 +280,8 @@
         </div>
       </div>
 
+      <CastList :actors="movie.original.externalData?.actors" class="mt-4" />
+
       <!-- Collapsible metadata -->
       <Disclosure v-slot="{ open }">
         <DisclosureButton
@@ -295,7 +301,6 @@
             :runtime="movieData.runtime"
             :genres="movieData.genres"
             :directors="movieData.directors"
-            :actors="movieData.actors"
           />
           <BookMetadataGrid
             v-else-if="bookData"
@@ -388,6 +393,7 @@ import { hasValue, isDefined } from "../../../../lib/checks/checks.js";
 import { DetailedReviewListItem } from "../../../../lib/types/lists";
 
 import BookMetadataGrid from "@/common/components/BookMetadataGrid.vue";
+import CastList from "@/common/components/CastList.vue";
 import CommentThread from "@/common/components/CommentThread.vue";
 import DeleteConfirmationModal from "@/common/components/DeleteConfirmationModal.vue";
 import ExternalLink from "@/common/components/ExternalLink.vue";

--- a/src/features/watch-list/components/ListItemDetailsContent.vue
+++ b/src/features/watch-list/components/ListItemDetailsContent.vue
@@ -31,7 +31,7 @@
         :number-of-pages="bookData.numberOfPages"
         :subjects="bookData.subjects"
       />
-      <CastList :actors="movie.externalData?.actors" class="md:col-span-2" />
+      <CastList :actors="movieData?.actors" class="md:col-span-2" />
       <WatchProviders :external-id="movie.externalId" class="md:col-span-2" />
     </div>
 

--- a/src/features/watch-list/components/ListItemDetailsContent.vue
+++ b/src/features/watch-list/components/ListItemDetailsContent.vue
@@ -22,7 +22,6 @@
         :runtime="movieData.runtime"
         :genres="movieData.genres"
         :directors="movieData.directors"
-        :actors="movieData.actors"
         :vote-average="movieData.vote_average"
       />
       <BookMetadataGrid
@@ -32,6 +31,7 @@
         :number-of-pages="bookData.numberOfPages"
         :subjects="bookData.subjects"
       />
+      <CastList :actors="movie.externalData?.actors" class="md:col-span-2" />
       <WatchProviders :external-id="movie.externalId" class="md:col-span-2" />
     </div>
 
@@ -119,6 +119,7 @@ import { hasValue } from "../../../../lib/checks/checks.js";
 import { DetailedWorkListItem } from "../../../../lib/types/lists";
 
 import BookMetadataGrid from "@/common/components/BookMetadataGrid.vue";
+import CastList from "@/common/components/CastList.vue";
 import CommentThread from "@/common/components/CommentThread.vue";
 import DeleteConfirmationModal from "@/common/components/DeleteConfirmationModal.vue";
 import MovieMetadataGrid from "@/common/components/MovieMetadataGrid.vue";


### PR DESCRIPTION
## What & why

The movie detail drawer (reviews + watch-list) rendered the cast as a comma-separated text blob buried in the metadata grid — and on mobile it was hidden behind the collapsed "Movie Details" toggle. The actor **photos were already fetched and stored** (`{ name, profilePath }`, billing-sorted on the backend) but never displayed.

This replaces the text with a sleek strip of **circular cast avatars** — the 5 top-billed members with photos + names — plus a **"See all" modal** for the full cast.

## What changed

**New**
- `src/common/tmdbImages.ts` — null-safe `profileImageUrl()` (returns `undefined` for missing photos so the initials fallback engages instead of requesting a broken `…/w185null` image).
- `CastAvatar.vue` — one circular avatar with a shape-matched pulse skeleton that fades into the photo on `@load`; delegates to `VAvatar`'s seeded-color initials when there's no photo (and on image error).
- `CastList.vue` — labeled "Cast" strip: first 5 avatars + names, with "See all (N)" and a `+N` tile that open the modal.
- `CastModal.vue` — full cast in a responsive grid, teleported over the drawer (`<v-modal z-index="60">`, same pattern as `DeleteConfirmationModal`).
- Tests: `CastAvatar.spec.ts`, `CastList.spec.ts`.

**Modified**
- `MovieMetadataGrid.vue` — removed the cast row + its prop/toggle logic.
- `MovieDetailsContent.vue` (desktop + **promoted** mobile, now outside the collapsible) and `ListItemDetailsContent.vue` — render `CastList` **above** the where-to-watch section.

Frontend-only — no backend, DB, or type changes. Character names were intentionally left out of scope (they aren't stored; would need a schema migration + backfill).

## Verification

- ✅ `npm run type-check`, `npm run lint` (`--max-warnings 0`), `npm test` (89 passed, incl. 6 new) all green.
- ⚠️ Not yet visually rendered in a browser locally — worth a look at the deploy preview for the desktop cast position, the promoted mobile placement, and long-name behavior in the avatar cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)