### PR TITLE
Add actor filter to reviews and watch-list search

### DIFF
--- a/src/common/clubType.ts
+++ b/src/common/clubType.ts
@@ -207,7 +207,8 @@ export const CLUB_TYPE_CONFIG: Record<ClubType, ClubTypeConfig> = {
     label: "Movie club",
     noun: "movie",
     searchHint: "Search for a movie to add.",
-    searchableFieldsHint: "title, genre, company, director, or release year",
+    searchableFieldsHint:
+      "title, genre, company, director, actor, or release year",
     filterOptions: [
       enumOption(
         "genre",
@@ -227,6 +228,12 @@ export const CLUB_TYPE_CONFIG: Record<ClubType, ClubTypeConfig> = {
         "Director",
         "Select a director",
         (data) => asMovie(data)?.directors?.map((d) => d.name) ?? [],
+      ),
+      enumOption(
+        "actor",
+        "Actor",
+        "Select an actor",
+        (data) => asMovie(data)?.actors?.map((a) => a.name) ?? [],
       ),
       reviewDateOption,
       dateOption(

--- a/src/common/filterWorks.test.ts
+++ b/src/common/filterWorks.test.ts
@@ -37,7 +37,7 @@ function movieItem(
     createdDate: "2026-01-01",
     externalData: {
       kind: "movie",
-      actors: [],
+      actors: data.actors ?? [],
       directors: [],
       genres: data.genres ?? [],
       production_companies: data.production_companies ?? [],
@@ -205,6 +205,98 @@ describe("filterWorks enum and free-text filters", () => {
         filterWorks(books, { filters: {}, freeText: "tolkien" }, ClubType.book),
       ),
     ).toEqual(["tolkien"]);
+  });
+});
+
+describe("filterWorks movie actor filter", () => {
+  const movies = [
+    movieItem("forrest", {
+      title: "Forrest Gump",
+      genres: ["Drama"],
+      actors: [
+        { name: "Tom Hanks", profilePath: null },
+        { name: "Robin Wright", profilePath: "/rw.jpg" },
+      ],
+    }),
+    movieItem("matrix", {
+      title: "The Matrix",
+      genres: ["Action"],
+      actors: [
+        { name: "Keanu Reeves", profilePath: "/kr.jpg" },
+        { name: "Laurence Fishburne", profilePath: null },
+      ],
+    }),
+    movieItem("silent", { title: "Silent Film", actors: [] }),
+  ];
+
+  it("matches movies where an actor name contains the value", () => {
+    expect(
+      ids(
+        filterWorks(
+          movies,
+          { filters: { actor: { value: "Tom Hanks" } }, freeText: "" },
+          ClubType.movie,
+        ),
+      ),
+    ).toEqual(["forrest"]);
+  });
+
+  it("is case-insensitive and matches partial names", () => {
+    expect(
+      ids(
+        filterWorks(
+          movies,
+          { filters: { actor: { value: "hanks" } }, freeText: "" },
+          ClubType.movie,
+        ),
+      ),
+    ).toEqual(["forrest"]);
+  });
+
+  it("excludes movies with no matching actor", () => {
+    expect(
+      ids(
+        filterWorks(
+          movies,
+          { filters: { actor: { value: "Meryl Streep" } }, freeText: "" },
+          ClubType.movie,
+        ),
+      ),
+    ).toEqual([]);
+  });
+
+  it("ANDs the actor filter with other filters", () => {
+    expect(
+      ids(
+        filterWorks(
+          movies,
+          {
+            filters: {
+              actor: { value: "hanks" },
+              genre: { value: "Drama" },
+            },
+            freeText: "",
+          },
+          ClubType.movie,
+        ),
+      ),
+    ).toEqual(["forrest"]);
+
+    expect(
+      ids(
+        filterWorks(
+          movies,
+          {
+            filters: {
+              actor: { value: "Tom Hanks" },
+              genre: { value: "Action" },
+            },
+            freeText: "",
+          },
+          ClubType.movie,
+        ),
+      ),
+    ).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds the ability to search by **actor** on the Reviews and Watch List pages.

This branch has been rebased onto `main`, which in the meantime landed the
club-type search refactor (`searchMovies.ts` → `filterWorks.ts`, plus the
registry-driven `SearchFilterBar`). The actor feature is now implemented
through that registry rather than the old hardcoded filter branch:

- New `actor` `enumOption` in the movie club's `filterOptions`
  (`src/common/clubType.ts`), selecting `externalData.actors[].name`. The
  shared `SearchFilterBar` picks up the **"Actor"** pill automatically (after
  Director), including frequency-ranked suggestions like "Tom Hanks (3)", and
  the Watch List inherits it since `actor` isn't in its `excludeFilterKeys`.
- Matching is case-insensitive partial-match over actor names and ANDs with
  other filters — behaviour provided by the registry's `enumMatcher`.
- "actor" added to the movie club's `searchableFieldsHint`, which now feeds the
  Reviews empty-state copy.
- Actor-filter test coverage (matching, case-insensitivity, partial names,
  exclusions, filter ANDing) added to `src/common/filterWorks.test.ts`.

No backend changes: actor data already flows from the `movie_actors` table into
`externalData.actors` via `ListRepository`.

## Test plan

- `npm test` — 106/106 passing
- `npm run type-check` and `npm run lint` — clean
- Manual: on Reviews or Watch List, click the "Actor" pill, pick a suggestion,
  confirm the list filters; remove the pill to restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)