### PR TITLE
Fix home button linking to club home for non-members on share links

### DIFF
--- a/src/common/components/NavBar.vue
+++ b/src/common/components/NavBar.vue
@@ -43,11 +43,17 @@ const currentSlug = computed(() => {
   return Array.isArray(slug) ? slug[0] : slug;
 });
 
-const hasClubContext = computed(() => hasValue(currentSlug.value));
+// A clubSlug in the route (e.g. on a /share/... page) only counts as club
+// context when the user is actually a member of that club; visitors should
+// be sent to the root instead of a club they can't access.
+const hasClubContext = computed(() => {
+  const slug = currentSlug.value;
+  return hasValue(slug) && store.isClubMember(slug);
+});
 
 const logoDestination = computed(() => {
   const slug = currentSlug.value;
-  if (hasValue(slug)) {
+  if (hasValue(slug) && store.isClubMember(slug)) {
     return { name: "ClubHome", params: { clubSlug: slug } };
   }
   return "/";


### PR DESCRIPTION
## Problem

When someone opens a share link (`/share/club/:clubSlug/...`) and clicks the MovieClub logo in the top left, they're sent to that club's home (`ClubHome`) instead of the root domain. Since they aren't a member of that club, the `clubGuard` then bounces them to a login prompt / Club Not Found page — a broken experience.

## Cause

`NavBar.vue` treated any `clubSlug` route param as club context. Share routes carry a `clubSlug`, so the logo destination resolved to `{ name: "ClubHome" }` even for visitors with no membership in that club.

## Fix

Gate the logo destination (and the `ClubSwitcher`'s club-context check) on `auth.isClubMember(slug)`:

- Logged-out visitors and logged-in non-members on a share link now get the logo pointing to `/` (the landing page, or their own default club if logged in).
- Members browsing their own club keep the existing behavior — logo goes to that club's home.

## Testing

- `npm run type-check`, `npm run lint` (via hooks), and `npm test` (102 tests) all pass.

https://claude.ai/code/session_01GJoD5WKasaNSvvazoD7p32

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJoD5WKasaNSvvazoD7p32)_