### PR TITLE
Preserve added-by and added-date when moving a list item

### DIFF
--- a/netlify/functions/repositories/ListRepository.ts
+++ b/netlify/functions/repositories/ListRepository.ts
@@ -1,5 +1,6 @@
 import { sql } from "kysely";
 
+import { isDefined } from "../../../lib/checks/checks";
 import { ClubType, WorkListSystemType } from "../../../lib/types/generated/db";
 import { db } from "../utils/database";
 
@@ -175,6 +176,10 @@ class ListRepository {
    * UI and by the review flow (which moves from any source list into the
    * `reviews` system list). The destination insert is a no-op if the work is
    * already on the target list, so a movie can safely be on multiple lists.
+   *
+   * The original "added by" user and "time added" are carried forward to the
+   * destination so attribution survives a move rather than resetting to the
+   * mover and the current time.
    */
   async moveItem(
     sourceListId: string,
@@ -194,7 +199,7 @@ class ListRepository {
           .selectFrom("work_list_item")
           .where("list_id", "=", sourceListId)
           .where("work_id", "=", workId)
-          .select("added_by_user_id")
+          .select(["added_by_user_id", "time_added"])
           .executeTakeFirst(),
       ]);
 
@@ -205,6 +210,9 @@ class ListRepository {
           work_id: workId,
           position: max.next_position,
           added_by_user_id: source?.added_by_user_id ?? null,
+          ...(isDefined(source?.time_added)
+            ? { time_added: source.time_added }
+            : {}),
         })
         .onConflict((oc) => oc.columns(["list_id", "work_id"]).doNothing())
         .execute();


### PR DESCRIPTION
## Summary

When moving a movie from one list to another on a club's lists page, the move now carries forward **both** pieces of attribution metadata: which user added it (`added_by_user_id`) and when it was added (`time_added`).

The `added_by_user_id` was already preserved by `ListRepository.moveItem` (from #368), but `time_added` was being dropped — the destination row fell back to the column's `now()` default, so a moved item showed the *move* time instead of when it was originally added. This made the "Added by X on DATE" line in the movie details drawer inaccurate after any move.

## Changes

- `ListRepository.moveItem` now selects `time_added` alongside `added_by_user_id` from the source row and carries it forward to the destination insert. When the source has no row (defensive), the column keeps its `now()` default via spread, so existing behavior is unchanged.
- Updated the method doc comment to describe the carried-forward attribution.

## Notes

- No schema change required — `time_added` already exists on `work_list_item`.
- The insert remains `ON CONFLICT DO NOTHING`, so moving an item into a list it's already on is still a safe no-op.
- `npm run type-check` and `eslint` pass.

https://claude.ai/code/session_01XdNfLUQv5CcMk4grywcR7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdNfLUQv5CcMk4grywcR7n)_