### PR TITLE
Remove sort-by-Title option from reviews gallery

### DIFF
--- a/src/features/reviews/components/GalleryView.vue
+++ b/src/features/reviews/components/GalleryView.vue
@@ -146,7 +146,7 @@ const emit = defineEmits<{
 }>();
 
 const CUSTOM_RENDERED_COLUMNS = ["title", "imageUrl", "createdDate"];
-const NON_SORTABLE_COLUMNS = ["imageUrl"];
+const NON_SORTABLE_COLUMNS = ["imageUrl", "title"];
 
 const getVisibleCells = (row: Row<DetailedReviewListItem>) => {
   return row.getVisibleCells().filter((cell) => {


### PR DESCRIPTION
## What

Removes **Title** from the "Sort By" dropdown on the reviews page (gallery view).

## Why / How

The gallery's "Sort By" dropdown in `GalleryView.vue` is generated by `getSortableColumns()`, which lists every table header except those named in the local `NON_SORTABLE_COLUMNS` array. Adding `"title"` to that array drops just the Title option:

```ts
const NON_SORTABLE_COLUMNS = ["imageUrl", "title"];
```

This is scoped to the gallery dropdown only — the shared TanStack Table column definitions in `ReviewView.vue` are untouched, and the Table view's header-click sorting still works. There was no default sort on `title`, so no UI can be stranded in a now-unselectable sort state.

## Testing

- `npm run type-check` ✅
- `npm run lint` ✅
- `npx vitest run src/features/reviews/tests` ✅ (9 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)