### PR TITLE
Remove Blur Scores feature flag, enable it for everyone

### DIFF
--- a/netlify/functions/club/settings.ts
+++ b/netlify/functions/club/settings.ts
@@ -18,7 +18,6 @@ router.get("/", secured, async ({ clubId }, res) => {
 const updateSettingsSchema = z.object({
   features: z
     .object({
-      blurScores: z.boolean(),
       awards: z.boolean(),
       discussionQuestions: z.boolean(),
     })

--- a/netlify/functions/repositories/SettingsRepository.ts
+++ b/netlify/functions/repositories/SettingsRepository.ts
@@ -2,7 +2,6 @@ import { db } from "../utils/database";
 
 export interface ClubSettings {
   features: {
-    blurScores: boolean;
     awards: boolean;
     discussionQuestions: boolean;
   };
@@ -10,7 +9,6 @@ export interface ClubSettings {
 
 const DEFAULT_SETTINGS: ClubSettings = {
   features: {
-    blurScores: true,
     awards: false,
     discussionQuestions: false,
   },

--- a/src/features/reviews/components/GalleryView.vue
+++ b/src/features/reviews/components/GalleryView.vue
@@ -107,7 +107,6 @@
       :revealed-movie-ids="revealedMovieIds"
       :has-rated="hasRated"
       :current-user-id="currentUserId"
-      :blur-scores-enabled="blurScoresEnabled"
       @toggle-reveal="toggleMovieReveal"
       @close="selectedMovieId = undefined"
     />
@@ -138,7 +137,6 @@ const props = defineProps<{
   revealedMovieIds: Set<string>;
   hasRated: (movieId: string) => boolean;
   currentUserId?: string;
-  blurScoresEnabled: boolean;
 }>();
 
 const emit = defineEmits<{

--- a/src/features/reviews/components/WorkDetailsContent.vue
+++ b/src/features/reviews/components/WorkDetailsContent.vue
@@ -418,7 +418,6 @@ const props = defineProps<{
   revealedMovieIds: Set<string>;
   hasRated: (movieId: string) => boolean;
   currentUserId?: string;
-  blurScoresEnabled: boolean;
   isDesktop: boolean;
 }>();
 
@@ -566,11 +565,6 @@ const toggleMovieReveal = (movieId: string) => {
 };
 
 const shouldBlurScore = (rowId: string, columnId: string) => {
-  // If blur scores setting is disabled in club settings, don't blur anything
-  if (!props.blurScoresEnabled) {
-    return false;
-  }
-
   if (props.hasRated(rowId) || props.revealedMovieIds.has(rowId)) {
     return false;
   }
@@ -591,7 +585,6 @@ const hasClubScoresToReveal = computed(() => {
 });
 
 const showRevealPill = computed(() => {
-  if (!props.blurScoresEnabled) return false;
   if (
     props.hasRated(props.movie.id) ||
     props.revealedMovieIds.has(props.movie.id)
@@ -603,7 +596,6 @@ const showRevealPill = computed(() => {
 const tmdbRevealed = ref(false);
 
 const shouldBlurTmdbScore = computed(() => {
-  if (!props.blurScoresEnabled) return false;
   if (props.hasRated(props.movie.id) || tmdbRevealed.value) return false;
   return true;
 });

--- a/src/features/reviews/components/WorkDetailsDrawer.vue
+++ b/src/features/reviews/components/WorkDetailsDrawer.vue
@@ -10,7 +10,6 @@
         :revealed-movie-ids="revealedMovieIds"
         :has-rated="hasRated"
         :current-user-id="currentUserId"
-        :blur-scores-enabled="blurScoresEnabled"
         :is-desktop="isDesktop"
         @close="close"
         @toggle-reveal="toggleMovieReveal"
@@ -27,7 +26,6 @@
         :revealed-movie-ids="revealedMovieIds"
         :has-rated="hasRated"
         :current-user-id="currentUserId"
-        :blur-scores-enabled="blurScoresEnabled"
         :is-desktop="isDesktop"
         @close="close"
         @toggle-reveal="toggleMovieReveal"
@@ -53,7 +51,6 @@ defineProps<{
   revealedMovieIds: Set<string>;
   hasRated: (movieId: string) => boolean;
   currentUserId?: string;
-  blurScoresEnabled: boolean;
 }>();
 
 const emit = defineEmits<{

--- a/src/features/reviews/views/ReviewView.vue
+++ b/src/features/reviews/views/ReviewView.vue
@@ -57,7 +57,6 @@
           :revealed-movie-ids="revealedMovieIds"
           :has-rated="hasUserRated"
           :current-user-id="userId"
-          :blur-scores-enabled="blurScoresEnabled === true"
           @toggle-reveal="toggleReveal"
         />
       </template>
@@ -92,12 +91,7 @@ import VAvatar from "@/common/components/VAvatar.vue";
 import VToggle from "@/common/components/VToggle.vue";
 import { asMovie } from "@/common/workDisplay";
 import AddReviewPrompt from "@/features/reviews/components/AddReviewPrompt.vue";
-import {
-  useClub,
-  useIsInClub,
-  useMembers,
-  useClubSettings,
-} from "@/service/useClub";
+import { useClub, useIsInClub, useMembers } from "@/service/useClub";
 import {
   useDeleteReview,
   useReviewsList,
@@ -111,14 +105,6 @@ const isGalleryView = ref(true);
 
 // Load club data for share functionality
 const { data: club } = useClub(clubSlug);
-
-// Load club settings to check if blur scores is enabled
-const { data: settings, isLoading: isLoadingSettings } =
-  useClubSettings(clubSlug);
-const blurScoresEnabled = computed(
-  () =>
-    settings.value?.features?.blurScores === true || isLoadingSettings.value,
-);
 
 onMounted(() => {
   const savedView = localStorage.getItem("isGalleryView");
@@ -233,10 +219,6 @@ const toggleReveal = (movieId: string) => {
 };
 
 const shouldBlurScore = (rowId: string, columnId: string) => {
-  if (!blurScoresEnabled.value) {
-    return false;
-  }
-
   if (hasUserRated.value(rowId) || revealedMovieIds.value.has(rowId)) {
     return false;
   }

--- a/src/features/settings/views/ClubSettingsView.vue
+++ b/src/features/settings/views/ClubSettingsView.vue
@@ -42,20 +42,6 @@
         <div class="rounded-lg bg-gray-800 p-4">
           <div class="flex items-center justify-between gap-4">
             <div class="flex-1">
-              <h4 class="font-medium">Blur Scores</h4>
-              <p class="mt-1 text-sm text-gray-400">
-                Hide other members' scores until you submit your own
-              </p>
-            </div>
-            <v-switch
-              :model-value="blurScoresEnabled"
-              color="primary"
-              class="ml-5 flex-shrink-0"
-              @update:model-value="updateBlurScoresFeature"
-            />
-          </div>
-          <div class="mt-3 flex items-center justify-between gap-4">
-            <div class="flex-1">
               <h4 class="font-medium">Awards</h4>
               <p class="mt-1 text-sm text-gray-400">
                 Enable the awards feature for this club
@@ -353,9 +339,6 @@ const hasNameChanged = computed(() => {
 
 const { mutate: updateSlugMutation, isPending: isUpdatingSlug } =
   useUpdateClubSlug(clubId);
-const blurScoresEnabled = computed(
-  () => settings.value?.features?.blurScores === true,
-);
 const awardsEnabled = computed(() => settings.value?.features?.awards === true);
 const discussionQuestionsEnabled = computed(
   () => settings.value?.features?.discussionQuestions === true,
@@ -439,16 +422,6 @@ const saveSlug = () => {
 const updateAwardsFeature = (value: boolean) => {
   updateSettings(
     { features: { awards: value } },
-    {
-      onSuccess: () => toast.success("Settings updated successfully"),
-      onError: () => toast.error("Failed to update settings"),
-    },
-  );
-};
-
-const updateBlurScoresFeature = (value: boolean) => {
-  updateSettings(
-    { features: { blurScores: value } },
     {
       onSuccess: () => toast.success("Settings updated successfully"),
       onError: () => toast.error("Failed to update settings"),

--- a/src/service/useClub.ts
+++ b/src/service/useClub.ts
@@ -174,7 +174,6 @@ export function useInviteToken(clubSlug: string) {
 
 interface ClubSettings {
   features: {
-    blurScores: boolean;
     awards: boolean;
     discussionQuestions: boolean;
   };


### PR DESCRIPTION
## What

Score-blurring (hide other members' scores until you've submitted your own, with reveal-on-click) was previously gated behind a per-club **Blur Scores** setting toggle. This makes it always-on for every club by removing the feature flag end to end.

## Changes

- **Backend:** drop `blurScores` from `SettingsRepository` defaults + `ClubSettings` interface, and from the settings-update Zod schema.
- **Types:** drop `blurScores` from the `useClub` `ClubSettings` type.
- **Settings UI:** remove the Blur Scores toggle (and its computed + update handler) from the club settings page.
- **Behavior:** remove the `blurScoresEnabled` prop threaded through `ReviewView → GalleryView → WorkDetailsDrawer → WorkDetailsContent`, making `shouldBlurScore` / `showRevealPill` / `shouldBlurTmdbScore` unconditional. The blur *mechanics* are untouched — only the on/off switch is gone.

Net: 63 deletions, 1 insertion across 8 files.

## Migration

None needed. Stored club settings are spread over `DEFAULT_SETTINGS` on read, so any existing `blurScores: false` value is simply ignored — blur is on for everyone. The stale key is inert and drops out on the next settings write.

## Verification

- `npm run type-check` — clean
- `npm run lint` — clean (`--max-warnings 0`)
- `npm test` — 106/106 passing across 10 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)