### PR TITLE
Support books for AI discussion questions

### DIFF
--- a/netlify/functions/club/reviews.ts
+++ b/netlify/functions/club/reviews.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 import { hasValue } from "../../../lib/checks/checks.js";
-import { WorkType } from "../../../lib/types/generated/db.js";
 import ListRepository from "../repositories/ListRepository";
 import ReviewRepository from "../repositories/ReviewRepository";
 import SettingsRepository from "../repositories/SettingsRepository";
@@ -9,7 +8,8 @@ import WorkCommentRepository from "../repositories/WorkCommentRepository";
 import WorkRepository from "../repositories/WorkRepository";
 import SharedReviewService from "../services/SharedReviewService";
 import { secured } from "../utils/auth";
-import { DiscussionWork, generateDiscussionQuestions } from "../utils/gemini";
+import { generateJson } from "../utils/gemini";
+import { getProvider } from "../utils/providers";
 import { badRequest, ok, unauthorized } from "../utils/responses";
 import { Router } from "../utils/router";
 import { ClubRequest } from "../utils/validation";
@@ -157,6 +157,10 @@ router.delete(
   },
 );
 
+const discussionQuestionsSchema = z.object({
+  questions: z.array(z.string().min(1)).max(5),
+});
+
 router.post(
   "/:workId/discussion-questions",
   secured,
@@ -170,31 +174,35 @@ router.post(
       return res(badRequest("Feature not enabled"));
     }
 
-    // Resolve the work's title/metadata server-side from the workId so the
-    // prompt can't be poisoned by client-supplied input.
-    const work = await WorkRepository.getDiscussionContext(
-      clubId,
-      params.workId,
-    );
+    // Resolve the work server-side from the workId so the prompt can't be
+    // poisoned by client-supplied input. The work's provider owns the
+    // type-specific metadata lookup and prompt wording.
+    const work = await WorkRepository.getById(clubId, params.workId);
     if (!work) {
       return res(badRequest("Work not found"));
     }
 
-    const discussionWork: DiscussionWork =
-      work.type === WorkType.book
-        ? {
-            type: "book",
-            title: work.title,
-            authors: work.authors ?? undefined,
-            firstPublishYear: work.first_publish_year ?? undefined,
-          }
-        : {
-            type: "movie",
-            title: work.title,
-            releaseYear: work.release_date?.getFullYear().toString(),
-          };
+    const prompt = await getProvider(work.type).getDiscussionPrompt({
+      title: work.title,
+      externalId: work.external_id,
+    });
 
-    const questions = await generateDiscussionQuestions(discussionWork);
+    const { questions } = await generateJson({
+      prompt,
+      schema: discussionQuestionsSchema,
+      responseSchema: {
+        type: "object",
+        properties: {
+          questions: {
+            type: "array",
+            items: { type: "string" },
+            maxItems: 5,
+          },
+        },
+        required: ["questions"],
+      },
+      temperature: 0.9,
+    });
     return res(ok(JSON.stringify({ questions })));
   },
 );

--- a/netlify/functions/club/reviews.ts
+++ b/netlify/functions/club/reviews.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { hasValue } from "../../../lib/checks/checks.js";
+import { WorkType } from "../../../lib/types/generated/db.js";
 import ListRepository from "../repositories/ListRepository";
 import ReviewRepository from "../repositories/ReviewRepository";
 import SettingsRepository from "../repositories/SettingsRepository";
@@ -8,7 +9,7 @@ import WorkCommentRepository from "../repositories/WorkCommentRepository";
 import WorkRepository from "../repositories/WorkRepository";
 import SharedReviewService from "../services/SharedReviewService";
 import { secured } from "../utils/auth";
-import { generateDiscussionQuestions } from "../utils/gemini";
+import { DiscussionWork, generateDiscussionQuestions } from "../utils/gemini";
 import { badRequest, ok, unauthorized } from "../utils/responses";
 import { Router } from "../utils/router";
 import { ClubRequest } from "../utils/validation";
@@ -169,8 +170,8 @@ router.post(
       return res(badRequest("Feature not enabled"));
     }
 
-    // Resolve the movie's title/year server-side from the workId so the prompt
-    // can't be poisoned by client-supplied input.
+    // Resolve the work's title/metadata server-side from the workId so the
+    // prompt can't be poisoned by client-supplied input.
     const work = await WorkRepository.getDiscussionContext(
       clubId,
       params.workId,
@@ -179,11 +180,21 @@ router.post(
       return res(badRequest("Work not found"));
     }
 
-    const releaseYear = work.release_date?.getFullYear().toString();
-    const questions = await generateDiscussionQuestions(
-      work.title,
-      releaseYear,
-    );
+    const discussionWork: DiscussionWork =
+      work.type === WorkType.book
+        ? {
+            type: "book",
+            title: work.title,
+            authors: work.authors ?? undefined,
+            firstPublishYear: work.first_publish_year ?? undefined,
+          }
+        : {
+            type: "movie",
+            title: work.title,
+            releaseYear: work.release_date?.getFullYear().toString(),
+          };
+
+    const questions = await generateDiscussionQuestions(discussionWork);
     return res(ok(JSON.stringify({ questions })));
   },
 );

--- a/netlify/functions/repositories/WorkRepository.ts
+++ b/netlify/functions/repositories/WorkRepository.ts
@@ -72,16 +72,36 @@ class WorkRepository {
   }
 
   async getDiscussionContext(clubId: string, workId: string) {
+    // A work is either a movie or a book, so only one detail join matches.
+    // External-id namespaces differ (TMDB ids vs OpenLibrary keys), so the
+    // two detail tables can't cross-match; `work.type` disambiguates anyway.
     return db
+      .with("authors_agg", (qb) =>
+        qb
+          .selectFrom("book_authors")
+          .select([
+            "external_id",
+            db.fn.agg<string[]>("array_agg", ["author_name"]).as("authors"),
+          ])
+          .groupBy("external_id"),
+      )
       .selectFrom("work")
       .leftJoin(
         "movie_details",
         "movie_details.external_id",
         "work.external_id",
       )
+      .leftJoin("book_details", "book_details.external_id", "work.external_id")
+      .leftJoin("authors_agg", "authors_agg.external_id", "work.external_id")
       .where("work.id", "=", workId)
       .where("work.club_id", "=", clubId)
-      .select(["work.title", "movie_details.release_date"])
+      .select([
+        "work.title",
+        "work.type",
+        "movie_details.release_date",
+        "book_details.first_publish_year",
+        "authors_agg.authors",
+      ])
       .executeTakeFirst();
   }
 

--- a/netlify/functions/repositories/WorkRepository.ts
+++ b/netlify/functions/repositories/WorkRepository.ts
@@ -71,37 +71,12 @@ class WorkRepository {
     return insertedWork;
   }
 
-  async getDiscussionContext(clubId: string, workId: string) {
-    // A work is either a movie or a book, so only one detail join matches.
-    // External-id namespaces differ (TMDB ids vs OpenLibrary keys), so the
-    // two detail tables can't cross-match; `work.type` disambiguates anyway.
+  async getById(clubId: string, workId: string) {
     return db
-      .with("authors_agg", (qb) =>
-        qb
-          .selectFrom("book_authors")
-          .select([
-            "external_id",
-            db.fn.agg<string[]>("array_agg", ["author_name"]).as("authors"),
-          ])
-          .groupBy("external_id"),
-      )
       .selectFrom("work")
-      .leftJoin(
-        "movie_details",
-        "movie_details.external_id",
-        "work.external_id",
-      )
-      .leftJoin("book_details", "book_details.external_id", "work.external_id")
-      .leftJoin("authors_agg", "authors_agg.external_id", "work.external_id")
-      .where("work.id", "=", workId)
-      .where("work.club_id", "=", clubId)
-      .select([
-        "work.title",
-        "work.type",
-        "movie_details.release_date",
-        "book_details.first_publish_year",
-        "authors_agg.authors",
-      ])
+      .where("id", "=", workId)
+      .where("club_id", "=", clubId)
+      .select(["title", "type", "external_id"])
       .executeTakeFirst();
   }
 

--- a/netlify/functions/utils/gemini.ts
+++ b/netlify/functions/utils/gemini.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { z } from "zod";
 
-import { hasValue } from "../../../lib/checks/checks.js";
+import { hasElements, hasValue } from "../../../lib/checks/checks.js";
 
 const GEMINI_MODEL = "gemini-3.5-flash";
 const GEMINI_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`;
@@ -16,23 +16,68 @@ interface GeminiResponse {
   }[];
 }
 
-export async function generateDiscussionQuestions(
-  title: string,
-  releaseYear?: string,
-): Promise<string[]> {
-  const apiKey = process.env.GEMINI_API_KEY;
-  if (!hasValue(apiKey)) {
-    throw new Error("GEMINI_API_KEY is not configured");
-  }
+interface MovieWork {
+  type: "movie";
+  title: string;
+  releaseYear?: string;
+}
 
-  const filmLabel = hasValue(releaseYear) ? `${title} (${releaseYear})` : title;
-  const prompt = `Generate 3 to 5 discussion prompts for a movie club rewatching "${filmLabel}". Every prompt must be specific to THIS film — naming its actual characters, scenes, lines, or moments — never a generic question that could apply to any movie.
+interface BookWork {
+  type: "book";
+  title: string;
+  authors?: string[];
+  firstPublishYear?: string;
+}
+
+/**
+ * The minimal, source-resolved metadata needed to prompt for discussion
+ * questions. Built server-side in the reviews handler so client input can't
+ * poison the prompt.
+ */
+export type DiscussionWork = MovieWork | BookWork;
+
+function buildMoviePrompt(work: MovieWork): string {
+  const label = hasValue(work.releaseYear)
+    ? `${work.title} (${work.releaseYear})`
+    : work.title;
+  return `Generate 3 to 5 discussion prompts for a movie club rewatching "${label}". Every prompt must be specific to THIS film — naming its actual characters, scenes, lines, or moments — never a generic question that could apply to any movie.
 
 Order the prompts by depth: the first should be casual and easy to answer — a low-stakes entry point. Each subsequent prompt should be more thought-provoking than the last, with the final one being substantial — a real book-club-worthy question, adapted for film.
 
 Whenever the film supports it, frame prompts as debates: questions with defensible answers on more than one side, designed to spark disagreement among friends rather than consensus. Keep each prompt succinct — one clear, concise question with no preamble.
 
 If you do not recognize this film or cannot confirm it is a real movie, return 0 questions.`;
+}
+
+function buildBookPrompt(work: BookWork): string {
+  const byline = hasElements(work.authors)
+    ? ` by ${work.authors.join(" and ")}`
+    : "";
+  const yearSuffix = hasValue(work.firstPublishYear)
+    ? ` (${work.firstPublishYear})`
+    : "";
+  return `Generate 3 to 5 discussion prompts for a book club discussing "${work.title}"${byline}${yearSuffix}. Every prompt must be specific to THIS book — naming its actual characters, plot points, themes, or passages — never a generic question that could apply to any book.
+
+Order the prompts by depth: the first should be casual and easy to answer — a low-stakes entry point. Each subsequent prompt should be more thought-provoking than the last, with the final one being substantial — a real book-club-worthy question.
+
+Whenever the book supports it, frame prompts as debates: questions with defensible answers on more than one side, designed to spark disagreement among friends rather than consensus. Keep each prompt succinct — one clear, concise question with no preamble.
+
+If you do not recognize this book or cannot confirm it is a real book, return 0 questions.`;
+}
+
+function buildPrompt(work: DiscussionWork): string {
+  return work.type === "book" ? buildBookPrompt(work) : buildMoviePrompt(work);
+}
+
+export async function generateDiscussionQuestions(
+  work: DiscussionWork,
+): Promise<string[]> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!hasValue(apiKey)) {
+    throw new Error("GEMINI_API_KEY is not configured");
+  }
+
+  const prompt = buildPrompt(work);
 
   const response = await axios.post<GeminiResponse>(
     `${GEMINI_ENDPOINT}?key=${apiKey}`,

--- a/netlify/functions/utils/gemini.ts
+++ b/netlify/functions/utils/gemini.ts
@@ -1,14 +1,10 @@
 import axios from "axios";
 import { z } from "zod";
 
-import { hasElements, hasValue } from "../../../lib/checks/checks.js";
+import { hasValue } from "../../../lib/checks/checks.js";
 
 const GEMINI_MODEL = "gemini-3.5-flash";
 const GEMINI_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`;
-
-const questionsSchema = z.object({
-  questions: z.array(z.string().min(1)).max(5),
-});
 
 interface GeminiResponse {
   candidates?: {
@@ -16,87 +12,36 @@ interface GeminiResponse {
   }[];
 }
 
-interface MovieWork {
-  type: "movie";
-  title: string;
-  releaseYear?: string;
-}
-
-interface BookWork {
-  type: "book";
-  title: string;
-  authors?: string[];
-  firstPublishYear?: string;
+interface GenerateJsonOptions<T> {
+  prompt: string;
+  /** OpenAPI-style structured-output schema enforced by Gemini server-side. */
+  responseSchema: Record<string, unknown>;
+  /** Validates the JSON Gemini returns and types the result. */
+  schema: z.ZodType<T>;
+  temperature?: number;
 }
 
 /**
- * The minimal, source-resolved metadata needed to prompt for discussion
- * questions. Built server-side in the reviews handler so client input can't
- * poison the prompt.
+ * Generic Gemini call: send a prompt with a structured-output schema, get back
+ * validated JSON. Callers own their prompts and schemas — this module knows
+ * nothing about what is being generated.
  */
-export type DiscussionWork = MovieWork | BookWork;
-
-function buildMoviePrompt(work: MovieWork): string {
-  const label = hasValue(work.releaseYear)
-    ? `${work.title} (${work.releaseYear})`
-    : work.title;
-  return `Generate 3 to 5 discussion prompts for a movie club rewatching "${label}". Every prompt must be specific to THIS film — naming its actual characters, scenes, lines, or moments — never a generic question that could apply to any movie.
-
-Order the prompts by depth: the first should be casual and easy to answer — a low-stakes entry point. Each subsequent prompt should be more thought-provoking than the last, with the final one being substantial — a real book-club-worthy question, adapted for film.
-
-Whenever the film supports it, frame prompts as debates: questions with defensible answers on more than one side, designed to spark disagreement among friends rather than consensus. Keep each prompt succinct — one clear, concise question with no preamble.
-
-If you do not recognize this film or cannot confirm it is a real movie, return 0 questions.`;
-}
-
-function buildBookPrompt(work: BookWork): string {
-  const byline = hasElements(work.authors)
-    ? ` by ${work.authors.join(" and ")}`
-    : "";
-  const yearSuffix = hasValue(work.firstPublishYear)
-    ? ` (${work.firstPublishYear})`
-    : "";
-  return `Generate 3 to 5 discussion prompts for a book club discussing "${work.title}"${byline}${yearSuffix}. Every prompt must be specific to THIS book — naming its actual characters, plot points, themes, or passages — never a generic question that could apply to any book.
-
-Order the prompts by depth: the first should be casual and easy to answer — a low-stakes entry point. Each subsequent prompt should be more thought-provoking than the last, with the final one being substantial — a real book-club-worthy question.
-
-Whenever the book supports it, frame prompts as debates: questions with defensible answers on more than one side, designed to spark disagreement among friends rather than consensus. Keep each prompt succinct — one clear, concise question with no preamble.
-
-If you do not recognize this book or cannot confirm it is a real book, return 0 questions.`;
-}
-
-function buildPrompt(work: DiscussionWork): string {
-  return work.type === "book" ? buildBookPrompt(work) : buildMoviePrompt(work);
-}
-
-export async function generateDiscussionQuestions(
-  work: DiscussionWork,
-): Promise<string[]> {
+export async function generateJson<T>(
+  options: GenerateJsonOptions<T>,
+): Promise<T> {
   const apiKey = process.env.GEMINI_API_KEY;
   if (!hasValue(apiKey)) {
     throw new Error("GEMINI_API_KEY is not configured");
   }
 
-  const prompt = buildPrompt(work);
-
   const response = await axios.post<GeminiResponse>(
     `${GEMINI_ENDPOINT}?key=${apiKey}`,
     {
-      contents: [{ parts: [{ text: prompt }] }],
+      contents: [{ parts: [{ text: options.prompt }] }],
       generationConfig: {
-        temperature: 0.9,
+        temperature: options.temperature,
         responseMimeType: "application/json",
-        responseSchema: {
-          type: "object",
-          properties: {
-            questions: {
-              type: "array",
-              items: { type: "string" },
-              maxItems: 5,
-            },
-          },
-          required: ["questions"],
-        },
+        responseSchema: options.responseSchema,
       },
     },
   );
@@ -106,10 +51,10 @@ export async function generateDiscussionQuestions(
     throw new Error("Gemini returned no text content");
   }
 
-  const parsed = questionsSchema.safeParse(JSON.parse(rawText));
+  const parsed = options.schema.safeParse(JSON.parse(rawText));
   if (!parsed.success) {
     throw new Error(`Gemini returned malformed JSON: ${parsed.error.message}`);
   }
 
-  return parsed.data.questions;
+  return parsed.data;
 }

--- a/netlify/functions/utils/providers/bookProvider.ts
+++ b/netlify/functions/utils/providers/bookProvider.ts
@@ -1,4 +1,8 @@
-import { isDefined, hasValue } from "../../../../lib/checks/checks.js";
+import {
+  hasElements,
+  isDefined,
+  hasValue,
+} from "../../../../lib/checks/checks.js";
 import { DetailedBookData } from "../../../../lib/types/book";
 import { WorkType } from "../../../../lib/types/generated/db";
 import { DetailedWorkData } from "../../../../lib/types/lists";
@@ -208,6 +212,40 @@ class BookProvider implements MediaProvider {
       map.set(row.external_id, data);
     }
     return map;
+  }
+
+  async getDiscussionPrompt(work: {
+    title: string;
+    externalId: string | null;
+  }): Promise<string> {
+    let authors: string[] = [];
+    let firstPublishYear: string | undefined;
+    if (hasValue(work.externalId)) {
+      const details = await db
+        .selectFrom("book_details")
+        .where("external_id", "=", work.externalId)
+        .select("first_publish_year")
+        .executeTakeFirst();
+      firstPublishYear = details?.first_publish_year ?? undefined;
+
+      const authorRows = await db
+        .selectFrom("book_authors")
+        .where("external_id", "=", work.externalId)
+        .select("author_name")
+        .execute();
+      authors = authorRows.map((row) => row.author_name);
+    }
+    const byline = hasElements(authors) ? ` by ${authors.join(" and ")}` : "";
+    const yearSuffix = hasValue(firstPublishYear)
+      ? ` (${firstPublishYear})`
+      : "";
+    return `Generate 3 to 5 discussion prompts for a book club discussing "${work.title}"${byline}${yearSuffix}. Every prompt must be specific to THIS book — naming its actual characters, plot points, themes, or passages — never a generic question that could apply to any book.
+
+Order the prompts by depth: the first should be casual and easy to answer — a low-stakes entry point. Each subsequent prompt should be more thought-provoking than the last, with the final one being substantial — a real book-club-worthy question.
+
+Whenever the book supports it, frame prompts as debates: questions with defensible answers on more than one side, designed to spark disagreement among friends rather than consensus. Keep each prompt succinct — one clear, concise question with no preamble.
+
+If you do not recognize this book or cannot confirm it is a real book, return 0 questions.`;
   }
 
   async refreshStaleDetails(limit: number): Promise<RefreshResult> {

--- a/netlify/functions/utils/providers/movieProvider.ts
+++ b/netlify/functions/utils/providers/movieProvider.ts
@@ -185,6 +185,31 @@ class MovieProvider implements MediaProvider {
     return map;
   }
 
+  async getDiscussionPrompt(work: {
+    title: string;
+    externalId: string | null;
+  }): Promise<string> {
+    let releaseYear: string | undefined;
+    if (hasValue(work.externalId)) {
+      const details = await db
+        .selectFrom("movie_details")
+        .where("external_id", "=", work.externalId)
+        .select("release_date")
+        .executeTakeFirst();
+      releaseYear = details?.release_date?.getFullYear().toString();
+    }
+    const label = hasValue(releaseYear)
+      ? `${work.title} (${releaseYear})`
+      : work.title;
+    return `Generate 3 to 5 discussion prompts for a movie club rewatching "${label}". Every prompt must be specific to THIS film — naming its actual characters, scenes, lines, or moments — never a generic question that could apply to any movie.
+
+Order the prompts by depth: the first should be casual and easy to answer — a low-stakes entry point. Each subsequent prompt should be more thought-provoking than the last, with the final one being substantial — a real book-club-worthy question, adapted for film.
+
+Whenever the film supports it, frame prompts as debates: questions with defensible answers on more than one side, designed to spark disagreement among friends rather than consensus. Keep each prompt succinct — one clear, concise question with no preamble.
+
+If you do not recognize this film or cannot confirm it is a real movie, return 0 questions.`;
+  }
+
   async refreshStaleDetails(limit: number): Promise<RefreshResult> {
     const stale = await db
       .selectFrom("movie_details")

--- a/netlify/functions/utils/providers/types.ts
+++ b/netlify/functions/utils/providers/types.ts
@@ -43,4 +43,15 @@ export interface MediaProvider {
    * collected rather than thrown so one bad id doesn't abort the batch.
    */
   refreshStaleDetails: (limit: number) => Promise<RefreshResult>;
+
+  /**
+   * Build the LLM prompt asking for discussion questions about one work,
+   * enriched with this provider's cached metadata (release year, authors, …).
+   * Callers pass the work's own row values, so the prompt is always built from
+   * server-resolved data — never from client input.
+   */
+  getDiscussionPrompt: (work: {
+    title: string;
+    externalId: string | null;
+  }) => Promise<string>;
 }

--- a/src/features/reviews/components/DiscussionQuestions.vue
+++ b/src/features/reviews/components/DiscussionQuestions.vue
@@ -100,7 +100,8 @@ import { useDiscussionQuestions } from "@/service/useDiscussionQuestions";
 const props = defineProps<{
   clubSlug: string;
   workId: string;
-  mediaNoun: "movie" | "book";
+  /** Singular media noun from the club-type registry ("movie", "book"). */
+  mediaNoun: string;
 }>();
 
 const { data, isFetching, isError, refetch } = useDiscussionQuestions(

--- a/src/features/reviews/components/DiscussionQuestions.vue
+++ b/src/features/reviews/components/DiscussionQuestions.vue
@@ -49,8 +49,8 @@
         class="flex flex-col gap-2"
       >
         <p class="text-sm text-red-400">
-          We couldn't recognize this movie, so we couldn't generate discussion
-          questions for it.
+          We couldn't recognize this {{ mediaNoun }}, so we couldn't generate
+          discussion questions for it.
         </p>
         <button
           class="ai-shimmer-button flex items-center justify-center gap-2 rounded-lg py-3 text-sm font-semibold text-white"
@@ -100,6 +100,7 @@ import { useDiscussionQuestions } from "@/service/useDiscussionQuestions";
 const props = defineProps<{
   clubSlug: string;
   workId: string;
+  mediaNoun: "movie" | "book";
 }>();
 
 const { data, isFetching, isError, refetch } = useDiscussionQuestions(

--- a/src/features/reviews/components/WorkDetailsContent.vue
+++ b/src/features/reviews/components/WorkDetailsContent.vue
@@ -392,8 +392,10 @@ import { computed, ref } from "vue";
 
 import DiscussionQuestions from "./DiscussionQuestions.vue";
 import { hasValue, isDefined } from "../../../../lib/checks/checks.js";
+import { ClubType } from "../../../../lib/types/generated/db";
 import { DetailedReviewListItem } from "../../../../lib/types/lists";
 
+import { clubTypeConfig } from "@/common/clubType";
 import BookMetadataGrid from "@/common/components/BookMetadataGrid.vue";
 import CastList from "@/common/components/CastList.vue";
 import CommentThread from "@/common/components/CommentThread.vue";
@@ -488,9 +490,9 @@ const cancelDateEdit = () => {
 const movieData = computed(() => asMovie(props.movie.original.externalData));
 const bookData = computed(() => asBook(props.movie.original.externalData));
 // Drives book/movie wording in child components (e.g. the discussion-questions
-// "couldn't recognize this ___" message). Mirrors the movieData/bookData split.
-const mediaNoun = computed<"movie" | "book">(() =>
-  isDefined(bookData.value) ? "book" : "movie",
+// "couldn't recognize this ___" message).
+const mediaNoun = computed(
+  () => clubTypeConfig(club.value?.type ?? ClubType.movie).noun,
 );
 const posterUrl = computed(() =>
   workPosterUrl(

--- a/src/features/reviews/components/WorkDetailsContent.vue
+++ b/src/features/reviews/components/WorkDetailsContent.vue
@@ -166,6 +166,7 @@
         v-if="discussionQuestionsEnabled"
         :club-slug="clubId"
         :work-id="movie.original.id"
+        :media-noun="mediaNoun"
       />
 
       <div
@@ -355,6 +356,7 @@
         v-if="discussionQuestionsEnabled"
         :club-slug="clubId"
         :work-id="movie.original.id"
+        :media-noun="mediaNoun"
       />
 
       <!-- Sticky action footer -->
@@ -485,6 +487,11 @@ const cancelDateEdit = () => {
 
 const movieData = computed(() => asMovie(props.movie.original.externalData));
 const bookData = computed(() => asBook(props.movie.original.externalData));
+// Drives book/movie wording in child components (e.g. the discussion-questions
+// "couldn't recognize this ___" message). Mirrors the movieData/bookData split.
+const mediaNoun = computed<"movie" | "book">(() =>
+  isDefined(bookData.value) ? "book" : "movie",
+);
 const posterUrl = computed(() =>
   workPosterUrl(
     props.movie.original.externalData,


### PR DESCRIPTION
## What

The AI discussion-questions feature was hardcoded for movies. This teaches it about book works, reusing the existing book data model end-to-end — **no schema migration needed** (`WorkType.book`, `book_details`, `book_authors` already exist).

A book club viewing a book review now gets book-appropriate prompts (resolved server-side from the work's title, author(s), and first-publish year), and the "couldn't recognize this ___" fallback reads naturally for books.

## How

Three backend seams + the UI string:

- **`gemini.ts`** — replaced the `(title, releaseYear)` signature with a discriminated union `DiscussionWork = MovieWork | BookWork`. The movie prompt is **byte-for-byte unchanged**; the book variant mirrors its structure (depth ordering, debate framing, succinctness, "return 0 if unrecognized" guard) with book-specific language and a `"Title" by Author (Year)` label.
- **`WorkRepository.getDiscussionContext`** — left-joins `book_details` (`first_publish_year`) and an `authors_agg` CTE (array-aggregating `book_authors`, same pattern `bookProvider` already uses), and selects `work.type` so the handler can branch. The two detail joins are safe because TMDB and OpenLibrary id namespaces are disjoint; `work.type` is the authoritative tiebreaker.
- **`reviews.ts`** — maps the resolved row to the correct `DiscussionWork` variant. Title/metadata stay server-resolved, so the prompt still can't be poisoned by client input.
- **`DiscussionQuestions.vue` / `WorkDetailsContent.vue`** — the one movie-specific UI string now interpolates a `mediaNoun` prop, derived from the same `bookData`/`movieData` split the component already uses.

## Notes

- The discriminated union makes the mapping type-safe: TS forces book fields when `type: "book"`, so a book can't fall through to a movie prompt.
- Requires `GEMINI_API_KEY` (Netlify-console secret), same as the existing movie path — unchanged.

## Testing

- `npm run type-check` — clean
- `npm run lint` — clean
- `npm test` — 106 passed (10 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)