### PR TITLE
Use current date as review date when moving an item into reviews

### DIFF
--- a/netlify/functions/repositories/ListRepository.ts
+++ b/netlify/functions/repositories/ListRepository.ts
@@ -180,6 +180,11 @@ class ListRepository {
    * The original "added by" user and "time added" are carried forward to the
    * destination so attribution survives a move rather than resetting to the
    * mover and the current time.
+   *
+   * Exception: the reviews system list reuses `time_added` as the "date
+   * reviewed", so a move into reviews must stamp the current time (the column
+   * default) rather than carry the source list's added-date forward, which
+   * would back-date the review.
    */
   async moveItem(
     sourceListId: string,
@@ -187,7 +192,7 @@ class ListRepository {
     workId: string,
   ) {
     return db.transaction().execute(async (trx) => {
-      const [max, source] = await Promise.all([
+      const [max, source, destination] = await Promise.all([
         trx
           .selectFrom("work_list_item")
           .where("list_id", "=", destinationListId)
@@ -201,7 +206,15 @@ class ListRepository {
           .where("work_id", "=", workId)
           .select(["added_by_user_id", "time_added"])
           .executeTakeFirst(),
+        trx
+          .selectFrom("work_list")
+          .where("id", "=", destinationListId)
+          .select("system_type")
+          .executeTakeFirst(),
       ]);
+
+      const isMoveIntoReviews =
+        destination?.system_type === WorkListSystemType.reviews;
 
       await trx
         .insertInto("work_list_item")
@@ -210,7 +223,7 @@ class ListRepository {
           work_id: workId,
           position: max.next_position,
           added_by_user_id: source?.added_by_user_id ?? null,
-          ...(isDefined(source?.time_added)
+          ...(isDefined(source?.time_added) && !isMoveIntoReviews
             ? { time_added: source.time_added }
             : {}),
         })


### PR DESCRIPTION
## Problem

Moving a movie from a watch list into **Reviews** carried the item's original *date added* forward and surfaced it as the *date reviewed*. So a movie added to the watch list months ago and reviewed today showed the old date as its review date.

## Root cause

[PR #377](https://github.com/Cobresun/movie-club/pull/377) made `ListRepository.moveItem` carry forward `time_added` to preserve add-date attribution when moving between user lists — correct for user→user moves.

But the reviews system list **overloads** `work_list_item.time_added` as the *date reviewed* (`ReviewRepository.getReviewList`, surfaced at `list.ts` as `createdDate`), and the "review this movie" action moves the item into the reviews list through the very same `moveItem`. So the carry-forward back-dated reviews.

## Fix

`moveItem` now also looks up the destination list's `system_type`. When the destination is the `reviews` system list, it omits `time_added` from the insert so the column's `DEFAULT now()` (migration `20240511_ListDateColumn.ts`) stamps the current time. User→user moves are unchanged — they still carry the original add-date forward.

## Testing

- `npm run type-check` — clean
- `eslint` on the changed file — clean

No backend test harness exists in this repo (tests live only under `src/`), so this was verified by tracing the data flow end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)