### PR TITLE
Fix missing padding between movies on shared watchlist page

### DIFF
--- a/src/features/watch-list/views/SharedListView.vue
+++ b/src/features/watch-list/views/SharedListView.vue
@@ -18,7 +18,7 @@
         description="This list is empty."
       />
 
-      <div v-else class="grid grid-cols-auto justify-items-center">
+      <div v-else class="grid grid-cols-auto justify-items-center gap-4">
         <div v-for="item in sortedItems" :key="item.id" class="relative">
           <div
             v-if="item.id === nextWorkId"


### PR DESCRIPTION
## Problem

On the shared watchlist page (`SharedListView.vue`), the movie poster cards were rendered flush against each other with no spacing between them.

## Cause

The poster grid was missing a `gap` utility:

```html
<div v-else class="grid grid-cols-auto justify-items-center">
```

The equivalent grid in the non-shared `ListItems.vue` component already uses `gap-4`, so the two views were inconsistent.

## Fix

Added `gap-4` to the grid to match the spacing used in `ListItems.vue`:

```html
<div v-else class="grid grid-cols-auto justify-items-center gap-4">
```

https://claude.ai/code/session_011CnDCg6qGFpyURGmBdgwUw

---
_Generated by [Claude Code](https://claude.ai/code/session_011CnDCg6qGFpyURGmBdgwUw)_