### PR TITLE
Fix delete confirmation modal showing 'Delete Review' for non-review lists

### DIFF
--- a/src/common/components/DeleteConfirmationModal.vue
+++ b/src/common/components/DeleteConfirmationModal.vue
@@ -31,9 +31,8 @@ withDefaults(
     message?: string;
   }>(),
   {
-    title: "Delete Review",
-    message:
-      "Are you sure you want to delete this review? This action cannot be undone.",
+    title: "Remove from List",
+    message: "Are you sure you want to remove this item from the list?",
   },
 );
 

--- a/src/features/reviews/components/WorkDetailsContent.vue
+++ b/src/features/reviews/components/WorkDetailsContent.vue
@@ -2,6 +2,8 @@
   <div class="flex-grow text-left">
     <delete-confirmation-modal
       :show="showDeleteConfirmation"
+      title="Delete Review"
+      message="Are you sure you want to delete this review? This action cannot be undone."
       @confirm="confirmDelete"
       @cancel="cancelDelete"
     />

--- a/src/features/reviews/views/ReviewView.vue
+++ b/src/features/reviews/views/ReviewView.vue
@@ -3,6 +3,8 @@
     <add-review-prompt v-if="modalOpen" @close="closePrompt" />
     <delete-confirmation-modal
       :show="!!reviewToDelete"
+      title="Delete Review"
+      message="Are you sure you want to delete this review? This action cannot be undone."
       @confirm="confirmDelete"
       @cancel="cancelDelete"
     />


### PR DESCRIPTION
When deleting a movie/book from a non-review list (e.g. watch list, reading list), the confirmation modal incorrectly said "Delete Review" / "Are you sure you want to delete this review?". This is confusing since those items are not reviews.

### Changes
- **DeleteConfirmationModal.vue** — Changed default  to "Remove from List" and  to "Are you sure you want to remove this item from the list?"
- **ReviewView.vue** — Passes explicit review-specific  and  props to preserve the original language for review deletion
- **WorkDetailsContent.vue** — Same explicit override for the review drawer\'s delete flow

CommentThread.vue already has its own custom props ("Delete Comment"), so it was unaffected.