### PR TITLE
Fix bottom sheet dismissal on iOS Chrome and via the back button

### DIFF
--- a/src/common/components/VBottomSheet.vue
+++ b/src/common/components/VBottomSheet.vue
@@ -6,7 +6,7 @@
       <div
         v-if="isVisible"
         ref="sheetRef"
-        class="fixed inset-x-0 bottom-0 max-h-[90vh] w-full overflow-y-auto rounded-t-2xl bg-background"
+        class="sheet fixed inset-x-0 bottom-0 w-full overflow-y-auto rounded-t-2xl bg-background"
         :class="[
           contentZIndexClass,
           {
@@ -38,6 +38,7 @@
 import { computed, ref } from "vue";
 
 import VBackdrop from "./VBackdrop.vue";
+import { useBackButtonClose } from "../composables/useBackButtonClose.js";
 import { useBodyScrollLock } from "../composables/useBodyScrollLock.js";
 
 type ZIndex = "40" | "50" | "60";
@@ -82,6 +83,9 @@ const handleClose = (immediate = false) => {
     isVisible.value = false;
   }
 };
+
+// Dismiss the sheet when the browser back button (or back gesture) is pressed.
+useBackButtonClose(() => handleClose());
 
 const touchStartY = ref<number | null>(null);
 const touchStartTime = ref<number | null>(null);
@@ -155,6 +159,16 @@ const sheetStyle = computed(() => {
 </script>
 
 <style scoped>
+.sheet {
+  /* Cap the sheet height so the grabber stays on screen. `dvh` tracks the
+     *visible* viewport, which matters on mobile browsers (notably Chrome/Safari
+     on iOS) where the address bar shrinks the visible area: plain `vh` resolves
+     to the larger toolbar-hidden viewport, pushing the grabber off the top of
+     the screen. `vh` is kept as a fallback for browsers without `dvh`. */
+  max-height: 90vh;
+  max-height: 90dvh;
+}
+
 .slide-up-enter-active,
 .slide-up-leave-active {
   transition: transform 200ms ease-in-out;

--- a/src/common/composables/useBackButtonClose.ts
+++ b/src/common/composables/useBackButtonClose.ts
@@ -1,0 +1,47 @@
+import { onMounted, onUnmounted } from "vue";
+
+/**
+ * Lets the browser back button (and the mobile back gesture) dismiss an overlay
+ * such as a bottom sheet or modal.
+ *
+ * On mount we push an extra history entry (keeping the same URL so no real
+ * navigation happens). Pressing back pops that entry and fires `popstate`,
+ * which we translate into a dismissal via `onDismiss`. When the overlay is
+ * closed by any other means (grabber, backdrop, escape, etc.), the pushed entry
+ * is removed on unmount so a later back press is not "swallowed" by a stale
+ * entry.
+ *
+ * @param onDismiss - Called when the back button should close the overlay.
+ *
+ * @example
+ * useBackButtonClose(() => handleClose());
+ */
+export function useBackButtonClose(onDismiss: () => void) {
+  // Whether our extra history entry is still on the stack and needs cleanup.
+  let pushed = false;
+
+  const onPopState = () => {
+    // The browser has already popped our entry, so don't pop it again on
+    // unmount — just dismiss the overlay.
+    pushed = false;
+    onDismiss();
+  };
+
+  onMounted(() => {
+    // Spread the existing state so vue-router's internal state is preserved,
+    // and omit the URL so the address bar (and current route) stay put.
+    window.history.pushState({ ...window.history.state, vOverlay: true }, "");
+    pushed = true;
+    window.addEventListener("popstate", onPopState);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener("popstate", onPopState);
+    if (pushed) {
+      pushed = false;
+      // Remove the entry we added so the back button isn't consumed by it after
+      // the overlay has already been dismissed some other way.
+      window.history.back();
+    }
+  });
+}

--- a/src/common/tests/VBottomSheet.spec.ts
+++ b/src/common/tests/VBottomSheet.spec.ts
@@ -1,0 +1,20 @@
+import VBottomSheet from "../components/VBottomSheet.vue";
+
+import { render } from "@/tests/utils";
+
+const sheet = () => document.querySelector(".rounded-t-2xl");
+
+describe("VBottomSheet", () => {
+  it("pushes a history entry when opened so the back button can dismiss it", () => {
+    const pushState = vi
+      .spyOn(window.history, "pushState")
+      .mockImplementation(() => {});
+
+    render(VBottomSheet);
+
+    expect(sheet()).toBeInTheDocument();
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    pushState.mockRestore();
+  });
+});

--- a/src/common/tests/useBackButtonClose.spec.ts
+++ b/src/common/tests/useBackButtonClose.spec.ts
@@ -1,0 +1,82 @@
+import { render } from "@testing-library/vue";
+import { defineComponent, h } from "vue";
+
+import { useBackButtonClose } from "../composables/useBackButtonClose";
+
+// Minimal host component so the composable runs inside a real mount/unmount
+// lifecycle. `onDismiss` is forwarded so each test can observe dismissals.
+const Harness = (onDismiss: () => void) =>
+  defineComponent({
+    setup() {
+      useBackButtonClose(onDismiss);
+      return () => h("div");
+    },
+  });
+
+describe("useBackButtonClose", () => {
+  // Mock the History API so tests never trigger real jsdom navigation (which
+  // would fire stray async popstate events that leak across tests).
+  let pushState: ReturnType<typeof vi.spyOn>;
+  let back: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    pushState = vi
+      .spyOn(window.history, "pushState")
+      .mockImplementation(() => {});
+    back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("pushes a history entry on mount without changing the URL", () => {
+    render(Harness(vi.fn()));
+
+    expect(pushState).toHaveBeenCalledTimes(1);
+    // Pushed with our overlay marker and an empty title, and no URL argument so
+    // the address bar / current route is left untouched.
+    expect(pushState).toHaveBeenCalledWith(
+      expect.objectContaining({ vOverlay: true }),
+      "",
+    );
+  });
+
+  it("calls onDismiss when the back button (popstate) fires", () => {
+    const onDismiss = vi.fn();
+    render(Harness(onDismiss));
+
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("pops the pushed entry on unmount when closed another way", () => {
+    const view = render(Harness(vi.fn()));
+
+    view.unmount();
+
+    expect(back).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not pop history again after a back-button dismissal", () => {
+    const view = render(Harness(vi.fn()));
+
+    // The browser already consumed our entry via popstate...
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    view.unmount();
+
+    // ...so we must not call history.back() a second time.
+    expect(back).not.toHaveBeenCalled();
+  });
+
+  it("stops responding to popstate after unmount", () => {
+    const onDismiss = vi.fn();
+    const view = render(Harness(onDismiss));
+    view.unmount();
+
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Two issues with bottom sheets:

1. **iOS Chrome:** Bottom sheets appeared to expand to full screen and couldn't be dismissed — the grabber at the top was missing. The sheet capped its height with `max-h-[90vh]`. On mobile browsers (notably Chrome/Safari on iOS), `vh` resolves to the *larger* toolbar-hidden viewport, so a tall sheet anchored to `bottom-0` pushed its top — where the grabber lives — up behind the browser chrome / off the top of the screen, leaving no way to dismiss it.

2. **All browsers:** Pressing the browser back button (or using the mobile back gesture) did not dismiss an open bottom sheet.

## Changes

- **Viewport height fix:** `VBottomSheet` now caps its height with `dvh` (dynamic viewport height), which tracks the *visible* viewport, with `vh` kept as a fallback for older browsers. This keeps the grabber on screen on iOS.

- **Back-button dismissal:** New `useBackButtonClose` composable pushes a history entry when the overlay opens and closes it on `popstate`, so the back button / back gesture dismisses open bottom sheets in all browsers. The pushed entry is kept in sync — it's removed on unmount when the sheet is closed by any other means (grabber, backdrop, escape, Cancel/Apply), so the back button is never "swallowed" by a stale entry. The current URL and vue-router's history state are left untouched (we push with the same URL and spread the existing state).

This covers every bottom sheet, including the ones rendered through `VModal`'s mobile path, since both share `VBottomSheet`.

## Testing

- New `useBackButtonClose.spec.ts` covers the full composable contract (push on open, dismiss on popstate, cleanup on unmount, no double-pop, listener removal).
- New `VBottomSheet.spec.ts` verifies the back-button behaviour is wired up when a sheet opens.
- Full suite passes (112 tests), type-check and lint clean.

https://claude.ai/code/session_0123LXUbpBQD1YXLvrqDtkk1

---
_Generated by [Claude Code](https://claude.ai/code/session_0123LXUbpBQD1YXLvrqDtkk1)_