### PR TITLE
Add highest-rated-by-year statistics widget

### DIFF
--- a/src/features/statistics/components/HighestRatedByYearWidget.vue
+++ b/src/features/statistics/components/HighestRatedByYearWidget.vue
@@ -1,0 +1,61 @@
+<template>
+  <WidgetShell v-if="entries.length > 0" title="Highest Rated by Year">
+    <p class="-mt-2 mb-4 text-sm text-slate-400">
+      The top-rated movie your club watched each year.
+    </p>
+    <div class="space-y-2">
+      <div
+        v-for="entry in entries"
+        :key="entry.year"
+        class="flex items-center gap-3 rounded-lg border border-slate-700/30 bg-background/50 px-3 py-2.5"
+      >
+        <span class="w-12 shrink-0 text-lg font-bold text-primary">
+          {{ entry.year }}
+        </span>
+        <img
+          v-if="entry.imageUrl"
+          :src="entry.imageUrl"
+          :alt="entry.title"
+          class="h-14 w-10 shrink-0 rounded object-cover"
+        />
+        <div
+          v-else
+          class="flex h-14 w-10 shrink-0 items-center justify-center rounded bg-slate-700/50 text-xs text-slate-500"
+        >
+          ?
+        </div>
+        <div class="min-w-0 flex-1">
+          <p
+            class="w-fit max-w-full truncate text-sm font-medium text-white"
+            :title="entry.title"
+          >
+            {{ entry.title }}
+          </p>
+          <p class="mt-1 text-xs text-slate-400">
+            {{ entry.movieCount }}
+            {{ entry.movieCount === 1 ? "movie" : "movies" }} watched
+          </p>
+        </div>
+        <span
+          class="shrink-0 rounded-full bg-green-900/30 px-2.5 py-1 text-sm font-bold text-green-400"
+        >
+          {{ entry.average.toFixed(1) }}
+        </span>
+      </div>
+    </div>
+  </WidgetShell>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+import WidgetShell from "./WidgetShell.vue";
+import { computeHighestRatedByYear } from "../statsComputers";
+import type { MovieData } from "../types";
+
+const props = defineProps<{
+  movieData: MovieData[];
+}>();
+
+const entries = computed(() => computeHighestRatedByYear(props.movieData));
+</script>

--- a/src/features/statistics/statsComputers.ts
+++ b/src/features/statistics/statsComputers.ts
@@ -5,6 +5,7 @@ import type {
   GenreStats,
   GenreWatchCount,
   GuiltyPleasureEntry,
+  HighestRatedByYearEntry,
   MemberLeaderboardEntry,
   MemberPairSimilarity,
   MovieData,
@@ -653,4 +654,45 @@ export function computeDecadeStats(
       count: data.count,
     }))
     .sort((a, b) => a.decade.localeCompare(b.decade));
+}
+
+export function computeHighestRatedByYear(
+  movieData: MovieData[],
+): HighestRatedByYearEntry[] {
+  const yearGroups = new Map<
+    number,
+    { best: MovieData | null; count: number }
+  >();
+
+  for (const movie of movieData) {
+    if (!hasValue(movie.createdDate)) continue;
+
+    const watchedDate = new Date(movie.createdDate);
+    if (isNaN(watchedDate.getTime())) continue;
+
+    const year = watchedDate.getFullYear();
+    const group = yearGroups.get(year);
+    if (isDefined(group)) {
+      group.count++;
+      if (!isDefined(group.best) || movie.average > group.best.average) {
+        group.best = movie;
+      }
+    } else {
+      yearGroups.set(year, { best: movie, count: 1 });
+    }
+  }
+
+  const entries: HighestRatedByYearEntry[] = [];
+  for (const [year, group] of yearGroups) {
+    if (!isDefined(group.best)) continue;
+    entries.push({
+      year,
+      title: group.best.title,
+      imageUrl: group.best.imageUrl,
+      average: Math.round(group.best.average * 100) / 100,
+      movieCount: group.count,
+    });
+  }
+
+  return entries.sort((a, b) => b.year - a.year);
 }

--- a/src/features/statistics/tests/statsComputers.test.ts
+++ b/src/features/statistics/tests/statsComputers.test.ts
@@ -5,6 +5,7 @@ import type { DetailedMovieData } from "../../../../lib/types/movie";
 import {
   computeGenreStats,
   computeGuiltyPleasures,
+  computeHighestRatedByYear,
   computeMemberLeaderboard,
   computeScoreVariance,
   computeTasteSimilarity,
@@ -864,5 +865,81 @@ describe("computeScoreVariance", () => {
         points[i - 1].date.getTime(),
       );
     }
+  });
+});
+
+// ---------- computeHighestRatedByYear ----------
+
+describe("computeHighestRatedByYear", () => {
+  it("returns an empty array for an empty movie list", () => {
+    expect(computeHighestRatedByYear([])).toEqual([]);
+  });
+
+  it("picks the highest-rated movie for each watched year", () => {
+    const movies = [
+      makeMovie({
+        title: "2023 Low",
+        average: 5,
+        createdDate: "2023-03-01T00:00:00.000Z",
+      }),
+      makeMovie({
+        title: "2023 High",
+        average: 9,
+        createdDate: "2023-08-01T00:00:00.000Z",
+      }),
+      makeMovie({
+        title: "2024 Only",
+        average: 6,
+        createdDate: "2024-01-15T00:00:00.000Z",
+      }),
+    ];
+
+    const result = computeHighestRatedByYear(movies);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      year: 2024,
+      title: "2024 Only",
+      average: 6,
+      movieCount: 1,
+    });
+    expect(result[1]).toMatchObject({
+      year: 2023,
+      title: "2023 High",
+      average: 9,
+      movieCount: 2,
+    });
+  });
+
+  it("sorts results by year descending", () => {
+    const movies = [
+      makeMovie({ createdDate: "2021-01-01T00:00:00.000Z" }),
+      makeMovie({ createdDate: "2025-01-01T00:00:00.000Z" }),
+      makeMovie({ createdDate: "2023-01-01T00:00:00.000Z" }),
+    ];
+
+    const years = computeHighestRatedByYear(movies).map((e) => e.year);
+
+    expect(years).toEqual([2025, 2023, 2021]);
+  });
+
+  it("skips movies with an invalid watched date", () => {
+    const movies = [
+      makeMovie({ title: "Valid", createdDate: "2024-01-01T00:00:00.000Z" }),
+      makeMovie({ title: "Invalid", createdDate: "not-a-date" }),
+    ];
+
+    const result = computeHighestRatedByYear(movies);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Valid");
+  });
+
+  it("rounds the average to two decimals", () => {
+    const movies = [
+      makeMovie({ average: 8.126, createdDate: "2024-01-01T00:00:00.000Z" }),
+    ];
+
+    expect(computeHighestRatedByYear(movies)[0].average).toBe(8.13);
   });
 });

--- a/src/features/statistics/types.ts
+++ b/src/features/statistics/types.ts
@@ -73,6 +73,14 @@ export interface ClubConsensusEntry {
   scores: { name: string; score: number }[];
 }
 
+export interface HighestRatedByYearEntry {
+  year: number;
+  title: string;
+  imageUrl: string | undefined;
+  average: number;
+  movieCount: number;
+}
+
 export interface ScoreTrendPoint {
   date: Date;
   movieTitle: string;

--- a/src/features/statistics/views/InsightsView.vue
+++ b/src/features/statistics/views/InsightsView.vue
@@ -11,6 +11,7 @@
     <GenreStatsWidget :movie-data="movieData" :members="members" />
     <GenreWatchCountWidget :movie-data="movieData" />
     <DecadeStatsWidget :movie-data="movieData" :members="members" />
+    <HighestRatedByYearWidget :movie-data="movieData" />
     <ReviewerLeaderboardWidget
       v-if="members.length > 1"
       :movie-data="movieData"
@@ -45,6 +46,7 @@ import DecadeStatsWidget from "../components/DecadeStatsWidget.vue";
 import GenreStatsWidget from "../components/GenreStatsWidget.vue";
 import GenreWatchCountWidget from "../components/GenreWatchCountWidget.vue";
 import GuiltyPleasuresWidget from "../components/GuiltyPleasuresWidget.vue";
+import HighestRatedByYearWidget from "../components/HighestRatedByYearWidget.vue";
 import LeaderboardsWidget from "../components/LeaderboardsWidget.vue";
 import ReviewerLeaderboardWidget from "../components/ReviewerLeaderboardWidget.vue";
 import ScoreDistributionWidget from "../components/ScoreDistributionWidget.vue";


### PR DESCRIPTION
## Summary

Adds a **Highest Rated by Year** widget to the club statistics insights view. For each year the club watched/reviewed movies, it surfaces the single highest-rated movie (by club average), along with how many movies were watched that year. Years are listed most-recent-first.

## Changes

- **`statsComputers.ts`** — new `computeHighestRatedByYear` computer that groups movies by the year of their `createdDate` (watched/reviewed date), picks the highest-average movie per year, and returns entries sorted by year descending.
- **`types.ts`** — new `HighestRatedByYearEntry` type.
- **`HighestRatedByYearWidget.vue`** — new widget rendering one row per year (year, poster, title, movies-watched count, and the average score badge), following the existing list-widget styling (e.g. `ClubConsensusWidget`). Hidden when there is no data.
- **`InsightsView.vue`** — renders the new widget after `DecadeStatsWidget`.
- **Tests** — added a `computeHighestRatedByYear` describe block covering year grouping, per-year max selection, descending sort, invalid-date skipping, and average rounding.

## Verification

- `npm run type-check` ✅
- `npx eslint` on changed files ✅
- `npx vitest run` on the statistics test file ✅ (55 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QY9CLDHuci5t3ZmQ96spG3)_