### PR TITLE
Remove scroll bar from filter pills

### DIFF
--- a/src/common/components/SearchFilterBar.vue
+++ b/src/common/components/SearchFilterBar.vue
@@ -26,7 +26,7 @@
     <!-- Available filter options as pills -->
     <PopoverGroup
       as="div"
-      class="scrollbar-hide relative mt-2 flex w-full flex-nowrap gap-2 overflow-x-auto md:flex-wrap md:justify-center"
+      class="relative mt-2 flex w-full flex-wrap justify-center gap-2"
     >
       <template v-for="opt in FILTER_OPTIONS" :key="opt.key">
         <!-- Applied filter pill (clickable to remove) -->
@@ -353,13 +353,3 @@ onUnmounted(() => {
   window.removeEventListener("resize", syncTeleportedPanelPosition);
 });
 </script>
-
-<style scoped>
-.scrollbar-hide {
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
-}
-.scrollbar-hide::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Opera */
-}
-</style>


### PR DESCRIPTION
## Summary

Gets rid of the scroll bar on the filter pills in `SearchFilterBar.vue`.

Previously the pill row used `flex-nowrap` + `overflow-x-auto` on mobile (so pills scrolled horizontally) and only wrapped on desktop (`md:flex-wrap`). A `scrollbar-hide` CSS hack was used to mask the resulting scroll bar.

Now the pills simply wrap on all viewports (`flex-wrap justify-center`), so there's no overflow container to render a scroll bar at all. The now-unused `scrollbar-hide` style block has been removed.

## Changes

- `src/common/components/SearchFilterBar.vue`: replace `flex-nowrap gap-2 overflow-x-auto md:flex-wrap md:justify-center` + `scrollbar-hide` with `flex-wrap justify-center gap-2`, and drop the unused `scrollbar-hide` scoped CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgusquQWdjZM7MRzmcjA3b)_