### PR TITLE
Migrate shared dev database on production deploys

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -43,6 +43,8 @@ Always validate schema migrations against a **freshly spawned dev database**, ne
 
 **Why this matters — blast radius of shared `dev`.** The Netlify `preview-database` plugin (`netlify/plugins/preview-database/index.js`) points every PR that *does not* change migrations straight at shared `dev`. So if you run `migrate:dev` with `.env` still pointing at `postgresql://.../dev`, you rewrite the schema underneath every other open PR's deploy preview at once — their code still expects the old schema and their previews 500 until the migration is reverted on shared `dev` and the previews are rebuilt. The spawn-first rule isn't about cleanliness; it's the only thing that keeps this blast radius from firing.
 
+**After a migration merges, shared `dev` syncs automatically.** The `preview-database` plugin's `onSuccess` hook runs the schema migrator against shared `dev` on every *production* deploy (i.e. every merge to `main`), so `dev` tracks `main` without anyone running `migrate:dev` by hand. This closes the old gap where a merged migration reached prod but not `dev`, leaving every non-migration preview 500ing on the new column. The sync is non-fatal (a failure warns but does not fail the deploy) and a no-op when `dev` is already current. You should therefore only need to run `npm run migrate:dev` against shared `dev` yourself as a **fallback** — when the deploy hook failed, or to apply a migration before it has merged (which the guard rail blocks unless it is already on `origin/main`).
+
 ```bash
 # 1. Spawn a fresh DB from the latest snapshot. Names must use only
 #    lowercase letters, numbers, and underscores — hyphens are rejected.

--- a/netlify/plugins/preview-database/index.js
+++ b/netlify/plugins/preview-database/index.js
@@ -414,4 +414,84 @@ const onPreBuild = async ({ utils, inputs }) => {
   }
 };
 
-export { onPreBuild };
+/**
+ * After a successful production deploy, advance the shared `dev` database to
+ * the latest schema.
+ *
+ * The production build already migrates the *production* database (via
+ * `npm run migrate`), and migration-carrying deploy previews migrate their own
+ * spawned `pr_<id>` database. But nothing keeps shared `dev` — the database
+ * every *non-migration* deploy preview (and local development) points at — in
+ * sync with `main`. Without this hook `dev` silently falls a migration behind
+ * on every merge until someone runs `migrate:dev` by hand, and until they do,
+ * every non-migration preview 500s on the newly-required column.
+ *
+ * This is deliberately non-fatal: production is already migrated by the build
+ * step, so a failure here must not fail an otherwise-successful deploy. A stale
+ * `dev` only affects preview/local environments and is recoverable with
+ * `npm run migrate:dev`. We therefore log loudly and return rather than
+ * `failBuild`. The migrator itself is safe to run on every production deploy:
+ * when `dev` is already current it is a no-op, and its built-in guard only
+ * blocks migrations that are not on `origin/main` (never the case on a `main`
+ * build).
+ *
+ * @param {PluginContext} context
+ * @returns {void}
+ */
+const onSuccess = ({ inputs }) => {
+  const { CONTEXT } = process.env;
+
+  if (CONTEXT !== "production") {
+    return;
+  }
+
+  const rootUrl = process.env.DATABASE_URL_ROOT;
+  if (!hasValue(rootUrl)) {
+    console.warn(
+      "Warning: DATABASE_URL_ROOT not set; skipping shared dev migration sync",
+    );
+    return;
+  }
+
+  const sourceDb = hasValue(inputs.sourceDatabase)
+    ? inputs.sourceDatabase
+    : "dev";
+
+  const url = new URL(rootUrl);
+  url.pathname = `/${sourceDb}`;
+  const devDatabaseUrl = url.toString();
+
+  console.log(
+    `\n🔄 Syncing schema migrations to shared ${sourceDb} database...`,
+  );
+
+  try {
+    const scriptPath = path.join(
+      process.cwd(),
+      "migrations",
+      "schemaMigrator.ts",
+    );
+
+    // Stream the migrator's output straight to the build log so its progress
+    // (and any failure detail) is visible without re-capturing it here.
+    execSync(`npx tsx ${scriptPath}`, {
+      stdio: "inherit",
+      env: { ...process.env, DATABASE_URL: devDatabaseUrl },
+    });
+
+    console.log(`✓ Shared ${sourceDb} database is up to date\n`);
+  } catch (error) {
+    // Non-fatal: production is already migrated by the build step, so a failure
+    // here must not fail the deploy. A stale `dev` only affects preview/local
+    // environments and is recoverable with `npm run migrate:dev`.
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `⚠️  Failed to sync migrations to the shared ${sourceDb} database: ${message}`,
+    );
+    console.warn(
+      "   Production is unaffected. Run `npm run migrate:dev` to sync manually.",
+    );
+  }
+};
+
+export { onPreBuild, onSuccess };


### PR DESCRIPTION
## Problem

Migrations already run automatically on deploy (`npm run build` starts with `npm run migrate`), but the `preview-database` plugin decides *which* database each deploy targets, and **nothing ever migrates the shared `dev` database**:

| Deploy context | `npm run migrate` targets |
|---|---|
| Production (merge to `main`) | prod DB ✅ |
| Migration-carrying PR preview | its spawned `pr_<id>` DB ✅ |
| Non-migration PR preview | shared `dev` — **no migration runs** |

Shared `dev` is what every *non-migration* deploy preview (and local development via `.env`) points at. So the moment a migration merges to `main`, `dev` is a migration behind, and every non-migration preview 500s on the newly-required column until a human runs `npm run migrate:dev` by hand.

This just bit us: after #386 (`Add character names to movie cast`) merged, `GET /list/reviews` threw `column "character_name" does not exist` on `dev` and every preview built against it.

## Fix

Add an `onSuccess` hook to the `preview-database` plugin that, **on production deploys only**, runs the schema migrator against the shared `dev` database — the same trigger that already keeps prod in sync. `dev` now advances in lockstep with `main` on every merge, closing the drift window entirely.

Design points:
- **Non-fatal.** Production is already migrated by the build step, so a failure syncing `dev` logs a warning rather than failing an otherwise-successful deploy.
- **Safe to run on every production deploy.** When `dev` is already current the migrator is a no-op; it does not need to be gated to migration-carrying merges.
- **Reuses the existing guard rail.** `schemaMigrator.ts`'s `assertSafeToMigrate` only blocks migrations not on `origin/main` — never the case on a `main` build — so it passes cleanly here.
- **Observable.** Uses `stdio: "inherit"` so the migrator's output streams into the Netlify build log.

## Testing

Drove the exported `onSuccess` against the real `dev` database:
- `CONTEXT=deploy-preview` → returns immediately, migrator never invoked.
- `CONTEXT=production` → derives the `/dev` URL from `DATABASE_URL_ROOT`, runs the migrator, guard rail passes, no pending migrations → clean idempotent no-op.

Lint passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)