### PR TITLE
Motion system foundation: tokens, reduced-motion, redesigned route transitions

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -37,7 +37,6 @@
         "npm:@vue/eslint-config-prettier@^10.2.0",
         "npm:@vue/eslint-config-typescript@^14.6.0",
         "npm:ag-charts-vue3@^11.3.2",
-        "npm:animate.css@^4.1.1",
         "npm:autoprefixer@^10.4.23",
         "npm:axios@^1.16.0",
         "npm:bcrypt@6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@tanstack/vue-query": "^4.41.0",
         "@tanstack/vue-table": "^8.21.3",
         "ag-charts-vue3": "^11.3.2",
-        "animate.css": "^4.1.1",
         "axios": "^1.16.0",
         "bcrypt": "^6.0.0",
         "better-auth": "^1.6.11",
@@ -2855,12 +2854,6 @@
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.1.tgz",
       "integrity": "sha512-ogkIWbVrLwKtHY6oOAXaYkAxP+cTH7V5FZ5+Tm4NZFd8VDZ6uNMDrfzqctTZ42eTMCSR3ne3otpcxmqSnFfPYA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/animate.css": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
-      "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ==",
       "license": "MIT"
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@tanstack/vue-query": "^4.41.0",
     "@tanstack/vue-table": "^8.21.3",
     "ag-charts-vue3": "^11.3.2",
-    "animate.css": "^4.1.1",
     "axios": "^1.16.0",
     "bcrypt": "^6.0.0",
     "better-auth": "^1.6.11",

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,13 +12,8 @@
         <loading-spinner />
       </div>
     </div>
-    <router-view v-else v-slot="{ Component, route }">
-      <component :is="Component" v-if="isSafari" class="absolute w-full" />
-      <transition
-        v-else
-        :enter-active-class="route.meta.transitionIn"
-        :leave-active-class="route.meta.transitionOut"
-      >
+    <router-view v-else v-slot="{ Component }">
+      <transition name="route">
         <component :is="Component" class="absolute w-full" />
       </transition>
     </router-view>
@@ -32,15 +27,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
-
 import AuthModal from "@/common/components/AuthModal.vue";
 import NavBar from "@/common/components/NavBar.vue";
 import { useAuthStore } from "@/stores/auth";
 
 const authStore = useAuthStore();
-
-const isSafari = computed(() => {
-  return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-});
 </script>

--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -4,6 +4,77 @@
 
 @tailwind utilities;
 
+/* Motion tokens — the single source of truth for animation timing.
+   Exposed as Tailwind utilities (duration-fast, ease-standard, ...) via
+   tailwind.config.cjs, and consumed directly in SFC <style> via var(). */
+:root {
+  --motion-fast: 150ms; /* micro-interactions: press, hover, inline swaps */
+  --motion-base: 200ms; /* fades: backdrops, modals, list enter/leave */
+  --motion-slow: 300ms; /* spatial overlays: drawers, sheets, reveals */
+  --motion-page: 350ms; /* route transitions */
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --ease-emphasized: cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+/* Reduced-motion layer: durations collapse to near-zero rather than
+   `animation: none` so transitions still COMPLETE — overlay dismissal
+   (VModal/VBottomSheet/VSideDrawer) relies on @after-leave firing. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Route transitions: iOS-style parallax push/pop — the incoming-from-the-right
+   page always renders on top while the underlying page moves 30% and dims.
+
+   The direction lives in a `data-route-transition` attribute on <html> (set in
+   router/index.ts beforeEach) rather than in the <transition> name: a leaving
+   element keeps the transition props captured when it was RENDERED, so a
+   dynamic :name can never change the exit animation of the page it removes.
+   Attribute selectors are resolved live, so both pages always agree on the
+   direction. No attribute value ("none") means no transition rules match and
+   Vue ends the transition immediately. */
+html[data-route-transition="fade"] .route-enter-active {
+  transition: opacity var(--motion-base) var(--ease-standard);
+}
+html[data-route-transition="fade"] .route-leave-active {
+  display: none;
+}
+html[data-route-transition="fade"] .route-enter-from {
+  opacity: 0;
+}
+
+html[data-route-transition="push"] .route-enter-active,
+html[data-route-transition="push"] .route-leave-active,
+html[data-route-transition="pop"] .route-enter-active,
+html[data-route-transition="pop"] .route-leave-active {
+  transition:
+    transform var(--motion-page) var(--ease-emphasized),
+    opacity var(--motion-page) var(--ease-emphasized);
+}
+html[data-route-transition="push"] .route-leave-active,
+html[data-route-transition="pop"] .route-enter-active {
+  z-index: -1;
+}
+html[data-route-transition="push"] .route-enter-from {
+  transform: translateX(100%);
+}
+html[data-route-transition="push"] .route-leave-to,
+html[data-route-transition="pop"] .route-enter-from {
+  transform: translateX(-30%);
+  opacity: 0.4;
+}
+html[data-route-transition="pop"] .route-leave-to {
+  transform: translateX(100%);
+}
+
 html {
   font-family: "Poppins", sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/src/augmentations.d.ts
+++ b/src/augmentations.d.ts
@@ -5,8 +5,6 @@ export {};
 declare module "vue-router" {
   interface RouteMeta {
     depth: number;
-    transitionIn?: string;
-    transitionOut?: string;
   }
 }
 

--- a/src/common/components/CastAvatar.vue
+++ b/src/common/components/CastAvatar.vue
@@ -9,7 +9,7 @@
       :src="src"
       :alt="name"
       decoding="async"
-      class="h-full w-full rounded-full object-cover transition-opacity duration-300"
+      class="h-full w-full rounded-full object-cover transition-opacity duration-slow ease-standard"
       :class="loaded ? 'opacity-100' : 'opacity-0'"
       @load="loaded = true"
       @error="errored = true"

--- a/src/common/components/EmptyState.vue
+++ b/src/common/components/EmptyState.vue
@@ -15,7 +15,7 @@ const emit = defineEmits<{
 
 <template>
   <div
-    class="flex flex-col items-center justify-center px-8 py-16 text-center transition-opacity duration-300 ease-in-out md:py-24"
+    class="flex flex-col items-center justify-center px-8 py-16 text-center transition-opacity duration-slow ease-standard md:py-24"
   >
     <h2 class="mb-3 text-2xl font-bold text-white">{{ title }}</h2>
     <p class="mb-6 max-w-md text-base text-gray-400">{{ description }}</p>

--- a/src/common/components/PosterImage.vue
+++ b/src/common/components/PosterImage.vue
@@ -9,7 +9,7 @@
       :alt="alt"
       decoding="async"
       loading="eager"
-      class="h-full w-full object-cover transition-opacity duration-300"
+      class="h-full w-full object-cover transition-opacity duration-slow ease-standard"
       :class="loaded ? 'opacity-100' : 'opacity-0'"
       @load="loaded = true"
     />

--- a/src/common/components/SharedPageCtaBanner.vue
+++ b/src/common/components/SharedPageCtaBanner.vue
@@ -2,7 +2,7 @@
   <div v-if="!isLoggedIn">
     <div class="h-20" />
     <div
-      class="fixed inset-x-0 bottom-0 px-4 pb-4 transition-transform duration-300"
+      class="fixed inset-x-0 bottom-0 px-4 pb-4 transition-transform duration-slow ease-emphasized"
       :class="{ 'translate-y-[150%]': isScrollingDown }"
     >
       <div

--- a/src/common/components/VBackdrop.vue
+++ b/src/common/components/VBackdrop.vue
@@ -36,7 +36,7 @@ const handleClose = () => {
 /* Fade transition for backdrop */
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 200ms ease-in-out;
+  transition: opacity var(--motion-base) var(--ease-standard);
 }
 
 .fade-enter-from,

--- a/src/common/components/VBottomSheet.vue
+++ b/src/common/components/VBottomSheet.vue
@@ -10,7 +10,7 @@
         :class="[
           contentZIndexClass,
           {
-            'transition-transform duration-200 ease-in-out': !isDragging,
+            'transition-transform duration-slow ease-emphasized': !isDragging,
           },
         ]"
         :style="sheetStyle"
@@ -171,7 +171,7 @@ const sheetStyle = computed(() => {
 
 .slide-up-enter-active,
 .slide-up-leave-active {
-  transition: transform 200ms ease-in-out;
+  transition: transform var(--motion-slow) var(--ease-emphasized);
 }
 
 .slide-up-enter-from,

--- a/src/common/components/VBtn.vue
+++ b/src/common/components/VBtn.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="rounded-md text-center text-base font-bold tracking-wide text-text filter duration-150"
+    class="rounded-md text-center text-base font-bold tracking-wide text-text filter duration-fast ease-standard"
     :class="{
       'bg-gray-600': disabled,
       'cursor-pointer bg-primary hover:brightness-110 active:brightness-105':

--- a/src/common/components/VModal.vue
+++ b/src/common/components/VModal.vue
@@ -98,7 +98,7 @@ const zIndexClass = computed(() =>
 <style scoped>
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 200ms ease-in-out;
+  transition: opacity var(--motion-base) var(--ease-standard);
 }
 
 .fade-enter-from,

--- a/src/common/components/VSelect.vue
+++ b/src/common/components/VSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <select
     v-model="value"
-    class="mb-2 mr-4 cursor-pointer rounded-md bg-primary px-2 py-1 text-center text-base font-bold tracking-wide text-text filter duration-150 hover:brightness-110 active:brightness-105"
+    class="mb-2 mr-4 cursor-pointer rounded-md bg-primary px-2 py-1 text-center text-base font-bold tracking-wide text-text filter duration-fast ease-standard hover:brightness-110 active:brightness-105"
   >
     <option v-for="item in items" :key="item" :value="item">
       {{ item }}

--- a/src/common/components/VSideDrawer.vue
+++ b/src/common/components/VSideDrawer.vue
@@ -61,7 +61,7 @@ onBeforeUnmount(() => {
 <style scoped>
 .slide-in-right-enter-active,
 .slide-in-right-leave-active {
-  transition: transform 280ms cubic-bezier(0.32, 0.72, 0, 1);
+  transition: transform var(--motion-slow) var(--ease-emphasized);
 }
 
 .slide-in-right-enter-from,

--- a/src/common/components/VSwitch.vue
+++ b/src/common/components/VSwitch.vue
@@ -5,7 +5,7 @@
     @click="!disabled && emit('update:model-value', !modelValue)"
   >
     <div
-      class="relative h-[22px] w-11 rounded-full py-0.5 pl-1 transition-colors duration-200"
+      class="relative h-[22px] w-11 rounded-full py-0.5 pl-1 transition-colors duration-base ease-standard"
       :class="{
         'bg-gray-600': !modelValue,
         'bg-primary': modelValue && color === 'primary',
@@ -13,7 +13,7 @@
       }"
     >
       <div
-        class="h-[18px] w-[18px] transform rounded-full bg-white shadow transition-transform duration-200"
+        class="h-[18px] w-[18px] transform rounded-full bg-white shadow transition-transform duration-base ease-standard"
         :class="{ 'translate-x-full': modelValue }"
       ></div>
     </div>

--- a/src/common/components/WorkDescription.vue
+++ b/src/common/components/WorkDescription.vue
@@ -3,7 +3,7 @@
     <!-- Visible text with conditional truncation -->
     <p
       ref="descriptionRef"
-      class="text-sm text-gray-300 transition-all duration-300 ease-in-out"
+      class="text-sm text-gray-300 transition-all duration-slow ease-standard"
       :class="{
         'line-clamp-2': !isDescriptionExpanded,
       }"

--- a/src/common/components/WorkSearchCard.vue
+++ b/src/common/components/WorkSearchCard.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="mb-4 w-32 rounded-lg text-left transition-all duration-100 hover:ring-2 hover:ring-primary"
+    class="mb-4 w-32 rounded-lg text-left transition-all duration-fast ease-standard hover:ring-2 hover:ring-primary"
     @click="emit('select')"
   >
     <div class="flex h-full flex-col rounded-lg bg-slate-700">

--- a/src/features/awards/components/AwardRanking.vue
+++ b/src/features/awards/components/AwardRanking.vue
@@ -5,7 +5,7 @@
   </div>
   <transition-group
     tag="div"
-    move-class="transition ease-linear duration-300"
+    move-class="transition duration-slow ease-emphasized"
     class="grid grid-cols-auto"
   >
     <WorkPosterCard

--- a/src/features/awards/components/AwardResult.vue
+++ b/src/features/awards/components/AwardResult.vue
@@ -6,7 +6,7 @@
   <transition-group
     tag="div"
     enter-from-class="h-0"
-    enter-active-class="transition-[height] ease-linear duration-500 overflow-hidden"
+    enter-active-class="transition-[height] ease-standard duration-500 overflow-hidden"
     enter-to-class="h-96"
   >
     <div v-if="showResult" class="grid grid-cols-auto">

--- a/src/features/clubs/components/MenuCard.vue
+++ b/src/features/clubs/components/MenuCard.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="w-full rounded-xl p-2 text-base tracking-wide duration-150 hover:brightness-105 active:brightness-110 md:p-3 md:text-xl"
+    class="w-full rounded-xl p-2 text-base tracking-wide duration-fast ease-standard hover:brightness-105 active:brightness-110 md:p-3 md:text-xl"
     :class="`bg-${bgColor}`"
     @click="emit('click')"
   >

--- a/src/features/reviews/components/DiscussionQuestions.vue
+++ b/src/features/reviews/components/DiscussionQuestions.vue
@@ -136,7 +136,7 @@ const regenerate = () => {
   background: #222831; /* theme background */
   z-index: 0;
   isolation: isolate;
-  transition: filter 0.2s ease;
+  transition: filter var(--motion-base) var(--ease-standard);
 }
 
 .ai-shimmer-button::before {
@@ -180,15 +180,9 @@ const regenerate = () => {
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .ai-shimmer-button::before {
-    animation: none;
-  }
-}
-
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.25s ease;
+  transition: opacity var(--motion-base) var(--ease-standard);
 }
 .fade-enter-from,
 .fade-leave-to {

--- a/src/features/reviews/components/GalleryView.vue
+++ b/src/features/reviews/components/GalleryView.vue
@@ -66,7 +66,7 @@
           :title="row.renderValue('title')"
           :poster-url="row.renderValue('imageUrl')"
           :highlighted="selectedMovieId === row.id"
-          class="ease transition-all duration-100 md:cursor-pointer"
+          class="transition-all duration-fast ease-standard md:cursor-pointer"
           @click="openMovieDetails(row)"
         >
           <div class="mb-2 text-sm text-gray-400">

--- a/src/features/reviews/components/WorkDetailsContent.vue
+++ b/src/features/reviews/components/WorkDetailsContent.vue
@@ -82,7 +82,7 @@
         >
           <span class="text-gray-400">TMDB Rating: </span>
           <span
-            class="transition-[filter] duration-500 ease-out"
+            class="transition-[filter] duration-500 ease-standard"
             :class="
               shouldBlurTmdbScore ? 'select-none blur' : 'select-auto blur-none'
             "
@@ -113,7 +113,7 @@
       <div
         :inert="!showRevealPill"
         :aria-hidden="!showRevealPill || undefined"
-        class="overflow-hidden transition-all duration-300 ease-out"
+        class="overflow-hidden transition-all duration-slow ease-standard"
         :style="{
           maxHeight: showRevealPill ? '4rem' : '0px',
           marginTop: showRevealPill ? '1.5rem' : '0px',
@@ -142,7 +142,7 @@
             :props="cell.getContext()"
           />
           <div
-            class="ml-2 flex-grow transition-[filter] duration-500 ease-out"
+            class="ml-2 flex-grow transition-[filter] duration-500 ease-standard"
             :class="
               shouldBlurScore(movie.id, cell.column.id) ? 'blur' : 'blur-none'
             "
@@ -240,7 +240,7 @@
       <div
         :inert="!showRevealPill"
         :aria-hidden="!showRevealPill || undefined"
-        class="overflow-hidden transition-all duration-300 ease-out"
+        class="overflow-hidden transition-all duration-slow ease-standard"
         :style="{
           maxHeight: showRevealPill ? '4rem' : '0px',
           marginTop: showRevealPill ? '0.5rem' : '0px',
@@ -270,7 +270,7 @@
             :props="cell.getContext()"
           />
           <div
-            class="ml-2 flex-grow transition-[filter] duration-500 ease-out"
+            class="ml-2 flex-grow transition-[filter] duration-500 ease-standard"
             :class="
               shouldBlurScore(movie.id, cell.column.id) ? 'blur' : 'blur-none'
             "
@@ -294,7 +294,7 @@
           <mdicon
             name="chevron-down"
             :class="open ? 'rotate-180 transform' : ''"
-            class="transition-transform duration-200"
+            class="transition-transform duration-base ease-standard"
           />
         </DisclosureButton>
         <DisclosurePanel class="mt-2 grid grid-cols-1 gap-y-2 px-1 text-sm">

--- a/src/features/reviews/views/ReviewView.vue
+++ b/src/features/reviews/views/ReviewView.vue
@@ -259,7 +259,7 @@ const columns = computed(() => [
             "div",
             {
               class:
-                "opacity-0 group-hover:opacity-100 transition-opacity duration-100 space-x-4",
+                "opacity-0 group-hover:opacity-100 transition-opacity duration-fast ease-standard space-x-4",
             },
             [
               h(mdicon, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,6 @@ import VTable from "@/common/components/VTable.vue";
 import MenuCard from "@/features/clubs/components/MenuCard.vue";
 
 import "./assets/styles/tailwind.css";
-import "animate.css";
 import "vue-toastification/dist/index.css";
 
 const fetchedMap = reactive(new Map<string, number>());
@@ -83,6 +82,8 @@ createApp(App)
     position: "bottom-center",
     hideProgressBar: true,
     bodyClassName: "font-default",
+    transition: "Vue-Toastification__fade",
+    timeout: 3000,
   })
   .use(VueQueryPlugin, vueQueryOptions)
   .use(createPinia())

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -372,9 +372,11 @@ const routes: Array<RouteRecordRaw> = [
   },
 ];
 
+const routerHistory = createWebHistory();
+
 const router = createRouter({
   routes,
-  history: createWebHistory(),
+  history: routerHistory,
   scrollBehavior(to, from) {
     // Overlays like the bottom sheet / details drawer push a synthetic history
     // entry (see useBackButtonClose) that keeps the same URL, then pop it on
@@ -388,28 +390,39 @@ const router = createRouter({
   },
 });
 
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+const historyPosition = () => {
+  const position: unknown = routerHistory.state.position;
+  return typeof position === "number" ? position : undefined;
+};
+
+// Safari plays its own native snapshot animation for the back/forward swipe
+// gesture, so replaying ours doubles it. Traversals are detected by history
+// position rather than a popstate listener: the browser has already moved to
+// the target entry when guards run, whereas a push updates history only after
+// navigation is confirmed — so a position change here means back/forward.
+let lastPosition = historyPosition();
+
 router.beforeEach((to, from) => {
-  const fadeIn = "animate__animated animate__faster animate__fadeIn";
-  if (!isDefined(from.name)) {
-    to.meta.transitionIn = fadeIn;
-    return;
+  const isTraversal = historyPosition() !== lastPosition;
+  let direction = "none";
+  if (isDefined(from.name) && !(isSafari && isTraversal)) {
+    if (to.meta.depth === from.meta.depth) {
+      direction = "fade";
+    } else {
+      direction = to.meta.depth > from.meta.depth ? "push" : "pop";
+    }
   }
-  const slideInRight =
-    "animate__animated animate__faster animate__slideInRight";
-  const slideInLeft = "animate__animated animate__faster animate__slideInLeft";
-  const slideOutRight =
-    "animate__animated animate__faster animate__slideOutRight";
-  const slideOutLeft =
-    "animate__animated animate__faster animate__slideOutLeft";
-  if (to.meta.depth === from.meta.depth) {
-    to.meta.transitionIn = fadeIn;
-    to.meta.transitionOut = undefined;
-  } else {
-    to.meta.transitionIn =
-      to.meta.depth > from.meta.depth ? slideInRight : slideInLeft;
-    to.meta.transitionOut =
-      to.meta.depth > from.meta.depth ? slideOutLeft : slideOutRight;
-  }
+  // Drives the html[data-route-transition="..."] CSS in tailwind.css. The
+  // direction must live outside the <transition> props because a leaving page
+  // keeps the props captured when it rendered (a dynamic :name can't change
+  // the exit animation), while attribute selectors resolve live.
+  document.documentElement.dataset.routeTransition = direction;
+});
+
+router.afterEach(() => {
+  lastPosition = historyPosition();
 });
 
 export default router;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -22,6 +22,16 @@ module.exports = {
       fontFamily: {
         default: "'Poppins', sans-serif",
       },
+      transitionDuration: {
+        fast: "var(--motion-fast)",
+        base: "var(--motion-base)",
+        slow: "var(--motion-slow)",
+        page: "var(--motion-page)",
+      },
+      transitionTimingFunction: {
+        standard: "var(--ease-standard)",
+        emphasized: "var(--ease-emphasized)",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary

Phase 1 of 3 introducing a cohesive motion system across the app.

- **Motion tokens**: four durations (`fast` 150ms / `base` 200ms / `slow` 300ms / `page` 350ms) and two easings (`standard`, `emphasized` — promoted from VSideDrawer's curve) as CSS custom properties, exposed as Tailwind utilities (`duration-base`, `ease-emphasized`, ...). All previously animated components (VModal, VBottomSheet, VBackdrop, VSideDrawer, VBtn, VSwitch, poster fade-ins, etc.) retrofitted onto the tokens — no more scattered 100–500ms inline values with five easing families.
- **Route transitions redesigned**: animate.css **removed** (~-1,600 lines of shipped CSS) in favor of ~40 lines of custom CSS. New iOS-style parallax push/pop: the incoming page slides fully while the underlying page moves 30% and dims. Same-depth navigations fade.
- **Safari re-enabled**: previously ALL transitions were disabled on Safari via UA sniff. Now only history traversals (back-swipe/back-button, where Safari renders its own native snapshot animation) skip the transition — detected via vue-router history position, which is immune to popstate listener-ordering differences between engines.
- **`prefers-reduced-motion` support** (previously respected in exactly one spot): a global layer collapses all durations to 0.01ms. Durations collapse rather than `animation: none` so transitions still complete — overlay dismissal depends on `@after-leave` firing.
- Toasts switch from the default bounce to fade with a 3s timeout.

## Implementation note

The route direction lives in a `data-route-transition` attribute on `<html>` set in `router.beforeEach`, not in a dynamic `<transition :name>`: Vue captures a leaving element's transition props at render time, so a name change can never affect the exit animation of the page being removed (verified live — back navigation replayed the forward slide). Attribute selectors resolve at style time, so both pages always agree on direction.

## Verification

- Playwright (Chromium): `route-push` classes on forward nav, `route-pop` on back, correct URLs.
- Playwright (WebKit): forward nav animates (`push`), back traversal skips (`none`); UA detection confirmed.
- Reduced-motion emulation: work details drawer opens and dismisses via Escape (the `@after-leave` trap).
- `vue-tsc`, `eslint --max-warnings 0`, `vite build` all green; `animate__` absent from dist CSS.
- `npm test`: 116/117 pass — the 1 failure (`statsComputers.test.ts` highest-rated-by-year tie ordering) is pre-existing on main and unrelated.

Phase 2 (micro-interactions) and Phase 3 (list/page polish) follow on top of these tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)