### PR TITLE
Motion system phase 2: micro-interactions

### DIFF
--- a/src/common/components/VBtn.vue
+++ b/src/common/components/VBtn.vue
@@ -1,9 +1,9 @@
 <template>
   <button
-    class="rounded-md text-center text-base font-bold tracking-wide text-text filter duration-fast ease-standard"
+    class="rounded-md text-center text-base font-bold tracking-wide text-text transition duration-fast ease-standard"
     :class="{
       'bg-gray-600': disabled,
-      'cursor-pointer bg-primary hover:brightness-110 active:brightness-105':
+      'cursor-pointer bg-primary hover:brightness-110 active:scale-[0.97] active:brightness-105':
         !disabled,
     }"
     :disabled="disabled"

--- a/src/common/components/WorkSearchPrompt.vue
+++ b/src/common/components/WorkSearchPrompt.vue
@@ -11,20 +11,24 @@
         <h5 class="text-left font-bold">
           {{ defaultListTitle }}
         </h5>
-        <div
+        <TransitionGroup
+          tag="div"
+          name="result"
+          appear
           class="mt-2 grid justify-items-center"
           style="grid-template-columns: repeat(auto-fill, minmax(136px, 1fr))"
         >
           <WorkSearchCard
-            v-for="item in filteredDefaultList"
+            v-for="(item, index) in filteredDefaultList"
             :key="item.externalId"
+            :style="{ '--stagger': Math.min(index, 8) }"
             :title="item.title"
             :subtitle="item.subtitle"
             :poster-url="item.imageUrl"
             :fallback-icon="fallbackIcon"
             @select="emit('select-from-default', item)"
           />
-        </div>
+        </TransitionGroup>
         <div v-if="showLoadMore" class="mt-3 flex justify-center">
           <v-btn :disabled="loadingMore" @click="onLoadMore?.()">
             {{ loadingMore ? "Loading..." : "Load More" }}
@@ -33,20 +37,24 @@
       </div>
       <div v-if="includeSearch && searchResults.length > 0">
         <h5 class="text-left font-bold">Search</h5>
-        <div
+        <TransitionGroup
+          tag="div"
+          name="result"
+          appear
           class="mt-2 grid justify-items-center"
           style="grid-template-columns: repeat(auto-fill, minmax(136px, 1fr))"
         >
           <WorkSearchCard
-            v-for="item in searchResults"
+            v-for="(item, index) in searchResults"
             :key="item.externalId"
+            :style="{ '--stagger': Math.min(index, 8) }"
             :title="item.title"
             :subtitle="item.subtitle"
             :poster-url="item.imageUrl"
             :fallback-icon="fallbackIcon"
             @select="emit('select-from-search', item)"
           />
-        </div>
+        </TransitionGroup>
       </div>
       <loading-spinner
         v-if="includeSearch && loadingSearch"
@@ -145,3 +153,28 @@ const showHint = computed(
 
 const hintMessage = computed(() => config.value.searchHint);
 </script>
+
+<style scoped>
+.result-enter-active {
+  transition:
+    opacity var(--motion-base) var(--ease-standard),
+    transform var(--motion-base) var(--ease-standard);
+  /* Capped stagger (set inline per card): at most 8 * 25ms of added delay. */
+  transition-delay: calc(var(--stagger, 0) * 25ms);
+}
+
+.result-enter-from {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+/* Removal is instant on purpose: while the user types, stale cards must
+   clear immediately instead of lagging behind the filter. */
+.result-leave-active {
+  display: none;
+}
+
+.result-move {
+  transition: transform var(--motion-base) var(--ease-emphasized);
+}
+</style>

--- a/src/features/clubs/components/MenuCard.vue
+++ b/src/features/clubs/components/MenuCard.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="w-full rounded-xl p-2 text-base tracking-wide duration-fast ease-standard hover:brightness-105 active:brightness-110 md:p-3 md:text-xl"
+    class="w-full rounded-xl p-2 text-base tracking-wide transition duration-fast ease-standard hover:-translate-y-0.5 hover:brightness-105 active:scale-[0.98] active:brightness-110 md:p-3 md:text-xl"
     :class="`bg-${bgColor}`"
     @click="emit('click')"
   >

--- a/src/features/reviews/components/ReviewScore.vue
+++ b/src/features/reviews/components/ReviewScore.vue
@@ -1,63 +1,65 @@
 <template>
-  <span
-    v-if="isDefined(score) && !isInputOpen"
-    :class="{
-      'cursor-pointer': isMe,
-    }"
-    @click.stop="handleScoreClick"
-  >
-    {{ score }}
-  </span>
-  <span
-    v-else-if="isMe && !isInputOpen"
-    role="button"
-    aria-label="Add score"
-    class="flex cursor-pointer items-center justify-center gap-0.5"
-    @click.stop="handleScoreClick"
-  >
-    <mdicon name="plus" />
-    <span v-if="openInDrawer !== true" class="text-xs text-gray-400">/10</span>
-  </span>
-  <span
-    v-else-if="isMe && isInputOpen"
-    class="flex items-center justify-center gap-0.5"
-  >
-    <input
-      ref="scoreInput"
-      v-model="scoreModel"
-      type="number"
-      inputmode="decimal"
-      min="0"
-      max="10"
-      step="any"
-      placeholder="8.5"
-      aria-label="Score"
-      class="rounded-lg border border-gray-300 bg-background text-center outline-none [appearance:textfield] focus:border-primary [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-      :class="{
-        'w-10 p-2': size !== 'sm',
-        'w-8': size === 'sm',
-        'animate-score-pop': drawAttention,
-      }"
-      @blur="submitScore(parseFloat(scoreModel))"
-      @keydown.enter="scoreInput?.blur()"
-      @animationend="drawAttention = false"
-    />
-    <span
-      class="text-xs text-gray-400 transition-opacity duration-200 motion-reduce:transition-none"
-      :class="drawAttention ? 'opacity-0' : 'opacity-100'"
-      >/10</span
-    >
+  <span class="inline-flex justify-center">
+    <Transition name="score-swap" mode="out-in" @after-enter="onAfterEnter">
+      <span
+        v-if="isDefined(score) && !isInputOpen"
+        key="score"
+        :class="{
+          'cursor-pointer': isMe,
+        }"
+        @click.stop="handleScoreClick"
+      >
+        {{ score }}
+      </span>
+      <span
+        v-else-if="isMe && !isInputOpen"
+        key="add"
+        role="button"
+        aria-label="Add score"
+        class="flex cursor-pointer items-center justify-center gap-0.5"
+        @click.stop="handleScoreClick"
+      >
+        <mdicon name="plus" />
+        <span v-if="openInDrawer !== true" class="text-xs text-gray-400"
+          >/10</span
+        >
+      </span>
+      <span
+        v-else-if="isMe && isInputOpen"
+        key="input"
+        class="flex items-center justify-center gap-0.5"
+      >
+        <input
+          ref="scoreInput"
+          v-model="scoreModel"
+          type="number"
+          inputmode="decimal"
+          min="0"
+          max="10"
+          step="any"
+          placeholder="8.5"
+          aria-label="Score"
+          class="rounded-lg border border-gray-300 bg-background text-center outline-none [appearance:textfield] focus:border-primary [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          :class="{
+            'w-10 p-2': size !== 'sm',
+            'w-8': size === 'sm',
+            'animate-score-pop': drawAttention,
+          }"
+          @blur="submitScore(parseFloat(scoreModel))"
+          @keydown.enter="scoreInput?.blur()"
+          @animationend="drawAttention = false"
+        />
+        <span
+          class="text-xs text-gray-400 transition-opacity duration-200 motion-reduce:transition-none"
+          :class="drawAttention ? 'opacity-0' : 'opacity-100'"
+          >/10</span
+        >
+      </span>
+    </Transition>
   </span>
 </template>
 <script setup lang="ts">
-import {
-  computed,
-  inject,
-  nextTick,
-  onBeforeUnmount,
-  onMounted,
-  ref,
-} from "vue";
+import { computed, inject, onBeforeUnmount, onMounted, ref } from "vue";
 
 import { hasValue, isDefined, isTrue } from "../../../../lib/checks/checks.js";
 import { RequestScoreEntryKey } from "../scoreEntry";
@@ -106,10 +108,13 @@ const openScoreInput = ({ animate = false }: { animate?: boolean } = {}) => {
   drawAttention.value = animate;
   isInputOpen.value = true;
   scoreModel.value = props.score?.toString() ?? "";
-  nextTick(() => {
-    scoreInput.value?.focus();
-    scoreInput.value?.select();
-  }).catch(console.error);
+};
+
+// With mode="out-in" the input is only inserted after the old element has
+// finished leaving, so focus must wait for after-enter (nextTick is too early).
+const onAfterEnter = () => {
+  scoreInput.value?.focus();
+  scoreInput.value?.select();
 };
 
 // Let the drawer / bottom-sheet slide-in animation (200ms sheet, 280ms drawer)
@@ -176,5 +181,18 @@ const submitScore = (score: number) => {
   .animate-score-pop {
     animation: none;
   }
+}
+
+.score-swap-enter-active,
+.score-swap-leave-active {
+  transition:
+    opacity var(--motion-fast) var(--ease-standard),
+    transform var(--motion-fast) var(--ease-standard);
+}
+
+.score-swap-enter-from,
+.score-swap-leave-to {
+  opacity: 0;
+  transform: scale(0.8);
 }
 </style>

--- a/src/features/reviews/tests/ReviewView.spec.ts
+++ b/src/features/reviews/tests/ReviewView.spec.ts
@@ -1,4 +1,4 @@
-import { screen, within } from "@testing-library/vue";
+import { screen, waitFor, within } from "@testing-library/vue";
 import { http, HttpResponse } from "msw";
 
 import ReviewView from "../views/ReviewView.vue";
@@ -66,6 +66,9 @@ describe("ReviewView", () => {
   it("should submit score", async () => {
     const { user, pinia } = render(ReviewView, {
       props: { clubSlug: "test-club" },
+      // Test Utils stubs <Transition> by default, which would swallow the
+      // after-enter hook that focuses the score input.
+      global: { stubs: { transition: false } },
     });
     const authStore = useAuthStore(pinia);
     // @ts-expect-error Overwriting readonly property for testing purposes
@@ -97,9 +100,12 @@ describe("ReviewView", () => {
     expect(addScoreButton).toBeInTheDocument();
 
     await user.click(addScoreButton);
-    const scoreInput = screen.getByRole("spinbutton", { name: "Score" });
-    expect(scoreInput).toBeInTheDocument();
-    expect(scoreInput).toHaveFocus();
+    // The input mounts after the out-in swap and receives focus on the
+    // transition's after-enter hook, both a few frames after the click.
+    const scoreInput = await screen.findByRole("spinbutton", {
+      name: "Score",
+    });
+    await waitFor(() => expect(scoreInput).toHaveFocus());
 
     const newReviews = [
       reviews[0],
@@ -131,9 +137,12 @@ describe("ReviewView", () => {
     );
 
     await user.keyboard("10{Enter}");
-    expect(
-      screen.queryByRole("spinbutton", { name: "Score" }),
-    ).not.toBeInTheDocument();
+    // The input leaves through the score-swap transition, so wait for it.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("spinbutton", { name: "Score" }),
+      ).not.toBeInTheDocument(),
+    );
     expect(within(row).getByRole("cell", { name: "10" })).toBeInTheDocument();
     expect(within(row).getByRole("cell", { name: "9" })).toBeInTheDocument();
   });

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -43,7 +43,11 @@ export const render = (
         },
         plugins: [VueQueryPlugin, pinia, [mdiVue, { icons: mdijs }], Toast],
         directives: { "lazy-load": LazyLoad },
-        stubs: ["router-link", "router-view"],
+        stubs: {
+          "router-link": true,
+          "router-view": true,
+          ...options.global?.stubs,
+        },
       },
     }),
     user,


### PR DESCRIPTION
## Summary

Phase 2 of 3 (stacked on #399 — merge that first). Adds motion to the highest-traffic interactions, all on the Phase 1 tokens:

- **Button press feedback**: `VBtn` scales to 0.97 on `:active` (fast/standard tokens); `MenuCard` lifts 2px on hover and scales to 0.98 on press.
- **Score editing** (the app's most repeated action): `ReviewScore` now swaps between score / add / input states through a 150ms out-in scale-fade. Input focus moved from `nextTick` to the transition's `@after-enter` hook — with `mode="out-in"` the input only mounts after the old element finishes leaving, so `nextTick` fires too early.
- **Search results stagger**: results in the add-work modal enter with a fade + 8px rise, staggered 25ms per card (capped at 8 cards / +200ms) via a per-card `--stagger` CSS variable — no JS animation hooks. Removal is deliberately instant so typing never lags the filter. `appear` is required: both grids mount together with their `v-if` parent, and Vue only animates insertions into an already-rendered TransitionGroup.
- Skeletons were audited and already consistent (`bg-lowBackground` + `animate-pulse`), so no change there.

## Test infrastructure note

`src/tests/utils.ts` now merges per-test `global.stubs` overrides instead of clobbering them. Vue Test Utils stubs `<Transition>` **process-wide by default** (via Vue's `transformVNodeArgs`), which silently swallows all transition hooks in every jsdom test — the score test disables that stub to exercise the real after-enter focus path, and awaits the now-asynchronous focus/removal.

## Verification

- Playwright (Chromium): clicking a score opens the input with focus landing correctly after the swap; blur closes it. Add-work modal cards enter with observed computed delays `0s → 0.2s` in 25ms steps; junk queries clear all cards within 120ms.
- Accidental bonus check: with `prefers-reduced-motion` emulated, the stagger delays collapse to 0s via the Phase 1 reduced-motion layer.
- `vue-tsc`, `eslint --max-warnings 0` green; `npm test` 116/117 (the 1 failure is the pre-existing `statsComputers` tie-ordering issue on main, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)