### PR TITLE
Motion system phase 3: list and page-level polish

### DIFF
--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -75,6 +75,31 @@ html[data-route-transition="pop"] .route-leave-to {
   transform: translateX(100%);
 }
 
+/* Scroll-reveal (v-reveal directive, src/directives/Reveal.ts). */
+.reveal-init {
+  opacity: 0;
+  transform: translateY(16px);
+  transition:
+    opacity var(--motion-slow) var(--ease-standard),
+    transform var(--motion-slow) var(--ease-emphasized);
+}
+.reveal-init.reveal-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* One-shot mount animation for content that always renders fresh
+   (empty states); `both` keeps the pre-animation frame hidden. */
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+}
+.animate-fade-up {
+  animation: fade-up var(--motion-slow) var(--ease-standard) both;
+}
+
 html {
   font-family: "Poppins", sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/src/common/components/ClubSwitcher.vue
+++ b/src/common/components/ClubSwitcher.vue
@@ -12,53 +12,62 @@
         <mdicon name="chevron-down" :size="18" />
       </MenuButton>
 
-      <MenuItems
-        class="absolute left-0 top-full z-50 mt-1 min-w-[200px] rounded-lg bg-lowBackground shadow-lg"
+      <transition
+        enter-active-class="transition duration-fast ease-standard"
+        enter-from-class="-translate-y-1 scale-95 opacity-0"
+        leave-active-class="transition duration-fast ease-standard"
+        leave-to-class="-translate-y-1 scale-95 opacity-0"
       >
-        <div class="py-1">
-          <MenuItem
-            v-for="club in clubs"
-            :key="club.clubId"
-            v-slot="{ active }"
-          >
-            <button
-              class="flex w-full items-center gap-2 px-4 py-2 text-sm"
-              :class="[
-                club.slug === currentSlug ? 'text-highlight' : 'text-white/80',
-                active ? 'bg-white/10' : '',
-              ]"
-              @click="selectClub(club.slug)"
+        <MenuItems
+          class="absolute left-0 top-full z-50 mt-1 min-w-[200px] origin-top-left rounded-lg bg-lowBackground shadow-lg"
+        >
+          <div class="py-1">
+            <MenuItem
+              v-for="club in clubs"
+              :key="club.clubId"
+              v-slot="{ active }"
             >
-              <mdicon
-                v-if="club.slug === currentSlug"
-                name="check"
-                :size="16"
-              />
-              <span :class="{ 'ml-6': club.slug !== currentSlug }">
-                {{ club.clubName }}
-              </span>
-              <mdicon
-                :name="clubTypeIcon(club.type)"
-                :size="14"
-                class="ml-auto opacity-60"
-                :title="clubTypeLabel(club.type)"
-              />
-            </button>
-          </MenuItem>
-        </div>
-        <div class="border-t border-white/10">
-          <MenuItem v-slot="{ active }">
-            <button
-              class="flex w-full items-center gap-2 px-4 py-2 text-sm text-white/80"
-              :class="active ? 'bg-white/10' : ''"
-              @click="createNewClub"
-            >
-              <mdicon name="plus" :size="16" />
-              Create New Club
-            </button>
-          </MenuItem>
-        </div>
-      </MenuItems>
+              <button
+                class="flex w-full items-center gap-2 px-4 py-2 text-sm"
+                :class="[
+                  club.slug === currentSlug
+                    ? 'text-highlight'
+                    : 'text-white/80',
+                  active ? 'bg-white/10' : '',
+                ]"
+                @click="selectClub(club.slug)"
+              >
+                <mdicon
+                  v-if="club.slug === currentSlug"
+                  name="check"
+                  :size="16"
+                />
+                <span :class="{ 'ml-6': club.slug !== currentSlug }">
+                  {{ club.clubName }}
+                </span>
+                <mdicon
+                  :name="clubTypeIcon(club.type)"
+                  :size="14"
+                  class="ml-auto opacity-60"
+                  :title="clubTypeLabel(club.type)"
+                />
+              </button>
+            </MenuItem>
+          </div>
+          <div class="border-t border-white/10">
+            <MenuItem v-slot="{ active }">
+              <button
+                class="flex w-full items-center gap-2 px-4 py-2 text-sm text-white/80"
+                :class="active ? 'bg-white/10' : ''"
+                @click="createNewClub"
+              >
+                <mdicon name="plus" :size="16" />
+                Create New Club
+              </button>
+            </MenuItem>
+          </div>
+        </MenuItems>
+      </transition>
     </Menu>
 
     <!-- Mobile: custom button + bottom sheet -->

--- a/src/common/components/EmptyState.vue
+++ b/src/common/components/EmptyState.vue
@@ -15,7 +15,7 @@ const emit = defineEmits<{
 
 <template>
   <div
-    class="flex flex-col items-center justify-center px-8 py-16 text-center transition-opacity duration-slow ease-standard md:py-24"
+    class="animate-fade-up flex flex-col items-center justify-center px-8 py-16 text-center md:py-24"
   >
     <h2 class="mb-3 text-2xl font-bold text-white">{{ title }}</h2>
     <p class="mb-6 max-w-md text-base text-gray-400">{{ description }}</p>

--- a/src/directives/Reveal.ts
+++ b/src/directives/Reveal.ts
@@ -1,0 +1,34 @@
+// Fade-and-rise an element in the first time it scrolls into view (see
+// .reveal-init / .reveal-visible in tailwind.css). Elements already in the
+// viewport reveal immediately on mount.
+let observer: IntersectionObserver | undefined;
+
+const getObserver = () => {
+  observer ??= new IntersectionObserver(
+    (entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("reveal-visible");
+          obs.unobserve(entry.target);
+        }
+      });
+    },
+    // The huge top margin treats everything ABOVE the viewport as
+    // intersecting: a fast scroll can jump past an element between observer
+    // callbacks, and without this it would never fire and the element would
+    // stay invisible.
+    { threshold: 0.15, rootMargin: "9999px 0px 0px 0px" },
+  );
+  return observer;
+};
+
+export default {
+  mounted(el: HTMLElement) {
+    el.classList.add("reveal-init");
+    getObserver().observe(el);
+  },
+
+  unmounted(el: HTMLElement) {
+    getObserver().unobserve(el);
+  },
+};

--- a/src/features/reviews/components/GalleryView.vue
+++ b/src/features/reviews/components/GalleryView.vue
@@ -51,11 +51,12 @@
         </div>
       </div>
 
+      <!-- Removal stays instant (absolute hidden) so filtering never lags;
+           the named transition adds enter and FLIP-move animation on top. -->
       <transition-group
         tag="div"
+        name="gallery"
         leave-active-class="absolute hidden"
-        enter-from-class="opacity-0"
-        leave-to-class="opacity-0"
         class="grid w-full justify-items-center gap-4"
         style="grid-template-columns: repeat(auto-fill, minmax(168px, 1fr))"
       >
@@ -280,3 +281,22 @@ watch(selectedMovieId, async (newValue, oldValue) => {
   }
 });
 </script>
+
+<style scoped>
+/* Scoped selectors ([data-v-...]) out-specify the card's own transition-all
+   utility, so enter/move timing wins over the hover transition. */
+.gallery-enter-active {
+  transition:
+    opacity var(--motion-base) var(--ease-standard),
+    transform var(--motion-base) var(--ease-standard);
+}
+
+.gallery-enter-from {
+  opacity: 0;
+  transform: scale(0.95);
+}
+
+.gallery-move {
+  transition: transform var(--motion-slow) var(--ease-emphasized);
+}
+</style>

--- a/src/features/statistics/components/WidgetShell.vue
+++ b/src/features/statistics/components/WidgetShell.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mx-auto w-11/12" :class="outerClass">
+  <div v-reveal class="mx-auto w-11/12" :class="outerClass">
     <div :class="innerClass ?? 'rounded-lg bg-lowBackground p-5'">
       <h3 v-if="title" class="mb-4 text-lg font-bold text-white">
         {{ title }}

--- a/src/features/watch-list/components/ListItems.vue
+++ b/src/features/watch-list/components/ListItems.vue
@@ -16,10 +16,21 @@
     />
     <template v-else>
       <div class="w-full">
+        <!-- The TransitionGroup IS the draggable's root element (via the
+             component prop — a NESTED transition-group breaks the library's
+             child-index math): SortableJS owns drag-move animation, the
+             TransitionGroup owns enter/leave and the FLIP reflow on
+             add/remove. componentData replaces $attrs on the rendered
+             element, so the grid classes live there. -->
         <VueDraggableNext
           v-model="draggableItems"
-          tag="div"
-          class="my-4 grid grid-cols-auto justify-items-center gap-4"
+          component="DraggableTransitionGroup"
+          :component-data="{
+            props: { tag: 'div', name: 'list-item' },
+            attrs: {
+              class: 'my-4 grid grid-cols-auto justify-items-center gap-4',
+            },
+          }"
           :delay="150"
           :delay-on-touch-only="true"
           :animation="200"
@@ -284,3 +295,30 @@ const onReview = (workId: string) => {
   );
 };
 </script>
+
+<style scoped>
+.list-item-enter-active {
+  transition:
+    opacity var(--motion-base) var(--ease-standard),
+    transform var(--motion-base) var(--ease-emphasized);
+}
+
+/* Leaving cards pop out of the grid flow so the remaining cards FLIP into
+   their new positions via the -move transition. */
+.list-item-leave-active {
+  position: absolute;
+  transition:
+    opacity var(--motion-base) var(--ease-standard),
+    transform var(--motion-base) var(--ease-standard);
+}
+
+.list-item-enter-from,
+.list-item-leave-to {
+  opacity: 0;
+  transform: scale(0.9);
+}
+
+.list-item-move {
+  transition: transform var(--motion-slow) var(--ease-emphasized);
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,10 +3,11 @@ import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persist
 import { VueQueryPlugin, VueQueryPluginOptions } from "@tanstack/vue-query";
 import mdiVue from "mdi-vue/v3";
 import { createPinia } from "pinia";
-import { createApp, reactive } from "vue";
+import { createApp, reactive, TransitionGroup } from "vue";
 import Toast from "vue-toastification";
 
 import LazyLoad from "./directives/LazyLoad";
+import Reveal from "./directives/Reveal";
 import { icons } from "./icons";
 import router from "./router";
 import { isDefined } from "../lib/checks/checks.js";
@@ -74,7 +75,11 @@ createApp(App)
   .component("v-modal", VModal)
   .component("page-header", PageHeader)
   .component("empty-state", EmptyState)
+  // Registered by name so VueDraggableNext's `component` prop can resolve it
+  // and render the TransitionGroup as its own root element (see ListItems).
+  .component("DraggableTransitionGroup", TransitionGroup)
   .directive("lazy-load", LazyLoad)
+  .directive("reveal", Reveal)
   .use(mdiVue, {
     icons,
   })

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -7,6 +7,7 @@ import {
   render as testingLibraryRender,
 } from "@testing-library/vue";
 import mdiVue from "mdi-vue/v3";
+import { TransitionGroup } from "vue";
 import Toast from "vue-toastification";
 
 import PiniaStoreHelperTest from "./PiniaStoreHelper.test.vue";
@@ -18,6 +19,7 @@ import VBtn from "@/common/components/VBtn.vue";
 import VModal from "@/common/components/VModal.vue";
 import VTable from "@/common/components/VTable.vue";
 import LazyLoad from "@/directives/LazyLoad";
+import Reveal from "@/directives/Reveal";
 
 export const render = (
   component: unknown,
@@ -40,9 +42,10 @@ export const render = (
           "movie-table": VTable,
           "v-modal": VModal,
           "page-header": PageHeader,
+          DraggableTransitionGroup: TransitionGroup,
         },
         plugins: [VueQueryPlugin, pinia, [mdiVue, { icons: mdijs }], Toast],
-        directives: { "lazy-load": LazyLoad },
+        directives: { "lazy-load": LazyLoad, reveal: Reveal },
         stubs: {
           "router-link": true,
           "router-view": true,


### PR DESCRIPTION
## Summary

Phase 3 of 3 (stacked on #400 → #399). List-level and page-level animation on the Phase 1 tokens:

- **Watch-list add/remove/reorder**: posters scale-fade in on add, scale-fade out on delete with siblings FLIP-gliding into place, and drag drops settle through the same FLIP move transition. SortableJS keeps owning mid-drag animation.
- **Statistics widget scroll-reveal**: all ~17 widgets fade-and-rise on first scroll into view via a new `v-reveal` directive (one shared IntersectionObserver, applied on `WidgetShell` so every widget gets it for free; transform/opacity only, no CLS).
- **Review gallery**: filter toggling now FLIPs surviving cards to their new grid positions and scale-fades entering ones; removal stays instant so filtering never lags.
- **Empty states** mount through a one-shot fade-up; the **club-switcher menu** scale-fades.

## Two bugs found & designed around during verification

1. **Nested transition-group silently breaks vue-draggable-next**: the Vue 3 port's `getChildrenNodes()` always reads `$el.children`, so with a nested `<transition-group>` every index lookup misses and drops stop persisting (drag *looked* fine — ghost/chosen classes appeared — but the model never updated). Fix: the TransitionGroup **is** the draggable root via the `component` prop, which restores correct `$el` semantics. Verified: reorder works, persists across reload, and animates.
2. **Fast scrolls strand reveal elements invisible**: an instant scroll jump can pass an element between IntersectionObserver callbacks so it never fires, leaving content at opacity 0 permanently (reproduced: 4 of 10 widgets stuck). Fix: a `9999px` top rootMargin makes everything above the viewport count as intersecting.

## Verification (Playwright, Chromium)

- Add → `list-item-enter-*` + sibling `list-item-move` observed; delete × N → `list-item-leave-*` + `move`; drag → order changed and persisted across reload, drop FLIP-animated. Dev DB restored to its original state afterwards.
- Statistics: 1/10 widgets revealed initially, 10/10 after instant jump to bottom, zero stuck at opacity 0 after scrolling back.
- Club switcher opens/closes through the transition; fresh console shows no warnings or errors.
- `vue-tsc`, `eslint --max-warnings 0`, `vite build` green; `npm test` 116/117 (1 pre-existing unrelated failure).

## Pre-existing issues noticed (not addressed here)

- `ListItems.vue` passes `header`/`message` to `<empty-state>` whose props are `title`/`description` — the list empty state renders without text.
- `statsComputers.test.ts` "sorts results by year descending" fails on main (tie-ordering in `computeHighestRatedByYear`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)