### PR TITLE
Fix mobile viewport zoom when focusing comment textareas

### DIFF
--- a/src/common/components/CommentThread.vue
+++ b/src/common/components/CommentThread.vue
@@ -57,7 +57,7 @@
           <textarea
             v-model="editContent"
             :maxlength="MAX_LENGTH"
-            class="w-full resize-none rounded-lg border border-gray-600 bg-background px-3 py-2 text-left text-sm text-white placeholder-gray-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            class="w-full resize-none rounded-lg border border-gray-600 bg-background px-3 py-2 text-left text-base text-white placeholder-gray-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary md:text-sm"
             rows="3"
           />
           <div class="mt-2 flex items-center justify-between">
@@ -131,7 +131,7 @@
         v-model="newComment"
         :maxlength="MAX_LENGTH"
         placeholder="Write a comment…"
-        class="w-full resize-none rounded-lg border border-gray-600 bg-lowBackground px-3 py-2 text-left text-sm text-white placeholder-gray-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+        class="w-full resize-none rounded-lg border border-gray-600 bg-lowBackground px-3 py-2 text-left text-base text-white placeholder-gray-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary md:text-sm"
         rows="3"
       />
       <div class="mt-2 flex items-center justify-between">


### PR DESCRIPTION
## Problem

On mobile, focusing the comment text box on a reviewed movie or a watchlist movie caused the viewport to zoom in. This is Mobile Safari's default behavior: it auto-zooms whenever a focused `input`/`textarea` has a font size below 16px.

## Fix

Both editable textareas in `CommentThread.vue` (the new-comment box and the inline edit box) used `text-sm` (14px), which triggered the zoom. Changed them to `text-base` (16px) on mobile and kept `text-sm` on `md+` screens via `text-base md:text-sm`. Desktop browsers don't have the focus-zoom behavior, so the visual appearance there is unchanged; on mobile the 16px font prevents the zoom while keeping focus.

## Testing

- `npm run type-check` passes
- `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrhoZubcQPvqqFoM4GeeaT)_