### PR TITLE
Keep underlying list in place when opening the details drawer

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -376,8 +376,15 @@ const routes: Array<RouteRecordRaw> = [
 const router = createRouter({
   routes,
   history: createWebHistory(),
-  scrollBehavior() {
-    // Always scroll to top when navigating between routes
+  scrollBehavior(to, from) {
+    // Overlays like the bottom sheet / details drawer push a synthetic history
+    // entry (see useBackButtonClose) that keeps the same URL, then pop it on
+    // close. vue-router still runs scrollBehavior for that popstate; returning
+    // { top: 0 } there yanks the underlying list to the top. Only reset scroll
+    // when the path actually changes (i.e. navigating between routes).
+    if (to.path === from.path) {
+      return false;
+    }
     return { top: 0 };
   },
 });


### PR DESCRIPTION
## Problem

When opening a movie's details drawer / bottom sheet, the list underneath auto-scrolls all the way to the top and then jumps back down to where it was, instead of staying put.

## Root cause

The bottom sheet and details drawer use `useBackButtonClose`, which pushes a synthetic history entry on open (so the back button / back gesture can dismiss the overlay) and pops it via `history.back()` on close. That `popstate` makes vue-router run its `scrollBehavior`, which unconditionally returned `{ top: 0 }` — scrolling the underlying list to the top. The browser's native scroll restoration then drops it back down, producing the visible jump.

Selection is tracked in local component state (`selectedInfo`), not in the URL, so the drawer open/close never actually changes the route — the scroll reset was pure collateral damage from the synthetic history entry.

## Fix

`scrollBehavior` now only resets scroll to the top when the path actually changes. Same-URL navigations (like an overlay open/close) leave the scroll position untouched, so the list stays exactly where it was.

## Testing

- `npm run type-check` — passes
- `npx eslint src/router/index.ts` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXULy1TrA4tbpCAuCZkLeJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXULy1TrA4tbpCAuCZkLeJ)_