### PR TITLE
Fix mobile club switcher silently cancelling the switch

### DIFF
--- a/src/common/components/ClubSwitcher.vue
+++ b/src/common/components/ClubSwitcher.vue
@@ -147,17 +147,27 @@ const activeClubName = computed(() => {
   return "Select Club";
 });
 
+// Close the mobile sheet only *after* the navigation resolves. Closing it first
+// unmounts the sheet, and `useBackButtonClose` would then pop its synthetic
+// history entry — cancelling the navigation we just started (mobile club
+// switch would silently do nothing). See useBackButtonClose for details.
 const selectClub = (slug: string) => {
-  isMobileOpen.value = false;
   setLastClubSlug(slug);
   router
     .push({ name: "ClubHome", params: { clubSlug: slug } })
+    .then(() => {
+      isMobileOpen.value = false;
+    })
     .catch(console.error);
 };
 
 const createNewClub = () => {
-  isMobileOpen.value = false;
-  router.push({ name: "NewClub" }).catch(console.error);
+  router
+    .push({ name: "NewClub" })
+    .then(() => {
+      isMobileOpen.value = false;
+    })
+    .catch(console.error);
 };
 
 onMounted(() => {

--- a/src/common/composables/useBackButtonClose.ts
+++ b/src/common/composables/useBackButtonClose.ts
@@ -1,4 +1,5 @@
 import { onMounted, onUnmounted } from "vue";
+import { useRouter } from "vue-router";
 
 /**
  * Lets the browser back button (and the mobile back gesture) dismiss an overlay
@@ -11,6 +12,12 @@ import { onMounted, onUnmounted } from "vue";
  * is removed on unmount so a later back press is not "swallowed" by a stale
  * entry.
  *
+ * If instead the overlay closes because the app *navigated* while it was open
+ * (for example the mobile club switcher routing to the chosen club), vue-router
+ * has already pushed a real history entry above our synthetic one. Reclaiming
+ * ours with `history.back()` would then traverse back over that real entry and
+ * cancel the navigation, so in that case we leave history untouched.
+ *
  * @param onDismiss - Called when the back button should close the overlay.
  *
  * @example
@@ -19,6 +26,14 @@ import { onMounted, onUnmounted } from "vue";
 export function useBackButtonClose(onDismiss: () => void) {
   // Whether our extra history entry is still on the stack and needs cleanup.
   let pushed = false;
+  // Set once a route navigation starts while the overlay is open. Popping our
+  // entry afterwards would undo that navigation, so we skip the cleanup.
+  let navigated = false;
+
+  // `useRouter()` is undefined outside a router context (e.g. bare unit tests);
+  // guard so those callers keep the original cleanup behaviour.
+  const router = useRouter();
+  let removeGuard: (() => void) | undefined;
 
   const onPopState = () => {
     // The browser has already popped our entry, so don't pop it again on
@@ -33,11 +48,19 @@ export function useBackButtonClose(onDismiss: () => void) {
     window.history.pushState({ ...window.history.state, vOverlay: true }, "");
     pushed = true;
     window.addEventListener("popstate", onPopState);
+    // Flag any navigation that happens while the overlay is open. Callers that
+    // navigate from an in-overlay action are expected to close the overlay only
+    // after the navigation resolves (see ClubSwitcher), so this is already set
+    // by the time the resulting unmount runs its cleanup.
+    removeGuard = router?.beforeEach(() => {
+      navigated = true;
+    });
   });
 
   onUnmounted(() => {
     window.removeEventListener("popstate", onPopState);
-    if (pushed) {
+    removeGuard?.();
+    if (pushed && !navigated) {
       pushed = false;
       // Remove the entry we added so the back button isn't consumed by it after
       // the overlay has already been dismissed some other way.

--- a/src/common/tests/ClubSwitcher.spec.ts
+++ b/src/common/tests/ClubSwitcher.spec.ts
@@ -1,0 +1,88 @@
+import { screen } from "@testing-library/vue";
+import type { Router } from "vue-router";
+import { useRouter } from "vue-router";
+
+import ClubSwitcher from "../components/ClubSwitcher.vue";
+
+import { ClubType } from "@/../lib/types/generated/db";
+import { render } from "@/tests/utils";
+
+// useRoute is mocked (setup.ts) to report the current club as "test-club".
+const userClubs = [
+  {
+    clubId: "1",
+    clubName: "Test Club",
+    slug: "test-club",
+    slugUpdatedAt: undefined,
+    type: ClubType.movie,
+  },
+  {
+    clubId: "2",
+    clubName: "Other Club",
+    slug: "other-club",
+    slugUpdatedAt: undefined,
+    type: ClubType.movie,
+  },
+];
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: () => ({ userClubs }),
+}));
+
+vi.mock("@/common/composables/useLastClubSlug", () => ({
+  setLastClubSlug: vi.fn(),
+}));
+
+// A real router so navigation runs real guards (which `useBackButtonClose`
+// depends on to detect that the overlay closed because of a navigation).
+const makeRealRouter = async () => {
+  const { createMemoryHistory, createRouter } =
+    await vi.importActual<typeof import("vue-router")>("vue-router");
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: "/", name: "Home", component: { template: "<div />" } },
+      {
+        path: "/club/:clubSlug",
+        name: "ClubHome",
+        component: { template: "<div />" },
+      },
+      { path: "/new", name: "NewClub", component: { template: "<div />" } },
+    ],
+  });
+  await router.push({ name: "ClubHome", params: { clubSlug: "test-club" } });
+  return router;
+};
+
+describe("ClubSwitcher (mobile)", () => {
+  let back: ReturnType<typeof vi.spyOn>;
+  let router: Router;
+
+  beforeEach(async () => {
+    // matchMedia is mocked to `matches: false`, so `useIsDesktop` reports mobile
+    // and the bottom-sheet path renders.
+    vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+    back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+
+    router = await makeRealRouter();
+    vi.mocked(useRouter).mockReturnValue(router);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("switches to the chosen club without the navigation being undone", async () => {
+    const { user } = render(ClubSwitcher);
+
+    // Open the bottom sheet, then pick the other club.
+    await user.click(screen.getByRole("button", { name: /Switch club/ }));
+    await user.click(screen.getByRole("button", { name: /Other Club/ }));
+
+    // The route actually changed to the selected club...
+    expect(router.currentRoute.value.params.clubSlug).toBe("other-club");
+    // ...and the overlay's history cleanup did not pop the entry we just added,
+    // which would have cancelled the switch (the original mobile bug).
+    expect(back).not.toHaveBeenCalled();
+  });
+});

--- a/src/common/tests/useBackButtonClose.spec.ts
+++ b/src/common/tests/useBackButtonClose.spec.ts
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/vue";
 import { defineComponent, h } from "vue";
+import { useRouter } from "vue-router";
 
 import { useBackButtonClose } from "../composables/useBackButtonClose";
 
@@ -12,6 +13,22 @@ const Harness = (onDismiss: () => void) =>
       return () => h("div");
     },
   });
+
+// setup.ts mocks vue-router globally, so build a real router (which runs real
+// navigation guards) and point the mocked `useRouter` at it for a given test.
+const makeRealRouter = async () => {
+  const { createMemoryHistory, createRouter } =
+    await vi.importActual<typeof import("vue-router")>("vue-router");
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: "/", component: { template: "<div />" } },
+      { path: "/other", component: { template: "<div />" } },
+    ],
+  });
+  await router.push("/");
+  return router;
+};
 
 describe("useBackButtonClose", () => {
   // Mock the History API so tests never trigger real jsdom navigation (which
@@ -78,5 +95,19 @@ describe("useBackButtonClose", () => {
     window.dispatchEvent(new PopStateEvent("popstate"));
 
     expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("does not pop history on unmount when the app navigated while open", async () => {
+    const router = await makeRealRouter();
+    vi.mocked(useRouter).mockReturnValue(router);
+
+    const view = render(Harness(vi.fn()));
+
+    // Navigating away (e.g. the club switcher routing to the chosen club)
+    // pushes a real entry above our synthetic one; popping ours would undo it.
+    await router.push("/other");
+    view.unmount();
+
+    expect(back).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -12,6 +12,8 @@ vi.mock("vue-router", () => ({
   })),
   useRouter: vi.fn(() => ({
     push: vi.fn(),
+    // `useBackButtonClose` registers a navigation guard; return an unregister fn.
+    beforeEach: vi.fn(() => vi.fn()),
   })),
 }));
 


### PR DESCRIPTION
## Problem

On mobile, selecting a club in the club switcher's bottom sheet did nothing — the current club never changed.

`ClubSwitcher.selectClub` closed the sheet (`isMobileOpen = false`, which unmounts `VBottomSheet`) at the same time it called `router.push(...)`. Unmounting the sheet triggers `useBackButtonClose`'s cleanup, which fires `history.back()` to reclaim the synthetic history entry it pushed on open. That `back()` traverses back over the entry vue-router had just pushed for the newly selected club, **cancelling the navigation**. The result: the switch silently does nothing.

This only affected mobile — desktop uses the Headless UI `Menu`, which doesn't involve `useBackButtonClose`.

## Fix

Both sides of the interaction:

- **`useBackButtonClose`** now flags any navigation that happens while the overlay is open (via a router `beforeEach` guard) and **skips the `history.back()` cleanup** in that case, because a real history entry now sits above the synthetic one and popping ours would undo the navigation. Overlays closed by any other means (grabber, backdrop, back button) keep the original cleanup behaviour.
- **`ClubSwitcher`** closes the mobile sheet only **after** the navigation resolves (`router.push(...).then(() => isMobileOpen = false)`), so the guard has already run before the sheet's unmount cleanup fires. Applied to both `selectClub` and `createNewClub`.

## Tests

- New `ClubSwitcher.spec.ts` drives the real mobile flow (open sheet → pick another club) against a real router and asserts the route changes to the selected club and `history.back()` is **not** called. Verified it fails when the fix is reverted.
- New case in `useBackButtonClose.spec.ts` locks the "don't reclaim the entry after navigating" behaviour.
- `setup.ts`'s global `vue-router` mock now returns a `beforeEach` (used by the composable) so all `VBottomSheet` consumers keep rendering under test.

All 154 tests pass; `type-check` and `lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLxtm2xUTNPed2H7YmtV9b)_