### PR TITLE
Live-sync scores after submitting via a per-movie poll

### DIFF
--- a/lib/types/lists.ts
+++ b/lib/types/lists.ts
@@ -22,8 +22,15 @@ export interface WorkListItem {
 }
 
 export interface ReviewListItem extends WorkListItem {
-  scores: Record<string, Review>;
+  scores: ReviewScores;
 }
+
+/**
+ * Per-user scores for a single work, keyed by user id. Includes a synthetic
+ * `"average"` entry. Returned as-is by the lightweight per-work scores endpoint
+ * (`GET /api/club/:clubSlug/reviews/:workId/scores`).
+ */
+export type ReviewScores = Record<string, Review>;
 
 export interface Review {
   id: string;

--- a/netlify/functions/club/list.ts
+++ b/netlify/functions/club/list.ts
@@ -5,7 +5,6 @@ import {
   DetailedReviewListItem,
   DetailedWorkData,
   DetailedWorkListItem,
-  Review,
 } from "../../../lib/types/lists.js";
 import { listInsertDtoSchema } from "../../../lib/types/lists.js";
 import ListRepository from "../repositories/ListRepository";
@@ -15,6 +14,7 @@ import WorkRepository from "../repositories/WorkRepository";
 import { secured } from "../utils/auth";
 import { getExternalDataForWorks } from "../utils/providers";
 import { badRequest, internalServerError, ok } from "../utils/responses";
+import { buildReviewScores } from "../utils/reviewScores";
 import { Router } from "../utils/router";
 import { ClubRequest, ListRequest, validListId } from "../utils/validation";
 
@@ -351,42 +351,17 @@ async function getReviewList(
     .map(([key, items]) => {
       const review = items[0];
 
-      const userScores: Record<string, Review> = items.reduce((acc, review) => {
-        if (
-          hasValue(review.user_id) &&
-          hasValue(review.score) &&
-          memberIds.has(review.user_id)
-        ) {
-          return {
-            ...acc,
-            [review.user_id]: {
-              id: review.review_id,
-              created_date: review.time_added.toISOString(),
-              score: parseFloat(review.score),
-            },
-          };
-        } else {
-          return acc;
-        }
-      }, {});
-
-      let scores: Record<string, Review>;
-      if (Object.keys(userScores).length === 0) {
-        scores = {};
-      } else {
-        scores = {
-          ...userScores,
-          average: {
-            id: "average",
-            created_date: new Date().toISOString(),
-            score:
-              Object.values(userScores).reduce(
-                (acc, review) => acc + review.score,
-                0,
-              ) / Object.keys(userScores).length,
-          },
-        };
-      }
+      // `getReviewList` surfaces the list-add timestamp as `time_added`, so map
+      // it onto the `created_date` field the shared helper expects.
+      const scores = buildReviewScores(
+        items.map((item) => ({
+          user_id: item.user_id,
+          review_id: item.review_id,
+          score: item.score,
+          created_date: item.time_added,
+        })),
+        memberIds,
+      );
 
       return {
         id: key,

--- a/netlify/functions/club/list.ts
+++ b/netlify/functions/club/list.ts
@@ -351,17 +351,7 @@ async function getReviewList(
     .map(([key, items]) => {
       const review = items[0];
 
-      // `getReviewList` surfaces the list-add timestamp as `time_added`, so map
-      // it onto the `created_date` field the shared helper expects.
-      const scores = buildReviewScores(
-        items.map((item) => ({
-          user_id: item.user_id,
-          review_id: item.review_id,
-          score: item.score,
-          created_date: item.time_added,
-        })),
-        memberIds,
-      );
+      const scores = buildReviewScores(items, memberIds);
 
       return {
         id: key,

--- a/netlify/functions/club/reviews.ts
+++ b/netlify/functions/club/reviews.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 
-import { hasValue } from "../../../lib/checks/checks.js";
+import { hasValue, isDefined } from "../../../lib/checks/checks.js";
+import { ReviewScores } from "../../../lib/types/lists";
 import ListRepository from "../repositories/ListRepository";
 import ReviewRepository from "../repositories/ReviewRepository";
 import SettingsRepository from "../repositories/SettingsRepository";
+import UserRepository from "../repositories/UserRepository";
 import WorkCommentRepository from "../repositories/WorkCommentRepository";
 import WorkRepository from "../repositories/WorkRepository";
 import SharedReviewService from "../services/SharedReviewService";
@@ -206,6 +208,62 @@ router.post(
     return res(ok(JSON.stringify({ questions })));
   },
 );
+
+// Lightweight per-work scores endpoint. Returns only the `scores` map (one entry
+// per member plus a synthetic `average`) for a single work, so clients can poll
+// it cheaply to pick up other members' scores during a synchronized scoring
+// session without refetching the whole reviews list (posters, metadata, etc.).
+router.get("/:workId/scores", secured, async ({ clubId, params }, res) => {
+  if (!hasValue(params.workId)) {
+    return res(badRequest("No workId provided"));
+  }
+  const scores = await buildWorkScores(clubId, params.workId);
+  return res(ok(JSON.stringify(scores)));
+});
+
+// Mirrors the per-work grouping in `club/list.ts` getReviewList, scoped to a
+// single work. Filters to current members so a departed member's stale score
+// doesn't reappear, and appends the average.
+async function buildWorkScores(
+  clubId: string,
+  workId: string,
+): Promise<ReviewScores> {
+  const [reviews, members] = await Promise.all([
+    ReviewRepository.getReviewsByWorkId(clubId, workId),
+    UserRepository.getMembersByClubId(clubId),
+  ]);
+  const memberIds = new Set(members.map((member) => member.id));
+
+  const userScores = reviews.reduce<ReviewScores>((acc, review) => {
+    if (
+      hasValue(review.user_id) &&
+      hasValue(review.review_id) &&
+      hasValue(review.score) &&
+      isDefined(review.created_date) &&
+      memberIds.has(review.user_id)
+    ) {
+      acc[review.user_id] = {
+        id: review.review_id,
+        created_date: review.created_date.toISOString(),
+        score: parseFloat(review.score),
+      };
+    }
+    return acc;
+  }, {});
+
+  const entries = Object.values(userScores);
+  if (entries.length === 0) return {};
+
+  return {
+    ...userScores,
+    average: {
+      id: "average",
+      created_date: new Date().toISOString(),
+      score:
+        entries.reduce((sum, review) => sum + review.score, 0) / entries.length,
+    },
+  };
+}
 
 router.get("/:workId/shared", async ({ clubId, params }, res) => {
   if (!hasValue(params.workId)) {

--- a/netlify/functions/club/reviews.ts
+++ b/netlify/functions/club/reviews.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { hasValue, isDefined } from "../../../lib/checks/checks.js";
+import { hasValue } from "../../../lib/checks/checks.js";
 import { ReviewScores } from "../../../lib/types/lists";
 import ListRepository from "../repositories/ListRepository";
 import ReviewRepository from "../repositories/ReviewRepository";
@@ -13,6 +13,7 @@ import { secured } from "../utils/auth";
 import { generateJson } from "../utils/gemini";
 import { getProvider } from "../utils/providers";
 import { badRequest, ok, unauthorized } from "../utils/responses";
+import { buildReviewScores } from "../utils/reviewScores";
 import { Router } from "../utils/router";
 import { ClubRequest } from "../utils/validation";
 
@@ -221,9 +222,9 @@ router.get("/:workId/scores", secured, async ({ clubId, params }, res) => {
   return res(ok(JSON.stringify(scores)));
 });
 
-// Mirrors the per-work grouping in `club/list.ts` getReviewList, scoped to a
-// single work. Filters to current members so a departed member's stale score
-// doesn't reappear, and appends the average.
+// Loads the raw per-work review rows plus the current member set and hands them
+// to the shared `buildReviewScores` helper (the same map `club/list.ts` builds
+// per work), scoped to a single work.
 async function buildWorkScores(
   clubId: string,
   workId: string,
@@ -234,35 +235,7 @@ async function buildWorkScores(
   ]);
   const memberIds = new Set(members.map((member) => member.id));
 
-  const userScores = reviews.reduce<ReviewScores>((acc, review) => {
-    if (
-      hasValue(review.user_id) &&
-      hasValue(review.review_id) &&
-      hasValue(review.score) &&
-      isDefined(review.created_date) &&
-      memberIds.has(review.user_id)
-    ) {
-      acc[review.user_id] = {
-        id: review.review_id,
-        created_date: review.created_date.toISOString(),
-        score: parseFloat(review.score),
-      };
-    }
-    return acc;
-  }, {});
-
-  const entries = Object.values(userScores);
-  if (entries.length === 0) return {};
-
-  return {
-    ...userScores,
-    average: {
-      id: "average",
-      created_date: new Date().toISOString(),
-      score:
-        entries.reduce((sum, review) => sum + review.score, 0) / entries.length,
-    },
-  };
+  return buildReviewScores(reviews, memberIds);
 }
 
 router.get("/:workId/shared", async ({ clubId, params }, res) => {

--- a/netlify/functions/repositories/ReviewRepository.ts
+++ b/netlify/functions/repositories/ReviewRepository.ts
@@ -22,6 +22,7 @@ class ReviewRepository {
         "work_list_item.time_added",
         "review.score",
         "review.user_id",
+        "review.created_date",
       ])
       .execute();
   }

--- a/netlify/functions/utils/reviewScores.ts
+++ b/netlify/functions/utils/reviewScores.ts
@@ -1,0 +1,51 @@
+import { hasValue, isDefined } from "../../../lib/checks/checks.js";
+import { ReviewScores } from "../../../lib/types/lists.js";
+
+// A single review row, normalized across the different queries that surface
+// scores. `getReviewList` and `getReviewsByWorkId` name their date columns
+// differently (`time_added` vs `created_date`), so callers map their rows into
+// this shape before handing them off.
+export interface ScoreEntry {
+  user_id: string | null;
+  review_id: string | null;
+  score: string | null;
+  created_date: Date | null;
+}
+
+// Builds the `scores` map for a single work: one entry per current member plus
+// a synthetic `average`. Filters to `memberIds` so a departed member's stale
+// score doesn't reappear, and returns an empty object when no member has scored.
+export function buildReviewScores(
+  entries: ScoreEntry[],
+  memberIds: Set<string>,
+): ReviewScores {
+  const userScores = entries.reduce<ReviewScores>((acc, entry) => {
+    if (
+      hasValue(entry.user_id) &&
+      hasValue(entry.review_id) &&
+      hasValue(entry.score) &&
+      isDefined(entry.created_date) &&
+      memberIds.has(entry.user_id)
+    ) {
+      acc[entry.user_id] = {
+        id: entry.review_id,
+        created_date: entry.created_date.toISOString(),
+        score: parseFloat(entry.score),
+      };
+    }
+    return acc;
+  }, {});
+
+  const scores = Object.values(userScores);
+  if (scores.length === 0) return {};
+
+  return {
+    ...userScores,
+    average: {
+      id: "average",
+      created_date: new Date().toISOString(),
+      score:
+        scores.reduce((sum, review) => sum + review.score, 0) / scores.length,
+    },
+  };
+}

--- a/netlify/functions/utils/reviewScores.ts
+++ b/netlify/functions/utils/reviewScores.ts
@@ -1,10 +1,9 @@
 import { hasValue, isDefined } from "../../../lib/checks/checks.js";
 import { ReviewScores } from "../../../lib/types/lists.js";
 
-// A single review row, normalized across the different queries that surface
-// scores. `getReviewList` and `getReviewsByWorkId` name their date columns
-// differently (`time_added` vs `created_date`), so callers map their rows into
-// this shape before handing them off.
+// A single review row, as surfaced by the queries that feed the scores map
+// (`getReviewList` and `getReviewsByWorkId`). Both select these columns
+// directly, so callers hand their rows off without any remapping.
 export interface ScoreEntry {
   user_id: string | null;
   review_id: string | null;

--- a/src/features/reviews/components/ReviewScore.vue
+++ b/src/features/reviews/components/ReviewScore.vue
@@ -140,7 +140,7 @@ const { mutate: update } = useUpdateReviewScore(clubId);
 const submitScore = (score: number) => {
   if (!isNaN(score) && score >= 0 && score <= 10 && score !== props.score) {
     if (hasValue(props.reviewId)) {
-      update({ reviewId: props.reviewId, score });
+      update({ reviewId: props.reviewId, workId: props.workId, score });
     } else {
       submit({
         workId: props.workId,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -33,6 +33,9 @@ export const handlers = [
   http.put("/api/club/:id/reviews/:reviewId", () => {
     return new HttpResponse(null, { status: 200 });
   }),
+  http.get("/api/club/:id/reviews/:workId/scores", () => {
+    return HttpResponse.json(reviews[0]?.scores ?? {});
+  }),
   http.get("/api/club/:id/list", () => {
     return HttpResponse.json([
       { id: "1", title: "Watch List", systemType: null, itemCount: 1 },

--- a/src/service/useReviews.ts
+++ b/src/service/useReviews.ts
@@ -1,11 +1,68 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
+import {
+  QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/vue-query";
+import { AxiosInstance } from "axios";
 
 import { reviewsListKey } from "./useList";
 import { useUser } from "./useUser";
 import { isDefined } from "../../lib/checks/checks.js";
-import { DetailedReviewListItem, WorkCommentDto } from "../../lib/types/lists";
+import {
+  DetailedReviewListItem,
+  ReviewScores,
+  WorkCommentDto,
+} from "../../lib/types/lists";
 
 import { useAuthStore } from "@/stores/auth";
+
+const SCORE_POLL_ATTEMPTS = 10;
+const SCORE_POLL_INTERVAL_MS = 500;
+
+// After a member submits/edits their own score we briefly poll the lightweight
+// per-work scores endpoint so everyone else's scores (submitted around the same
+// time in a synchronized session) stream in without a manual refresh. Keyed by
+// `${clubSlug}:${workId}` with a monotonic token so re-submitting the same work
+// supersedes the previous loop instead of stacking a second one.
+const activeScorePolls = new Map<string, number>();
+
+function startScorePoll(
+  request: AxiosInstance,
+  queryClient: QueryClient,
+  clubSlug: string,
+  workId: string,
+) {
+  const pollKey = `${clubSlug}:${workId}`;
+  const token = (activeScorePolls.get(pollKey) ?? 0) + 1;
+  activeScorePolls.set(pollKey, token);
+
+  const tick = async (attempt: number) => {
+    if (activeScorePolls.get(pollKey) !== token) return;
+    try {
+      const { data } = await request.get<ReviewScores>(
+        `/api/club/${clubSlug}/reviews/${workId}/scores`,
+      );
+      if (activeScorePolls.get(pollKey) !== token) return;
+      queryClient.setQueryData<DetailedReviewListItem[]>(
+        reviewsListKey(clubSlug),
+        (current) =>
+          current?.map((item) =>
+            item.id === workId ? { ...item, scores: data } : item,
+          ),
+      );
+    } catch {
+      // Transient failure — keep polling; a later tick may succeed.
+    }
+    if (attempt + 1 < SCORE_POLL_ATTEMPTS) {
+      setTimeout(() => void tick(attempt + 1), SCORE_POLL_INTERVAL_MS);
+    } else if (activeScorePolls.get(pollKey) === token) {
+      activeScorePolls.delete(pollKey);
+    }
+  };
+
+  setTimeout(() => void tick(0), SCORE_POLL_INTERVAL_MS);
+}
 
 export function useReviewWork(clubSlug: string) {
   const auth = useAuthStore();
@@ -52,6 +109,8 @@ export function useReviewWork(clubSlug: string) {
         },
       );
     },
+    onSuccess: (_data, { workId }) =>
+      startScorePoll(auth.request, queryClient, clubSlug, workId),
     onSettled: () =>
       queryClient.invalidateQueries({
         queryKey: reviewsListKey(clubSlug),
@@ -64,7 +123,16 @@ export function useUpdateReviewScore(clubSlug: string) {
   const queryClient = useQueryClient();
   const user = useUser();
   return useMutation({
-    mutationFn: ({ reviewId, score }: { reviewId: string; score: number }) =>
+    // `workId` isn't part of the PUT body — it's carried through so `onSuccess`
+    // can poll the per-work scores endpoint after an edit.
+    mutationFn: ({
+      reviewId,
+      score,
+    }: {
+      reviewId: string;
+      workId: string;
+      score: number;
+    }) =>
       auth.request.put(`/api/club/${clubSlug}/reviews/${reviewId}`, {
         score,
       }),
@@ -95,6 +163,8 @@ export function useUpdateReviewScore(clubSlug: string) {
         },
       );
     },
+    onSuccess: (_data, { workId }) =>
+      startScorePoll(auth.request, queryClient, clubSlug, workId),
     onSettled: () =>
       queryClient.invalidateQueries({
         queryKey: reviewsListKey(clubSlug),

--- a/src/service/useReviews.ts
+++ b/src/service/useReviews.ts
@@ -9,6 +9,7 @@ import { AxiosInstance } from "axios";
 import { reviewsListKey } from "./useList";
 import { useUser } from "./useUser";
 import { isDefined } from "../../lib/checks/checks.js";
+import { Member } from "../../lib/types/club";
 import {
   DetailedReviewListItem,
   ReviewScores,
@@ -51,6 +52,19 @@ function startScorePoll(
             item.id === workId ? { ...item, scores: data } : item,
           ),
       );
+
+      // Stop early once every current member has a score — there's nothing left
+      // to wait for. (`data` also carries a synthetic `average` key, which we
+      // ignore by checking each member id directly.)
+      const members = queryClient.getQueryData<Member[]>(["members", clubSlug]);
+      if (
+        isDefined(members) &&
+        members.length > 0 &&
+        members.every((member) => isDefined(data[member.id]))
+      ) {
+        activeScorePolls.delete(pollKey);
+        return;
+      }
     } catch {
       // Transient failure — keep polling; a later tick may succeed.
     }


### PR DESCRIPTION
## Problem

Club members usually score a movie/book at the same time. After everyone submits, each person has to hard-refresh the page a few times before the others' scores show up.

That's because the reviews list query (`["list", <slug>, "reviews"]`) never refetches on its own — `refetchOnWindowFocus` is off and `main.ts` has a custom `refetchOnMount` that stops refetching after 2 fetches per session. A member's new score only reaches your client when *you* perform a mutation (which invalidates that key).

## Fix

Add a lightweight per-work scores endpoint and, after a member submits/edits their own score, poll it for a short window so everyone else's scores stream in without a manual refresh.

- **`GET /api/club/:clubSlug/reviews/:workId/scores`** (`secured`) returns *only* the `scores` map for one work (per-member entries plus the synthetic `average`) — the exact shape the frontend already stores per list item. It reuses the existing single-work query `ReviewRepository.getReviewsByWorkId` and filters to current members, so posters/metadata are never re-fetched.
- After `useReviewWork` / `useUpdateReviewScore` succeed, a module-scoped poller hits that endpoint **10 times at 0.5s intervals** and merges each response into the cached reviews list, replacing only the matching work's `scores`. A token-keyed map prevents overlapping loops when the same work is re-scored during the window.
- Existing optimistic update + `onSettled` invalidation are kept: the invalidation gives the submitter their own authoritative row immediately; the poll catches everyone else over the following ~5s.

Polling only fires right after a submission — there's no global `refetchInterval`, so idle/page-load traffic is unchanged.

## Files

- `netlify/functions/club/reviews.ts` — new `/:workId/scores` route + `buildWorkScores` helper
- `lib/types/lists.ts` — shared `ReviewScores` type
- `src/service/useReviews.ts` — `startScorePoll` + `onSuccess` wiring on both score mutations
- `src/features/reviews/components/ReviewScore.vue` — thread `workId` into the edit call
- `src/mocks/handlers.ts` — MSW handler for the new endpoint (strict MSW)

## Verification

- `npm run type-check`, `npm run lint`, `npm test` (154 passing) all green.
- Manual two-client check still recommended: with two members on the Reviews view, a score submitted by one appears for the other within ~5s without a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
