### PR TITLE
chore: trim CLAUDE.md and lighten Claude Code hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npm run format",
-            "timeout": 30000
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); if [ -n \"$f\" ]; then npx prettier --write --ignore-unknown \"$f\"; fi",
+            "timeout": 15000
           }
         ]
       }
@@ -17,8 +17,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npm run type-check && npm run lint",
-            "timeout": 180000
+            "command": "npm run type-check && files=$(git diff --name-only --diff-filter=d HEAD | grep -E '\\.(vue|ts|mjs|cjs|js)$' || true); if [ -n \"$files\" ]; then echo \"$files\" | xargs npx eslint --max-warnings 0; fi",
+            "timeout": 60000
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,16 +10,6 @@ Movie Club is a Vue 3 web application for managing movie clubs, reviews, custom 
 
 Code quality checks (`npm run type-check` and `npm run lint`) run automatically via Claude Code hooks after every file edit. Run `npm test` manually when changes affect tested code.
 
-## Claude Code Skills
-
-Skills in `.claude/skills/` provide domain-specific guidance for Claude Code sessions. Available skills:
-
-- **better-auth-best-practices** — BetterAuth integration guide with config options, session management, plugins, and common gotchas. Automatically consulted when working on authentication features.
-- **vue-best-practices** — Vue 3 Composition API guide covering reactivity, SFC structure, component data flow, composables, and performance. Automatically consulted when working on Vue components.
-- **tanstack-query-vue** — TanStack Query v4 patterns for data fetching, caching, mutations, and optimistic updates. Automatically consulted when working on service composables or server state.
-- **kysely** — Kysely v0.27 query builder patterns with CockroachDB dialect. Automatically consulted when working on database queries, repositories, or migrations.
-- **playwright-cli** — Browser automation for web testing, form filling, screenshots, and data extraction.
-
 ## Development Commands
 
 ### Running the Application
@@ -94,17 +84,6 @@ Snapshots are stored in `s3://movie-club-crdb-dev-exports`. The spawn command cr
 - **No `watch()`:** Prefer keyed components over `watch()` for query data. See `.claude/rules/code-quality.md` for rationale and exceptions.
 
 ## Common Patterns
-
-### Feature Module Structure
-
-```
-src/features/<feature-name>/
-  ├── views/            # Page-level components (routed)
-  ├── components/       # Feature-specific components
-  ├── composables/      # Vue composables (if needed)
-  ├── tests/            # Feature tests (if any)
-  └── constants.ts      # Feature constants (if needed)
-```
 
 ### Adding a New API Endpoint
 


### PR DESCRIPTION
Cleanup from a `/doctor` pass over the repo's Claude Code config. No product code touched.

## CLAUDE.md — trim derivable content (~19 lines, ~250 tokens/session)
Removed two blocks a fresh session can reconstruct from the repo itself:
- **"Claude Code Skills" listing** — redundant with the `SKILL.md` descriptions already auto-loaded from each `.claude/skills/*` every session.
- **"Feature Module Structure" tree** — derivable via `ls src/features/*`.

Everything non-derivable (DB workflows, `netlify dev` primacy, API/table/feature recipes, env vars) is kept.

## `.claude/settings.json` — make hooks incremental
Measured the current hooks and found the Stop hook blocking every turn-end for ~44s, almost entirely from ESLint:

| script | scope | measured |
|---|---|---|
| `type-check` (`vue-tsc`) | whole project | 4.4s |
| `lint` (eslint, 5 dirs) | whole project | **40.7s** |
| `format` (prettier, 5 dirs) | whole project | 2.7s |

Changes:
- **PostToolUse format** → run `prettier --write --ignore-unknown` on only the edited file (path read from the hook's stdin JSON). ~2.7s → ~0.02s.
- **Stop** → keep full `type-check`, but lint only files changed since `HEAD` instead of all 5 dirs. Turn-end **~44s → ~8s**.

The full lint/type-check sweep still runs in CI via `npm run build`, which remains the authoritative gate — the hooks are just faster in-loop feedback now.

Both hook commands were tested: format handles a real file (16ms) and empty stdin (exit 0); the Stop command runs clean at 4.4s with no changed files and lints a single real file in ~3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)