### PR TITLE
Fix club invite link losing its destination through signup/login

### DIFF
--- a/src/common/components/AuthModal.vue
+++ b/src/common/components/AuthModal.vue
@@ -141,10 +141,10 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { useToast } from "vue-toastification";
 
-import { isString } from "../../../lib/checks/checks.js";
+import { hasValue, isString } from "../../../lib/checks/checks.js";
 
 import googleLogo from "@/assets/images/google-logo.svg";
 import { authClient } from "@/lib/auth-client";
@@ -156,6 +156,7 @@ const emit = defineEmits<{
 
 const toast = useToast();
 const route = useRoute();
+const router = useRouter();
 const authStore = useAuthStore();
 
 const isSignUp = ref(false);
@@ -183,7 +184,27 @@ const getRedirectUrl = (): string | undefined => {
   if (isString(redirectParam)) {
     return redirectParam;
   }
+  // A club invite page is itself the destination to return to: users often
+  // authenticate mid-flow there, and losing the page loses the invite.
+  if (route.name === "JoinClub") {
+    return route.fullPath;
+  }
   return undefined;
+};
+
+// After an SPA (non-OAuth) auth success: return to the redirect target if
+// there is one, otherwise fall back to the user's default club. When the
+// target is the page we're already on (e.g. the invite page), stay put — the
+// view reacts to the session change on its own.
+const navigateAfterAuth = () => {
+  const redirect = getRedirectUrl();
+  if (hasValue(redirect)) {
+    if (redirect !== route.fullPath) {
+      router.push(redirect).catch(console.error);
+    }
+  } else {
+    void authStore.navigateToDefaultClub();
+  }
 };
 
 const handleSubmit = async () => {
@@ -194,11 +215,15 @@ const handleSubmit = async () => {
   try {
     if (isSignUp.value) {
       // Sign Up
+      // callbackURL is baked into the verification email link, so after
+      // verifying (which auto-signs-in) the user lands back where they
+      // started — e.g. the club invite page instead of the app root.
       await authClient.signUp.email(
         {
           email: email.value,
           password: password.value,
           name: name.value,
+          callbackURL: getRedirectUrl(),
         },
         {
           onSuccess: () => {
@@ -214,17 +239,19 @@ const handleSubmit = async () => {
       );
     } else {
       // Sign In
+      // No callbackURL here: Better Auth would hard-redirect to it, racing
+      // the SPA navigation below. navigateAfterAuth handles the redirect
+      // target (or default club) via the router instead.
       await authClient.signIn.email(
         {
           email: email.value,
           password: password.value,
-          callbackURL: getRedirectUrl(),
         },
         {
           onSuccess: () => {
             toast.success("Signed in successfully!");
             handleClose();
-            void authStore.navigateToDefaultClub();
+            navigateAfterAuth();
           },
           onError: (ctx) => {
             // Handle email verification required error
@@ -248,7 +275,7 @@ const handleResendVerification = async () => {
   try {
     await authClient.sendVerificationEmail({
       email: email.value,
-      callbackURL: "/",
+      callbackURL: getRedirectUrl() ?? "/",
     });
     toast.success("Verification email sent! Please check your inbox.");
   } catch {

--- a/src/features/settings/views/JoinClubView.vue
+++ b/src/features/settings/views/JoinClubView.vue
@@ -35,6 +35,9 @@
 import { computed, watchEffect } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
+import { hasValue } from "../../../../lib/checks/checks.js";
+
+import { setLastClubSlug } from "@/common/composables/useLastClubSlug";
 import { useJoinClub, useClubDetails, useIsInClub } from "@/service/useClub";
 import { useAuthStore } from "@/stores/auth";
 
@@ -53,18 +56,24 @@ const {
 } = useClubDetails(inviteToken);
 const isLoading = computed(() => isClubDetailsLoading.value || isJoining.value);
 
-const isInClub = useIsInClub(clubDetails.value?.clubId ?? "");
+const clubSlug = computed(() => clubDetails.value?.slug ?? "");
+const isInClub = useIsInClub(clubSlug);
 
 const handleJoinClub = () => {
   joinClub();
 };
 
+// Redirects to the club once the user is a member — either immediately for
+// users who were already members, or after the join mutation refreshes the
+// membership list. `replace` keeps the invite page out of history so the back
+// button doesn't bounce the user through the redirect again.
 watchEffect(() => {
-  if (isInClub.value === true) {
+  if (isInClub.value === true && hasValue(clubSlug.value)) {
+    setLastClubSlug(clubSlug.value);
     router
-      .push({
+      .replace({
         name: "ClubHome",
-        params: { clubId: clubDetails.value?.clubId },
+        params: { clubSlug: clubSlug.value },
       })
       .catch(console.error);
   }

--- a/src/service/useClub.ts
+++ b/src/service/useClub.ts
@@ -1,7 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
 import type { UseQueryReturnType } from "@tanstack/vue-query";
 import axios from "axios";
-import { computed } from "vue";
+import { computed, unref } from "vue";
+import type { MaybeRef } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import { reviewsListKey } from "./useList";
@@ -69,12 +70,13 @@ export function useClubSlug(): string {
   throw Error("This route does not include a clubSlug");
 }
 
-export function useIsInClub(clubSlug: string) {
+export function useIsInClub(clubSlug: MaybeRef<string>) {
   const { data: clubs, isLoading } = useUserClubs();
   const isUserInClub = computed(() => {
+    const slug = unref(clubSlug);
     return isLoading.value
       ? false
-      : (clubs.value?.some((club) => club.slug === clubSlug) ?? false);
+      : (clubs.value?.some((club) => club.slug === slug) ?? false);
   });
   return isUserInClub;
 }
@@ -110,7 +112,6 @@ export function useLeaveClub(clubSlug: string) {
 export function useJoinClub(inviteToken: string) {
   const auth = useAuthStore();
   const queryClient = useQueryClient();
-  const router = useRouter();
 
   return useMutation({
     mutationFn: () =>
@@ -118,9 +119,10 @@ export function useJoinClub(inviteToken: string) {
         token: inviteToken,
         userId: auth.user?.id,
       }),
+    // Navigation to the joined club is handled by JoinClubView, which reacts
+    // to the refreshed membership list once this invalidation resolves.
     onSuccess: async () => {
       await queryClient.invalidateQueries(["user", "clubs"]);
-      router.push({ name: "Clubs" }).catch(console.error);
     },
   });
 }


### PR DESCRIPTION
## Problem

Users who receive a club invite link (`/join-club/:token`) and sign up or log in as part of that flow aren't redirected to the club afterwards. Every auth path lost the invite destination:

- **Email sign-in** unconditionally called `navigateToDefaultClub()`, navigating away from the invite page to the user's default club (or `/newClub` for brand-new users).
- **Google OAuth** used `callbackURL = redirect ?? "/"`, but the invite page never sets a `?redirect` query param, so users landed on `/` and the Clubs guard sent them to their default club.
- **Sign-up** sent the verification email without a `callbackURL`, so the verification link (which auto-signs-in via `autoSignInAfterVerification`) dropped users at the app root with no trace of the invite. The resend-verification path hardcoded `"/"`.
- **After actually joining**, `useJoinClub` pushed `{ name: "Clubs" }`, whose guard resolves `lastClubSlug` from localStorage — often a *different* club than the one just joined.
- **JoinClubView's already-a-member auto-redirect never fired**: `useIsInClub` was called once at setup with `clubDetails.value?.clubId ?? ""` (always `""` since the query hadn't resolved, and `useIsInClub` compares against `slug`, not `clubId`), and even if it had fired, the push used a `clubId` param that the `ClubHome` route doesn't accept.

## Fix

**`AuthModal.vue`**
- `getRedirectUrl()` now treats the `JoinClub` page itself as the redirect target when no `?redirect` param is present.
- Email sign-in navigates via the router to the redirect target (or stays put when already on it, letting the invite page react to the session change), falling back to `navigateToDefaultClub()` as before. `callbackURL` is removed from `signIn.email` since Better Auth's hard redirect raced the SPA navigation.
- Sign-up and resend-verification pass the redirect target as `callbackURL`, so the verification email link returns the user to the invite page, already signed in.
- Google OAuth picks up the invite page automatically through the shared `getRedirectUrl()`.

**`useClub.ts`**
- `useIsInClub` accepts a `MaybeRef<string>` so membership is evaluated reactively once club details load (the existing plain-string call in `ReviewView` is unaffected).
- `useJoinClub` no longer navigates to `Clubs`; it just invalidates the membership list and lets the view own the redirect.

**`JoinClubView.vue`**
- Redirects to `ClubHome` by **slug** (with `router.replace` so back doesn't bounce through the invite page) whenever the user is a member — covering both already-member visits and freshly completed joins — and records the club via `setLastClubSlug` so subsequent visits to `/` resolve to it.

## Testing

- `npm run type-check`, `npm run lint`, and `npm test` (153/153) all pass.
- Not exercised against a live backend: this environment has no `.env`/secrets, so `netlify dev` (BetterAuth + CockroachDB + Resend) can't run. Worth a manual pass of the four flows (email sign-in, Google OAuth, sign-up → verify email, already-a-member invite click) on the deploy preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXUgS4HJsLWHkNGZ2Vfxaw

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXUgS4HJsLWHkNGZ2Vfxaw)_