### PR TITLE
Fix iOS share sheet "Copy" not copying the review link

### DIFF
--- a/src/common/composables/useShare.ts
+++ b/src/common/composables/useShare.ts
@@ -23,6 +23,21 @@ const isMobileDevice = (): boolean => {
 };
 
 /**
+ * Detects iOS devices (iPhone/iPad/iPod), including iPadOS reporting a
+ * Mac user agent.
+ */
+const isIosDevice = (): boolean => {
+  if (typeof navigator === "undefined") return false;
+
+  return (
+    /iPhone|iPad|iPod/i.test(navigator.userAgent) ||
+    (navigator.userAgent.includes("Mac") &&
+      typeof document !== "undefined" &&
+      "ontouchend" in document)
+  );
+};
+
+/**
  * Composable for sharing content using the native Web Share API when available,
  * with fallback to clipboard copy.
  */
@@ -46,7 +61,10 @@ export function useShare() {
         await navigator.share({
           url,
           title,
-          text,
+          // WebKit quirk: when both `text` and `url` are passed on iOS, the
+          // share sheet's "Copy" action copies only the text and drops the
+          // URL, so omit the text there to keep the link copyable.
+          text: isIosDevice() ? undefined : text,
         });
         // User completed or cancelled share - no toast needed for native share
       } catch (error) {


### PR DESCRIPTION
## Problem

On iOS, sharing a review and choosing **Copy** in the share sheet didn't copy the review link at all.

This is a WebKit quirk: when `navigator.share()` is called with both `text` and `url`, the iOS share sheet's "Copy" action copies only the `text` string and silently drops the URL. Both review share call sites (`ReviewView.vue` and `WorkDetailsContent.vue`) pass a descriptive `text` (e.g. "Cobresun's review of Dune") alongside the URL, so Copy yielded that sentence instead of the link.

## Fix

In the shared `useShare` composable, detect iOS devices (including iPadOS reporting a Mac user agent) and omit the `text` field from the `navigator.share()` payload there, so the "Copy" action gets the URL. Other platforms keep the descriptive text, and share targets like Messages still receive the title and URL on iOS.

Fixing it centrally in the composable covers all callers (review table, work details, and statistics shares).

## Testing

- `npm run type-check`, `npm run lint` — clean
- `npm test` — 153/153 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011P8BpqPaKCFMZrE1w2dZrX

---
_Generated by [Claude Code](https://claude.ai/code/session_011P8BpqPaKCFMZrE1w2dZrX)_