### PR TITLE
Clarify reviews sort UI in gallery view

### DIFF
--- a/src/features/reviews/components/GalleryView.vue
+++ b/src/features/reviews/components/GalleryView.vue
@@ -1,54 +1,72 @@
 <template>
   <div ref="galleryContainerRef" class="flex">
     <div class="w-full md:px-6">
-      <div class="relative mb-4 flex max-w-full flex-wrap gap-2">
+      <div class="relative mb-4 flex max-w-full flex-wrap items-center gap-2">
         <Listbox v-model="selectedSort">
-          <ListboxButton
-            class="flex items-center whitespace-nowrap rounded-full border border-white px-4 py-1"
-            ><span>Sort By</span><mdicon name="chevron-down"
-          /></ListboxButton>
-          <ListboxOptions
-            class="absolute z-10 rounded-md border border-white bg-background"
-          >
-            <ListboxOption
-              v-for="header in getSortableColumns()"
-              :key="header.id"
-              :value="header.id"
-              class="min-w-32 cursor-pointer px-2 py-1 text-left hover:bg-lowBackground"
+          <div class="relative">
+            <ListboxButton
+              class="flex items-center gap-1 whitespace-nowrap rounded-full border border-white px-4 py-1"
             >
-              <FlexRender
-                :render="header.column.columnDef.header"
-                :props="{
-                  ...header.getContext(),
-                  meta: { size: 'sm', showName: true },
-                }"
-              />
-            </ListboxOption>
-          </ListboxOptions>
+              <span>{{ activeSortOption ? "Sorted by" : "Sort by" }}</span>
+              <span v-if="activeSortOption" class="font-semibold">{{
+                activeSortOption.label
+              }}</span>
+              <mdicon name="chevron-down" />
+            </ListboxButton>
+            <ListboxOptions
+              class="absolute z-10 mt-1 max-h-80 overflow-auto rounded-md border border-white bg-background py-1"
+            >
+              <p class="px-3 py-1 text-left text-sm text-gray-400">
+                Sort reviews by
+              </p>
+              <ListboxOption
+                v-for="option in sortOptions"
+                v-slot="{ selected }"
+                :key="option.id"
+                :value="option.id"
+              >
+                <div
+                  class="flex min-w-52 cursor-pointer items-center gap-2 px-3 py-2 text-left hover:bg-lowBackground"
+                >
+                  <VAvatar
+                    v-if="option.type === 'member'"
+                    :src="option.image"
+                    :name="option.name"
+                    :size="24"
+                  />
+                  <img
+                    v-else-if="option.type === 'average'"
+                    :src="AverageImg"
+                    class="h-6 w-6 max-w-none"
+                  />
+                  <mdicon v-else name="clock-outline" class="w-6" />
+                  <span class="flex-grow">{{ option.label }}</span>
+                  <mdicon v-if="selected" name="check" class="text-primary" />
+                </div>
+              </ListboxOption>
+            </ListboxOptions>
+          </div>
         </Listbox>
 
-        <div
-          v-if="sortState[0]"
-          class="flex items-center whitespace-nowrap rounded-full border border-white px-4 py-1"
+        <button
+          v-if="activeSortOption"
+          type="button"
+          class="flex items-center gap-2 whitespace-nowrap rounded-full border border-white px-4 py-1 hover:bg-lowBackground"
+          :title="`Currently ${directionLabel.toLowerCase()}. Click to reverse.`"
+          @click="reverseSort"
         >
-          <FlexRender
-            :render="reviewTable.getColumn(sortState[0].id)?.columnDef.header"
-            :props="{ meta: { showName: true, size: 'sm' } }"
-          />
-          <mdicon
-            :name="sortState[0].desc ? 'chevron-down' : 'chevron-up'"
-            class="ml-2 cursor-pointer"
-            @click="reverseSort"
-          />
-        </div>
-        <div
-          v-if="sortState[0]"
-          class="flex cursor-pointer items-center whitespace-nowrap rounded-full border border-white px-4 py-1"
+          <mdicon :name="sortState[0]?.desc ? 'chevron-down' : 'chevron-up'" />
+          <span>{{ directionLabel }}</span>
+        </button>
+        <button
+          v-if="activeSortOption"
+          type="button"
+          class="flex cursor-pointer items-center gap-1 whitespace-nowrap rounded-full border border-white px-4 py-1 hover:bg-lowBackground"
           @click="selectedSort = undefined"
         >
           Clear
           <mdicon name="close" />
-        </div>
+        </button>
       </div>
 
       <!-- Removal stays instant (absolute hidden) so filtering never lags;
@@ -134,6 +152,8 @@ import { Member } from "../../../../lib/types/club";
 import { DetailedReviewListItem } from "../../../../lib/types/lists";
 import { RequestScoreEntryKey } from "../scoreEntry";
 
+import AverageImg from "@/assets/images/average.svg";
+import VAvatar from "@/common/components/VAvatar.vue";
 import WorkPosterCard from "@/common/components/WorkPosterCard.vue";
 
 const props = defineProps<{
@@ -178,6 +198,52 @@ const getSortableColumns = () => {
     return !NON_SORTABLE_COLUMNS.includes(header.id);
   });
 };
+
+// The raw column headers are avatars and images, so "sort by <avatar>" reads as
+// meaningless to users. Map each sortable column to a plain-language descriptor
+// ("Sarah's rating", "Average rating", "Date reviewed") the dropdown can spell
+// out instead.
+type SortOption =
+  | { id: string; type: "member"; label: string; name: string; image?: string }
+  | { id: string; type: "average"; label: string }
+  | { id: string; type: "date"; label: string };
+
+const sortOptions = computed<SortOption[]>(() =>
+  getSortableColumns()
+    .filter((header) => header.column.getCanSort())
+    .map((header) => {
+      const id = header.id;
+      const member = props.members.find((m) => `member_${m.id}` === id);
+      if (isDefined(member)) {
+        return {
+          id,
+          type: "member",
+          label: `${member.name}'s rating`,
+          name: member.name,
+          image: member.image,
+        };
+      }
+      if (id === "score_average") {
+        return { id, type: "average", label: "Average rating" };
+      }
+      return { id, type: "date", label: "Date reviewed" };
+    }),
+);
+
+const activeSortOption = computed(() =>
+  sortOptions.value.find((option) => option.id === sortState.value[0]?.id),
+);
+
+// Direction words depend on what's being sorted: dates read newest/oldest,
+// ratings read highest/lowest. A bare up/down chevron didn't convey either.
+const directionLabel = computed(() => {
+  const sort = sortState.value[0];
+  if (!isDefined(sort)) return "";
+  if (activeSortOption.value?.type === "date") {
+    return sort.desc ? "Newest first" : "Oldest first";
+  }
+  return sort.desc ? "Highest first" : "Lowest first";
+});
 
 const getCell = (row: Row<DetailedReviewListItem>, columnId: string) => {
   return row.getVisibleCells().find((cell) => cell.column.id === columnId);

--- a/src/features/reviews/tests/ReviewView.spec.ts
+++ b/src/features/reviews/tests/ReviewView.spec.ts
@@ -46,6 +46,46 @@ describe("ReviewView", () => {
     expect(await screen.findByRole("table")).toBeInTheDocument();
   });
 
+  it("should show human-readable sort options in the gallery sort menu", async () => {
+    const { user } = render(ReviewView, { props: { clubSlug: "1" } });
+
+    // Gallery view is the default; open the "Sort by" menu.
+    const sortButton = await screen.findByRole("button", { name: /sort by/i });
+    await user.click(sortButton);
+
+    // Members are spelled out as "<name>'s rating" instead of a bare avatar,
+    // and the aggregate/date columns get plain-language labels too.
+    expect(
+      await screen.findByRole("option", { name: /dev's rating/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /average rating/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /date reviewed/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should describe the sort direction in words once a sort is chosen", async () => {
+    const { user } = render(ReviewView, { props: { clubSlug: "1" } });
+
+    const sortButton = await screen.findByRole("button", { name: /sort by/i });
+    await user.click(sortButton);
+
+    await user.click(
+      await screen.findByRole("option", { name: /average rating/i }),
+    );
+
+    // Direction reads as words rather than a bare chevron, and reverses on click.
+    const directionButton = await screen.findByRole("button", {
+      name: /highest first/i,
+    });
+    await user.click(directionButton);
+    expect(
+      await screen.findByRole("button", { name: /lowest first/i }),
+    ).toBeInTheDocument();
+  });
+
   it("should filter reviews when using search bar", async () => {
     const { user } = render(ReviewView, { props: { clubSlug: "1" } });
     const searchBar = await screen.findByRole("textbox");


### PR DESCRIPTION
## Problem

On the Reviews page (gallery view), the **Sort By** menu rendered raw column headers. For a member column that header is just an avatar + name, so "sort by member" gave no indication that it actually sorts reviews by *that member's rating*. People didn't know what selecting a person meant. The sort-direction control was also a bare up/down chevron with no explanation of what the direction did.

## Changes

- **Plain-language sort options.** Each option now spells out what it sorts by: `<Name>'s rating`, `Average rating`, and `Date reviewed`. Avatars/icons are kept alongside the text for quick scanning.
- **Menu affordances.** Added a "Sort reviews by" heading and a check mark next to the currently active option.
- **Active state on the trigger.** The button now reads `Sorted by <label>` once a sort is applied, so the current sort is visible without opening the menu.
- **Worded direction toggle.** Replaced the bare chevron with a labeled button that adapts to the column: `Highest first` / `Lowest first` for ratings, `Newest first` / `Oldest first` for dates. Clicking reverses the direction (with a tooltip explaining the action).

The change is contained to `GalleryView.vue`; the table view (which sorts via per-column header icons in context) is unchanged.

## Testing

- Added two tests to `ReviewView.spec.ts` covering the human-readable option labels and the worded, reversible direction control.
- `npm run type-check`, `eslint`, the reviews test suite, and the icons registration test all pass. All sort icons used (`clock-outline`, `check`, `chevron-down`, `close`) are already registered in `src/icons.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bzyLrJKjFk2PWMwcmbYXA

---
_Generated by [Claude Code](https://claude.ai/code/session_017bzyLrJKjFk2PWMwcmbYXA)_