### PR TITLE
Move CI checks off Netlify to save build minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+# Runs the repository quality gates (type-check, lint, test) that used to live
+# inside the Netlify build command. Moving them here keeps them off Netlify's
+# 300-min/month build budget — this is a public repo, so Actions minutes are
+# free. Netlify now only migrates the DB and builds the site.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A newer push to the same branch cancels the in-flight run instead of stacking.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run type-check
+      - run: npm run lint
+      - run: npm test

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,16 @@
+[build]
+  # Deploy-only work. Quality gates (type-check, lint, test) run in GitHub
+  # Actions (.github/workflows/ci.yml) so they don't burn Netlify build minutes.
+  # `migrate` keeps the target DB (prod on production, the spawned/dev DB on
+  # previews) in sync; `vite build` produces the site.
+  command = "npm run migrate && vite build"
+
+  # Skip a preview rebuild when a push changes only non-deployed files (docs,
+  # Claude config). Exit 0 = Netlify cancels the build; a non-empty diff of
+  # everything-else exits non-zero and the build proceeds. Errors (e.g. missing
+  # CACHED_COMMIT_REF on a first build) are treated as "build" by Netlify.
+  ignore = "git diff --quiet ${CACHED_COMMIT_REF} ${COMMIT_REF} -- . ':(exclude)*.md' ':(exclude).claude/'"
+
 [[plugins]]
   package = "./netlify/plugins/preview-database"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,8 +2,11 @@
   # Deploy-only work. Quality gates (type-check, lint, test) run in GitHub
   # Actions (.github/workflows/ci.yml) so they don't burn Netlify build minutes.
   # `migrate` keeps the target DB (prod on production, the spawned/dev DB on
-  # previews) in sync; `vite build` produces the site.
-  command = "npm run migrate && vite build"
+  # previews) in sync and regenerates lib/types/generated/db.ts; the git diff
+  # then fails the build if the committed types don't match the migrated schema
+  # (GitHub Actions type-checks against the committed file, so a stale db.ts
+  # would otherwise slip through). `vite build` produces the site.
+  command = "npm run migrate && (git diff --exit-code -- lib/types/generated || (echo 'Generated DB types are stale: run npm run codegen and commit lib/types/generated/db.ts' && exit 1)) && vite build"
 
   # Skip a preview rebuild when a push changes only non-deployed files (docs,
   # Claude config). Exit 0 = Netlify cancels the build; a non-empty diff of


### PR DESCRIPTION
## Why

Netlify had **no build command set**, so every deploy (production + every deploy-preview push) ran the full `npm run build`:

```
migrate && type-check && lint && test && vite build
```

The three quality gates dominate build time yet produce **no deploy artifact** — they were burning our 300-min/month Netlify budget, which is why we hit the cap so early each month.

## What changed

- **`.github/workflows/ci.yml`** (new) — runs `type-check` / `lint` / `test` on PRs and `main` pushes. This is a public repo, so Actions minutes are **free**. No secrets needed (tests are MSW-mocked); `concurrency` cancels superseded runs.
- **`netlify.toml`** — added a `[build]` block slimming the deploy to `npm run migrate && vite build`. Plugin `onPreBuild` order is preserved, so `migrate` still targets the correct (prod/preview) DB. Added an `ignore` rule so preview rebuilds skip docs-only / `.claude/`-only pushes.

## Speedup (measured on this PR)

Netlify build time, this PR vs. the recent baseline:

|                     | Build command           | Netlify build time       |
| ------------------- | ----------------------- | ------------------------ |
| **This PR (#420)**  | `migrate && vite build` | **42s** ✅               |
| Previous ~24 builds | full `npm run build`    | 140–169s (avg **~152s**) |

**→ ~110s faster per build — a 72% cut in Netlify build time.**

The CI work didn't disappear; it moved to GitHub's free budget. The Actions `checks` job took **~2m06s**, and its shape is exactly what left Netlify:

| Step         | Duration                    |
| ------------ | --------------------------- |
| `lint`       | **75s** ← the dominant cost |
| `test`       | 14s                         |
| `type-check` | 11s                         |
| `npm ci`     | 12s                         |

### Projected monthly impact

Extrapolating the recent deploy volume (~150 builds/month):

- **Before:** ~152s/build → **~380 min/month** — over the 300-min cap
- **After:** ~42s/build → **~105 min/month**


## Follow-up (required) ✅ 

Netlify no longer gates deploys on lint/test. **Require the new `checks` status check in `main` branch protection** so merges stay gated. It becomes selectable after this workflow's first run (already green on this PR).

<img width="926" height="430" alt="Screenshot 2026-07-15 at 10 20 20 PM" src="https://github.com/user-attachments/assets/2638c7f8-4cf4-4096-9c23-12d4104b23af" />
