### PR TITLE
Enrich Score Assist similarity: more signals, IDF, normalized blend

### DIFF
--- a/src/common/clubType.ts
+++ b/src/common/clubType.ts
@@ -155,13 +155,14 @@ export interface ClubTypeConfig {
   /** Per-type extraction of the strings shown in the details drawers. */
   readonly display: WorkDisplay;
   /**
-   * How alike two works of this club's type are, for Score Assist's pivot
-   * selection. Missing or mismatched-kind metadata scores 0.
+   * Build a similarity scorer for Score Assist's pivot selection, calibrated to
+   * a candidate pool (its tag frequencies weight the overlaps). The returned
+   * scorer maps a (target, candidate) pair to [0,1]; missing or mismatched-kind
+   * metadata scores 0.
    */
-  readonly similarity: (
-    target: WorkDataSummary | undefined,
-    candidate: WorkDataSummary | undefined,
-  ) => number;
+  readonly makeSimilarity: (
+    corpus: readonly (WorkDataSummary | undefined)[],
+  ) => WorkSimilarityScorer;
 }
 
 /**
@@ -308,39 +309,183 @@ const bookDisplay: WorkDisplay = {
 };
 
 // --- Per-type similarity (Score Assist pivot selection) ---------------------
-// How strongly a shared primary credit (director / author) counts towards
-// similarity, relative to a shared category (genre / subject).
-const PRIMARY_CREDIT_WEIGHT = 3;
-const CATEGORY_WEIGHT = 1;
+// Score Assist ranks comparison candidates by how "alike" they feel to the work
+// being reviewed, so the user compares familiar things. A scorer returns a value
+// in [0,1] (0 = nothing in common, 1 = identical on every measured axis): a
+// weighted average of per-field overlaps. Per-field weights encode that a shared
+// director/author counts far more than a shared genre/subject. Set overlaps use
+// a weighted Jaccard (intersection over union, so a work with many tags isn't
+// spuriously "similar" to everything), with each tag's weight coming from its
+// inverse document frequency in the club's own catalogue — sharing a rare genre
+// counts for more than sharing a ubiquitous one ("Drama"). Era/length signals
+// decay continuously with distance rather than snapping at a bucket boundary.
 
-// Case-insensitive: Google Books subjects vary in casing between volumes.
-function sharedCount(a: readonly string[], b: readonly string[]): number {
-  const normalized = new Set(a.map((value) => value.toLowerCase()));
-  return b.filter((value) => normalized.has(value.toLowerCase())).length;
+/** A comparison scorer specialised to one candidate pool (see makeSimilarity). */
+export type WorkSimilarityScorer = (
+  target: WorkDataSummary | undefined,
+  candidate: WorkDataSummary | undefined,
+) => number;
+
+const lower = (value: string): string => value.toLowerCase();
+
+const sum = (values: readonly number[]): number =>
+  values.reduce((total, value) => total + value, 0);
+
+/** Years of separation at which the release/publish-era signal halves. */
+const ERA_HALF_LIFE_YEARS = 15;
+/** Page-count difference at which the book-length signal halves. */
+const PAGE_HALF_LIFE = 300;
+
+// Movie field weights: a shared director dominates, cast/studio/genre are
+// secondary, era/language are gentle nudges. Books mirror the shape.
+const MOVIE_FIELD_WEIGHTS = {
+  director: 5,
+  cast: 2,
+  company: 1.5,
+  genre: 2,
+  era: 1,
+  language: 0.5,
+} as const;
+const BOOK_FIELD_WEIGHTS = {
+  author: 5,
+  subject: 2.5,
+  era: 1,
+  length: 0.5,
+} as const;
+
+/**
+ * Build an inverse-document-frequency lookup for one tag field over a catalogue.
+ * Smoothed so an empty corpus (or a tag no work has) weighs 1 — i.e. the scorer
+ * degrades to a plain Jaccard — while rarer tags weigh above 1.
+ */
+function buildIdf(
+  corpus: readonly (WorkDataSummary | undefined)[],
+  extract: (data: WorkDataSummary | undefined) => readonly string[],
+): (tag: string) => number {
+  const documentFrequency = new Map<string, number>();
+  for (const data of corpus) {
+    for (const tag of new Set(extract(data).map(lower))) {
+      documentFrequency.set(tag, (documentFrequency.get(tag) ?? 0) + 1);
+    }
+  }
+  const total = corpus.length;
+  return (tag) =>
+    Math.log((total + 1) / ((documentFrequency.get(lower(tag)) ?? 0) + 1)) + 1;
 }
 
-const movieSimilarity: ClubTypeConfig["similarity"] = (target, candidate) => {
-  const a = asMovie(target);
-  const b = asMovie(candidate);
-  if (a === undefined || b === undefined) return 0;
-  return (
-    sharedCount(
-      a.directors.map((director) => director.name),
-      b.directors.map((director) => director.name),
-    ) *
-      PRIMARY_CREDIT_WEIGHT +
-    sharedCount(a.genres, b.genres) * CATEGORY_WEIGHT
+/**
+ * IDF-weighted Jaccard overlap of two tag sets, in [0,1]. Returns 0 when either
+ * side is empty — two works that both list no genres share no signal, they are
+ * not "identical".
+ */
+function weightedJaccard(
+  a: readonly string[],
+  b: readonly string[],
+  idf: (tag: string) => number,
+): number {
+  const setA = new Set(a.map(lower));
+  const setB = new Set(b.map(lower));
+  if (setA.size === 0 || setB.size === 0) return 0;
+  let intersection = 0;
+  let union = 0;
+  for (const tag of new Set([...setA, ...setB])) {
+    const weight = idf(tag);
+    union += weight;
+    if (setA.has(tag) && setB.has(tag)) intersection += weight;
+  }
+  return union === 0 ? 0 : intersection / union;
+}
+
+/** Exponential closeness in [0,1]: 1 when equal, 0.5 at one half-life apart. */
+function proximityDecay(
+  a: number | undefined,
+  b: number | undefined,
+  halfLife: number,
+): number {
+  if (!isDefined(a) || !isDefined(b)) return 0;
+  return Math.exp((-Math.abs(a - b) * Math.LN2) / halfLife);
+}
+
+function names(people: readonly { name: string }[]): string[] {
+  return people.map((person) => person.name);
+}
+
+function releaseYear(data: { release_date?: string }): number | undefined {
+  const year = hasValue(data.release_date)
+    ? Number.parseInt(data.release_date.slice(0, 4), 10)
+    : Number.NaN;
+  return Number.isFinite(year) ? year : undefined;
+}
+
+const makeMovieSimilarity = (
+  corpus: readonly (WorkDataSummary | undefined)[],
+): WorkSimilarityScorer => {
+  const directorIdf = buildIdf(corpus, (d) =>
+    names(asMovie(d)?.directors ?? []),
   );
+  // Bulk payloads carry cast names only (castNames); full actor objects live in
+  // the per-work detail payload and aren't available for pivot scoring.
+  const castIdf = buildIdf(corpus, (d) => asMovie(d)?.castNames ?? []);
+  const companyIdf = buildIdf(
+    corpus,
+    (d) => asMovie(d)?.production_companies ?? [],
+  );
+  const genreIdf = buildIdf(corpus, (d) => asMovie(d)?.genres ?? []);
+  const totalWeight = sum(Object.values(MOVIE_FIELD_WEIGHTS));
+
+  return (target, candidate) => {
+    const a = asMovie(target);
+    const b = asMovie(candidate);
+    if (a === undefined || b === undefined) return 0;
+    const sameLanguage =
+      hasValue(a.original_language) &&
+      a.original_language === b.original_language;
+    const weighted =
+      MOVIE_FIELD_WEIGHTS.director *
+        weightedJaccard(names(a.directors), names(b.directors), directorIdf) +
+      MOVIE_FIELD_WEIGHTS.cast *
+        weightedJaccard(a.castNames, b.castNames, castIdf) +
+      MOVIE_FIELD_WEIGHTS.company *
+        weightedJaccard(
+          a.production_companies,
+          b.production_companies,
+          companyIdf,
+        ) +
+      MOVIE_FIELD_WEIGHTS.genre *
+        weightedJaccard(a.genres, b.genres, genreIdf) +
+      MOVIE_FIELD_WEIGHTS.era *
+        proximityDecay(releaseYear(a), releaseYear(b), ERA_HALF_LIFE_YEARS) +
+      MOVIE_FIELD_WEIGHTS.language * (sameLanguage ? 1 : 0);
+    return weighted / totalWeight;
+  };
 };
 
-const bookSimilarity: ClubTypeConfig["similarity"] = (target, candidate) => {
-  const a = asBook(target);
-  const b = asBook(candidate);
-  if (a === undefined || b === undefined) return 0;
-  return (
-    sharedCount(a.authors, b.authors) * PRIMARY_CREDIT_WEIGHT +
-    sharedCount(a.subjects, b.subjects) * CATEGORY_WEIGHT
-  );
+const makeBookSimilarity = (
+  corpus: readonly (WorkDataSummary | undefined)[],
+): WorkSimilarityScorer => {
+  const authorIdf = buildIdf(corpus, (d) => asBook(d)?.authors ?? []);
+  const subjectIdf = buildIdf(corpus, (d) => asBook(d)?.subjects ?? []);
+  const totalWeight = sum(Object.values(BOOK_FIELD_WEIGHTS));
+
+  return (target, candidate) => {
+    const a = asBook(target);
+    const b = asBook(candidate);
+    if (a === undefined || b === undefined) return 0;
+    const weighted =
+      BOOK_FIELD_WEIGHTS.author *
+        weightedJaccard(a.authors, b.authors, authorIdf) +
+      BOOK_FIELD_WEIGHTS.subject *
+        weightedJaccard(a.subjects, b.subjects, subjectIdf) +
+      BOOK_FIELD_WEIGHTS.era *
+        proximityDecay(
+          a.firstPublishYear,
+          b.firstPublishYear,
+          ERA_HALF_LIFE_YEARS,
+        ) +
+      BOOK_FIELD_WEIGHTS.length *
+        proximityDecay(a.numberOfPages, b.numberOfPages, PAGE_HALF_LIFE);
+    return weighted / totalWeight;
+  };
 };
 
 /**
@@ -409,7 +554,7 @@ export const CLUB_TYPE_CONFIG: Record<ClubType, ClubTypeConfig> = {
       shareTitle: "Movie Club Statistics",
     },
     display: movieDisplay,
-    similarity: movieSimilarity,
+    makeSimilarity: makeMovieSimilarity,
   },
   [ClubType.book]: {
     clubType: ClubType.book,
@@ -455,7 +600,7 @@ export const CLUB_TYPE_CONFIG: Record<ClubType, ClubTypeConfig> = {
       shareTitle: "Book Club Statistics",
     },
     display: bookDisplay,
-    similarity: bookSimilarity,
+    makeSimilarity: makeBookSimilarity,
   },
 };
 
@@ -532,17 +677,26 @@ export function workOverview(
 }
 
 /**
- * How alike two works are, for preferring familiar comparison points while
- * Score Assist binary-searches a score. Missing or mismatched-kind metadata
- * scores 0, so pivot selection degrades gracefully to score-midpoint distance.
+ * Build a similarity scorer for a work type, calibrated to a candidate pool so
+ * tag overlaps are IDF-weighted against that catalogue. Score Assist builds one
+ * scorer per session and reuses it across every pivot comparison.
+ */
+export function makeWorkSimilarity(
+  type: WorkType,
+  corpus: readonly (WorkDataSummary | undefined)[],
+): WorkSimilarityScorer {
+  return clubTypeConfig(CLUB_TYPE_BY_WORK_TYPE[type]).makeSimilarity(corpus);
+}
+
+/**
+ * A single similarity comparison with no catalogue context (every tag weighs
+ * equally). Convenience for one-off callers and tests; Score Assist itself uses
+ * {@link makeWorkSimilarity} so overlaps are IDF-weighted by the club's works.
  */
 export function workSimilarity(
   type: WorkType,
   target: WorkDataSummary | undefined,
   candidate: WorkDataSummary | undefined,
 ): number {
-  return clubTypeConfig(CLUB_TYPE_BY_WORK_TYPE[type]).similarity(
-    target,
-    candidate,
-  );
+  return makeWorkSimilarity(type, [])(target, candidate);
 }

--- a/src/features/reviews/composables/scoreAssistLogic.ts
+++ b/src/features/reviews/composables/scoreAssistLogic.ts
@@ -5,7 +5,7 @@ import {
   WorkDataSummary,
 } from "../../../../lib/types/lists";
 
-import { workSimilarity } from "@/common/clubType";
+import { makeWorkSimilarity, WorkSimilarityScorer } from "@/common/clubType";
 
 /**
  * Score Assist: converge on a 0-10 score suggestion for a target work by
@@ -46,6 +46,11 @@ export interface ScoreAssistResult {
 export interface ScoreAssistSession {
   readonly targetType: WorkType;
   readonly targetData?: WorkDataSummary;
+  /**
+   * Similarity scorer, IDF-calibrated to this session's candidate pool once at
+   * startSession and reused for every pivot comparison.
+   */
+  readonly similarity: WorkSimilarityScorer;
   /** Sorted ascending by score (title tie-break). */
   readonly candidates: readonly ScoredCandidate[];
   /**
@@ -109,12 +114,17 @@ export function startSession(
   target: DetailedReviewListItem,
   candidates: readonly ScoredCandidate[],
 ): ScoreAssistSession {
+  const sorted = [...candidates].sort((a, b) =>
+    a.score !== b.score ? a.score - b.score : a.title.localeCompare(b.title),
+  );
   const session: ScoreAssistSession = {
     targetType: target.type,
     targetData: target.externalData,
-    candidates: [...candidates].sort((a, b) =>
-      a.score !== b.score ? a.score - b.score : a.title.localeCompare(b.title),
+    similarity: makeWorkSimilarity(
+      target.type,
+      sorted.map((candidate) => candidate.externalData),
     ),
+    candidates: sorted,
     lo: 0,
     hi: 10,
     askedWorkIds: [],
@@ -193,12 +203,23 @@ function eligiblePivots(session: ScoreAssistSession): ScoredCandidate[] {
   });
 }
 
+// Pivot scoring weights. Similarity (in [0,1]) leads, so a clearly more familiar
+// comparison still wins. The positional term is a bounded nudge: it only decides
+// between candidates of comparable similarity, keeping the pivot near the centre
+// of the window so the binary search stays balanced instead of drifting to a
+// marginally-more-similar edge candidate. Within that term, closeness to the
+// bracket's score midpoint dominates and rank centrality only breaks its ties -
+// preserving the original ordering when no metadata is available.
+const POSITION_WEIGHT = 0.3;
+const RANK_TIEBREAK_WEIGHT = 0.01;
+
 /**
- * Pick the next comparison work: from the rank-middle third of the eligible
+ * Pick the next comparison work from the rank-middle third of the eligible
  * candidates (rank, not score-midpoint, so clumped scores still halve the
- * search space), prefer the work most similar to the target, then the one
- * closest to the bracket's score midpoint, then the most central rank.
- * Deterministic on purpose - tests can assert exact pivots.
+ * search space). Each candidate is scored as similarity + a bounded positional
+ * term (score-midpoint closeness, rank centrality as a tiebreak); the highest
+ * wins, exact ties breaking to the lowest index. Deterministic on purpose -
+ * tests can assert exact pivots.
  */
 function selectPivot(session: ScoreAssistSession): ScoredCandidate | undefined {
   const eligible = eligiblePivots(session);
@@ -208,28 +229,40 @@ function selectPivot(session: ScoreAssistSession): ScoredCandidate | undefined {
   const scoreMidpoint = (session.lo + session.hi) / 2;
   const windowMiddle = (start + end - 1) / 2;
 
+  // Normalise the two positional distances against the window's own spread so
+  // each lands in [0,1]. A zero spread (single item, or every score equal) makes
+  // that term uniform rather than dividing by zero.
+  let maxScoreDistance = 0;
+  let maxRankDistance = 0;
+  for (let i = start; i < end; i++) {
+    maxScoreDistance = Math.max(
+      maxScoreDistance,
+      Math.abs(eligible[i].score - scoreMidpoint),
+    );
+    maxRankDistance = Math.max(maxRankDistance, Math.abs(i - windowMiddle));
+  }
+
   let best: ScoredCandidate | undefined;
-  let bestRank: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  let bestScore = -Infinity;
   for (let i = start; i < end; i++) {
     const candidate = eligible[i];
-    const rank: [number, number, number] = [
-      workSimilarity(
-        session.targetType,
-        session.targetData,
-        candidate.externalData,
-      ),
-      -Math.abs(candidate.score - scoreMidpoint),
-      -Math.abs(i - windowMiddle),
-    ];
-    if (
-      !isDefined(best) ||
-      rank[0] > bestRank[0] ||
-      (rank[0] === bestRank[0] &&
-        (rank[1] > bestRank[1] ||
-          (rank[1] === bestRank[1] && rank[2] > bestRank[2])))
-    ) {
+    const similarity = session.similarity(
+      session.targetData,
+      candidate.externalData,
+    );
+    const scoreProximity =
+      maxScoreDistance === 0
+        ? 1
+        : 1 - Math.abs(candidate.score - scoreMidpoint) / maxScoreDistance;
+    const rankCentrality =
+      maxRankDistance === 0
+        ? 1
+        : 1 - Math.abs(i - windowMiddle) / maxRankDistance;
+    const positional = scoreProximity + RANK_TIEBREAK_WEIGHT * rankCentrality;
+    const combined = similarity + POSITION_WEIGHT * positional;
+    if (combined > bestScore) {
       best = candidate;
-      bestRank = rank;
+      bestScore = combined;
     }
   }
   return best;

--- a/src/features/reviews/tests/scoreAssistLogic.spec.ts
+++ b/src/features/reviews/tests/scoreAssistLogic.spec.ts
@@ -15,36 +15,56 @@ import {
   startSession,
 } from "../composables/scoreAssistLogic";
 
-import { workSimilarity } from "@/common/clubType";
+import { makeWorkSimilarity, workSimilarity } from "@/common/clubType";
 
 const USER_ID = "user-1";
 const OTHER_USER_ID = "user-2";
 
 function movieData(
-  opts: { directors?: string[]; genres?: string[] } = {},
+  opts: {
+    directors?: string[];
+    genres?: string[];
+    actors?: string[];
+    companies?: string[];
+    releaseDate?: string;
+    language?: string;
+  } = {},
 ): DetailedMovieData {
   return {
     kind: "movie",
-    actors: [],
-    castNames: [],
+    actors: (opts.actors ?? []).map((name) => ({
+      name,
+      character: null,
+      profilePath: null,
+    })),
+    castNames: opts.actors ?? [],
     directors: (opts.directors ?? []).map((name) => ({
       name,
       profilePath: null,
     })),
     genres: opts.genres ?? [],
-    production_companies: [],
+    production_companies: opts.companies ?? [],
     production_countries: [],
+    release_date: opts.releaseDate,
+    original_language: opts.language,
   };
 }
 
 function bookData(
-  opts: { authors?: string[]; subjects?: string[] } = {},
+  opts: {
+    authors?: string[];
+    subjects?: string[];
+    firstPublishYear?: number;
+    numberOfPages?: number;
+  } = {},
 ): DetailedBookData {
   return {
     kind: "book",
     title: "A Book",
     authors: opts.authors ?? [],
     subjects: opts.subjects ?? [],
+    firstPublishYear: opts.firstPublishYear,
+    numberOfPages: opts.numberOfPages,
   };
 }
 
@@ -320,28 +340,113 @@ describe("termination and suggestions", () => {
 });
 
 describe("workSimilarity", () => {
+  it("normalises every score into [0,1]", () => {
+    const nolan = movieData({ directors: ["Nolan"] });
+    const score = workSimilarity(WorkType.movie, nolan, nolan);
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
   it("weights a shared director above shared genres", () => {
     const t = movieData({
       directors: ["Nolan"],
       genres: ["Drama", "Thriller"],
     });
-    expect(
-      workSimilarity(WorkType.movie, t, movieData({ directors: ["Nolan"] })),
-    ).toBe(3);
-    expect(
-      workSimilarity(
-        WorkType.movie,
-        t,
-        movieData({ genres: ["Drama", "Thriller"] }),
-      ),
-    ).toBe(2);
-    expect(
-      workSimilarity(
-        WorkType.movie,
-        t,
-        movieData({ directors: ["Nolan"], genres: ["Drama"] }),
-      ),
-    ).toBe(4);
+    const sharedDirector = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ directors: ["Nolan"] }),
+    );
+    const sharedGenres = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ genres: ["Drama", "Thriller"] }),
+    );
+    expect(sharedDirector).toBeGreaterThan(sharedGenres);
+    expect(sharedGenres).toBeGreaterThan(0);
+  });
+
+  it("accumulates independent signals - director plus genre beats either alone", () => {
+    const t = movieData({ directors: ["Nolan"], genres: ["Drama"] });
+    const both = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ directors: ["Nolan"], genres: ["Drama"] }),
+    );
+    const directorOnly = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ directors: ["Nolan"] }),
+    );
+    expect(both).toBeGreaterThan(directorOnly);
+  });
+
+  it("uses Jaccard overlap, so a broad tag set is not spuriously similar", () => {
+    const t = movieData({ genres: ["Drama"] });
+    const focused = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ genres: ["Drama"] }),
+    );
+    const diluted = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ genres: ["Drama", "Action", "Comedy", "Horror"] }),
+    );
+    // Same shared genre, but the diluted candidate's larger union lowers overlap.
+    expect(focused).toBeGreaterThan(diluted);
+  });
+
+  it("rewards a shared lead actor, but less than a shared director", () => {
+    const t = movieData({ directors: ["Nolan"], actors: ["Bale"] });
+    const sharedActor = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ actors: ["Bale"] }),
+    );
+    const sharedDirector = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ directors: ["Nolan"] }),
+    );
+    expect(sharedActor).toBeGreaterThan(0);
+    expect(sharedActor).toBeLessThan(sharedDirector);
+  });
+
+  it("decays the era signal continuously with release-year distance", () => {
+    const t = movieData({ releaseDate: "2000-01-01" });
+    const sameYear = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ releaseDate: "2000-06-01" }),
+    );
+    const nearYear = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ releaseDate: "2005-01-01" }),
+    );
+    const farYear = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ releaseDate: "1960-01-01" }),
+    );
+    expect(sameYear).toBeGreaterThan(nearYear);
+    expect(nearYear).toBeGreaterThan(farYear);
+  });
+
+  it("adds a small bump for a shared original language", () => {
+    const t = movieData({ language: "ja" });
+    const sameLanguage = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ language: "ja" }),
+    );
+    const otherLanguage = workSimilarity(
+      WorkType.movie,
+      t,
+      movieData({ language: "en" }),
+    );
+    expect(sameLanguage).toBeGreaterThan(otherLanguage);
   });
 
   it("matches book authors and subjects case-insensitively", () => {
@@ -349,25 +454,79 @@ describe("workSimilarity", () => {
       authors: ["Ursula K. Le Guin"],
       subjects: ["Science Fiction"],
     });
-    expect(
-      workSimilarity(
-        WorkType.book,
-        t,
-        bookData({ subjects: ["science fiction"] }),
-      ),
-    ).toBe(1);
-    expect(
-      workSimilarity(
-        WorkType.book,
-        t,
-        bookData({ authors: ["Ursula K. Le Guin"] }),
-      ),
-    ).toBe(3);
+    const sharedSubject = workSimilarity(
+      WorkType.book,
+      t,
+      bookData({ subjects: ["science fiction"] }),
+    );
+    const sharedAuthor = workSimilarity(
+      WorkType.book,
+      t,
+      bookData({ authors: ["ursula k. le guin"] }),
+    );
+    expect(sharedSubject).toBeGreaterThan(0);
+    expect(sharedAuthor).toBeGreaterThan(sharedSubject);
+  });
+
+  it("decays book era and length signals with distance", () => {
+    const t = bookData({ firstPublishYear: 1990, numberOfPages: 300 });
+    const closeEra = workSimilarity(
+      WorkType.book,
+      t,
+      bookData({ firstPublishYear: 1992 }),
+    );
+    const farEra = workSimilarity(
+      WorkType.book,
+      t,
+      bookData({ firstPublishYear: 1900 }),
+    );
+    expect(closeEra).toBeGreaterThan(farEra);
+
+    const closeLength = workSimilarity(
+      WorkType.book,
+      t,
+      bookData({ numberOfPages: 320 }),
+    );
+    const farLength = workSimilarity(
+      WorkType.book,
+      t,
+      bookData({ numberOfPages: 900 }),
+    );
+    expect(closeLength).toBeGreaterThan(farLength);
   });
 
   it("scores 0 for missing or mismatched metadata", () => {
     expect(workSimilarity(WorkType.movie, undefined, movieData())).toBe(0);
     expect(workSimilarity(WorkType.movie, movieData(), bookData())).toBe(0);
     expect(workSimilarity(WorkType.book, bookData(), undefined)).toBe(0);
+    // Two works that each list no genres share no signal - not "identical".
+    expect(workSimilarity(WorkType.movie, movieData(), movieData())).toBe(0);
+  });
+});
+
+describe("makeWorkSimilarity IDF weighting", () => {
+  it("weights a rare shared genre above a ubiquitous one", () => {
+    // A catalogue where every film is a Drama but only one is Film-Noir.
+    const corpus = [
+      movieData({ genres: ["Drama"] }),
+      movieData({ genres: ["Drama"] }),
+      movieData({ genres: ["Drama"] }),
+      movieData({ genres: ["Drama", "Film-Noir"] }),
+    ];
+    const scorer = makeWorkSimilarity(WorkType.movie, corpus);
+    const target = movieData({ genres: ["Drama", "Film-Noir"] });
+
+    const sharedRare = scorer(target, movieData({ genres: ["Film-Noir"] }));
+    const sharedCommon = scorer(target, movieData({ genres: ["Drama"] }));
+    expect(sharedRare).toBeGreaterThan(sharedCommon);
+  });
+
+  it("falls back to equal weighting with an empty catalogue", () => {
+    const scorer = makeWorkSimilarity(WorkType.movie, []);
+    const target = movieData({ genres: ["Drama"] });
+    // With no corpus, IDF is 1 for every tag, matching the workSimilarity helper.
+    expect(scorer(target, movieData({ genres: ["Drama"] }))).toBeCloseTo(
+      workSimilarity(WorkType.movie, target, movieData({ genres: ["Drama"] })),
+    );
   });
 });


### PR DESCRIPTION
## What

Reworks the `workSimilarity` heuristic that drives **Score Assist**'s pivot selection (the "not sure what to score this?" comparison flow). It previously ranked comparison candidates by a raw count: `sharedDirectors × 3 + sharedGenres × 1` (authors/subjects for books). That fires rarely (most pairs score 0), is biased toward over-tagged works, and treats every tag as equally informative.

## Changes

**`clubType.ts` — the similarity engine**
- Now a **normalized `[0,1]` weighted average** over more of the metadata the reviews-list payload already carries (verified it's the full `movieProvider` mapping, cast included):
  - Movies: director, cast, studio, genre, release-era, original language.
  - Books: author, subject, publish-era, page length.
- **Weighted Jaccard** (intersection/union) for set fields, so a work with many genres isn't spuriously similar to everything.
- **IDF tag weighting** against the club's own catalogue — sharing a rare genre counts more than a ubiquitous one ("Drama"). This adapts per club with no hardcoded stop-list. Requires changing the registry contract from a pure `similarity(a, b)` fn to `makeSimilarity(corpus)`, built once per session.
- **Continuous era/length decay** (exp half-life) instead of a bucket cliff.

> Note: book `subjects` are already flattened from BISAC paths server-side (`splitCategories`), so a path-aware overlap would be dead code — IDF over the flat segments delivers the same "partial credit for a shared broad category" benefit and more.

**`scoreAssistLogic.ts` — pivot selection**
- `selectPivot` now scores each candidate as `similarity + a bounded positional term` (score-midpoint closeness, with rank centrality as a tiebreak) instead of strict lexicographic. A clearly-more-similar work still wins, but a *marginally* more similar edge candidate no longer overrides a well-centered one — keeping the binary search balanced. With no metadata, ordering is unchanged.
- The scorer is built once in `startSession` (IDF over the candidate pool) and threaded through the session.

## Testing
- `npm test` — 238 passed
- `npm run type-check` / `npm run lint` — clean
- Rewrote the `workSimilarity` unit tests for the new normalized semantics and added coverage for each new signal + IDF weighting. Existing pivot-selection and `answerComparison` tests pass unchanged, confirming search behavior is preserved for the metadata-less case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)