### PR TITLE
Make Score Assist entry button obvious and inviting

### DIFF
--- a/src/features/reviews/components/ScoreEntryPanel.vue
+++ b/src/features/reviews/components/ScoreEntryPanel.vue
@@ -4,14 +4,19 @@
          precise decimals typed by hand. Drag and type share `scoreModel`. -->
     <ScoreDial ref="scoreDial" v-model="scoreModel" @save="save" />
 
+    <!-- Blue-tinted ghost pill (the codebase's "highlighted/tappable" accent):
+         reads as a smart-assist CTA that hooks the "what number do I give?"
+         hesitation, while staying subordinate to the solid-primary "Save score"
+         block below. Copy names the payoff (decide) so the button's purpose is
+         obvious. -->
     <button
       v-if="showAssist"
       type="button"
-      class="flex items-center gap-2 rounded-full bg-lowBackground px-4 py-1.5 text-sm text-gray-300 transition hover:brightness-110"
+      class="flex items-center gap-2 rounded-full bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary ring-1 ring-inset ring-primary/20 transition duration-fast ease-standard hover:bg-primary/20 active:scale-[0.98]"
       @click="openAssist"
     >
-      <mdicon name="scale-balance" size="16" />
-      <span>Compare {{ noun }}s you've rated</span>
+      <mdicon name="creation" size="16" />
+      <span>Not sure? Compare to decide</span>
     </button>
 
     <!-- Styled to mirror the drawer's "Rate this ..." CTA (rounded-lg, py-3)
@@ -45,13 +50,11 @@ import {
 } from "vue";
 
 import { isDefined, isTrue } from "../../../../lib/checks/checks.js";
-import { ClubType } from "../../../../lib/types/generated/db";
 import { ScoreAssistKey } from "../scoreAssist";
 import { clampScore, isValidScore } from "../scoreScale";
 import ScoreDial from "./ScoreDial.vue";
 
-import { clubTypeConfig } from "@/common/clubType";
-import { useClub, useClubSlug } from "@/service/useClub";
+import { useClubSlug } from "@/service/useClub";
 import { useSubmitScore } from "@/service/useReviews";
 
 const props = defineProps<{
@@ -84,10 +87,6 @@ const emit = defineEmits<{
 }>();
 
 const clubSlug = useClubSlug();
-const { data: club } = useClub(clubSlug);
-const noun = computed(
-  () => clubTypeConfig(club.value?.type ?? ClubType.movie).noun,
-);
 
 const scoreModel = ref(
   props.draftScore?.toString() ?? props.score?.toString() ?? "",

--- a/src/features/reviews/tests/ReviewView.spec.ts
+++ b/src/features/reviews/tests/ReviewView.spec.ts
@@ -233,7 +233,7 @@ describe("ReviewView", () => {
       await screen.findByRole("spinbutton", { name: "Score" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Compare .* you've rated/ }),
+      screen.queryByRole("button", { name: /Compare to decide/ }),
     ).not.toBeInTheDocument();
   });
 
@@ -262,7 +262,7 @@ describe("ReviewView", () => {
     await user.click(await screen.findByRole("button", { name: "Add score" }));
 
     const trigger = await screen.findByRole("button", {
-      name: /Compare .* you've rated/,
+      name: /Compare to decide/,
     });
     await user.click(trigger);
 

--- a/src/features/reviews/tests/ScoreEntryDock.spec.ts
+++ b/src/features/reviews/tests/ScoreEntryDock.spec.ts
@@ -142,7 +142,7 @@ describe("ScoreEntryDock", () => {
 
     await user.click(screen.getByRole("button", { name: /Rate this movie/ }));
     await user.click(
-      await screen.findByRole("button", { name: /Compare .* you've rated/ }),
+      await screen.findByRole("button", { name: /Compare to decide/ }),
     );
 
     // The dial gave way to the comparison flow inside the same panel.

--- a/src/features/reviews/tests/ScoreEntryModal.spec.ts
+++ b/src/features/reviews/tests/ScoreEntryModal.spec.ts
@@ -119,7 +119,7 @@ describe("ScoreEntryModal", () => {
     logIn(pinia);
 
     await user.click(
-      await screen.findByRole("button", { name: /Compare .* you've rated/ }),
+      await screen.findByRole("button", { name: /Compare to decide/ }),
     );
 
     // The dial gave way to the comparison flow inside the same overlay.

--- a/src/features/reviews/tests/ScoreEntryPanel.spec.ts
+++ b/src/features/reviews/tests/ScoreEntryPanel.spec.ts
@@ -136,7 +136,7 @@ describe("ScoreEntryPanel", () => {
     const { user } = rendered;
 
     const assist = await screen.findByRole("button", {
-      name: /Compare .* you've rated/,
+      name: /Compare to decide/,
     });
     await user.click(assist);
     expect(rendered.emitted().assist).toHaveLength(1);
@@ -149,7 +149,7 @@ describe("ScoreEntryPanel", () => {
     });
 
     expect(
-      screen.queryByRole("button", { name: /Compare .* you've rated/ }),
+      screen.queryByRole("button", { name: /Compare to decide/ }),
     ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Problem

The entry point to the Score Assist comparison flow read **"Compare movies you've rated"** — a muted gray chip with a `scale-balance` (⚖) icon. It looked like a passive stats/browse action and hid the actual payoff (a suggested score without picking a number cold), so people didn't know to tap it.

## Change

Reworked the button in `ScoreEntryPanel.vue` into a clear, inviting CTA:

| | Before | After |
|---|---|---|
| Copy | Compare movies you've rated | **Not sure? Compare to decide** |
| Icon | `scale-balance` ⚖ | `creation` ✦ (sparkle — reads as smart assist) |
| Style | muted gray chip (`bg-lowBackground text-gray-300`) | blue-tinted ghost pill (`bg-primary/10 text-primary ring-primary/20`, hover `bg-primary/20`, `active:scale-[0.98]`) |

**Why:**
- The old copy described the *mechanism* but hid the *payoff*, and the muted styling read as de-emphasized — the opposite of "tap me."
- New copy hooks the exact hesitation ("Not sure?") and names the outcome ("decide").
- New style promotes it to the codebase's existing highlighted/tappable accent, while staying a **ghost** pill — deliberately subordinate to the solid-primary "Save score" block right below it (clean secondary/primary hierarchy, no two competing solid buttons).
- Fits one line on mobile: 27 chars ≈ ~230px incl. icon/padding at `text-sm`, well under a 320px viewport.

**Cleanup:** the new copy drops the `{noun}` interpolation, so the now-dead `noun`/`club` plumbing (`useClub`, `clubTypeConfig`, `ClubType`) is removed. Updated the six role-name test assertions across 4 spec files to `/Compare to decide/`.

## Testing

- `npm run type-check` ✅
- `npm run lint` (changed files) ✅
- Affected component/view tests + `icons.test.ts` ✅ (`creation` is registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)