### PR TITLE
Remove share button from spotlight review fact card

### DIFF
--- a/src/features/reviews/components/ReviewFactCard.vue
+++ b/src/features/reviews/components/ReviewFactCard.vue
@@ -21,14 +21,6 @@
         </p>
         <p class="text-sm leading-snug text-gray-200">{{ fact.text }}</p>
       </div>
-      <button
-        type="button"
-        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-gray-400 transition hover:bg-primary/15 hover:text-primary"
-        aria-label="Share this review"
-        @click="emit('share')"
-      >
-        <mdicon name="share-variant" size="18" />
-      </button>
     </div>
   </div>
 </template>
@@ -37,6 +29,4 @@
 import type { ReviewFact } from "../reviewFacts";
 
 defineProps<{ fact: ReviewFact }>();
-
-const emit = defineEmits<{ (e: "share"): void }>();
 </script>

--- a/src/features/reviews/components/WorkDetailsContent.vue
+++ b/src/features/reviews/components/WorkDetailsContent.vue
@@ -118,8 +118,7 @@
     </section>
 
     <!-- Spotlight fact: unlocks once every member has scored. Sits between the
-         verdict (scores) and the reference material (synopsis/details), with a
-         share shortcut since a completed review is the natural share moment.
+         verdict (scores) and the reference material (synopsis/details).
          Computed off the opening frame (see factReady), so it fades in after
          the drawer has painted. -->
     <Transition
@@ -130,7 +129,6 @@
         v-if="isDefined(reviewFact)"
         :fact="reviewFact"
         class="mt-4"
-        @share="shareReview(movie.original.id)"
       />
     </Transition>
 

--- a/src/features/reviews/views/SharedReviewView.vue
+++ b/src/features/reviews/views/SharedReviewView.vue
@@ -87,12 +87,10 @@
                     </div>
                   </div>
 
-                  <!-- Same spotlight fact the club sees in the review drawer;
-                       the share button re-shares this page's own link. -->
+                  <!-- Same spotlight fact the club sees in the review drawer. -->
                   <ReviewFactCard
                     v-if="isDefined(reviewFact)"
                     :fact="reviewFact"
-                    @share="sharePage"
                   />
 
                   <div
@@ -159,7 +157,6 @@ import LoadingSpinner from "@/common/components/LoadingSpinner.vue";
 import SharedPageCtaBanner from "@/common/components/SharedPageCtaBanner.vue";
 import SharedPageHeader from "@/common/components/SharedPageHeader.vue";
 import VAvatar from "@/common/components/VAvatar.vue";
-import { useShare } from "@/common/composables/useShare";
 import { asMovie, workPosterUrl } from "@/common/workDisplay";
 import SharedReviewComments from "@/features/reviews/components/SharedReviewComments.vue";
 import { useClub } from "@/service/useClub";
@@ -181,17 +178,6 @@ const reviewFact = computed(() =>
     ? computeReviewFact(allReviews.value, workId)
     : undefined,
 );
-
-const { share } = useShare();
-const sharePage = () => {
-  const title = data.value?.work.title ?? "Review";
-  const clubName = data.value?.clubName ?? club.value?.clubName ?? "Movie Club";
-  void share({
-    url: `${window.location.origin}/share/club/${clubSlug}/review/${workId}`,
-    title: `${title} - ${clubName} Review`,
-    text: `${clubName}'s review of ${title}`,
-  });
-};
 
 const movieData = computed(() => asMovie(data.value?.work.externalData));
 const posterSrc = computed(


### PR DESCRIPTION
## Summary
Removes the share icon button from the spotlighted fun fact card. It's gone from both places the card renders:
- the reviews drawer/sheet (`WorkDetailsContent.vue`)
- the shared review page (`SharedReviewView.vue`)

## Changes
- **`ReviewFactCard.vue`** — removed the share icon button and its now-unused `share` emit.
- **`WorkDetailsContent.vue`** — dropped the `@share` binding. The drawer's dock CTA share button is untouched.
- **`SharedReviewView.vue`** — dropped the `@share` binding plus the now-orphaned `sharePage` handler and `useShare` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)