### PR TITLE
Score Assist: suggest scores to two decimal places

### DIFF
--- a/src/features/reviews/components/WorkDetailsContent.vue
+++ b/src/features/reviews/components/WorkDetailsContent.vue
@@ -114,11 +114,7 @@
       enter-active-class="transition duration-slow ease-standard"
       enter-from-class="-translate-y-1 opacity-0"
     >
-      <ReviewFactCard
-        v-if="isDefined(reviewFact)"
-        :fact="reviewFact"
-        class="mt-4"
-      />
+      <ReviewFactCard v-if="isDefined(reviewFact)" :fact="reviewFact" class="mt-4" />
     </Transition>
 
     <!-- Synopsis -->

--- a/src/features/reviews/composables/scoreAssistLogic.ts
+++ b/src/features/reviews/composables/scoreAssistLogic.ts
@@ -29,7 +29,7 @@ export interface ScoredCandidate {
 export type ComparisonAnswer = "more" | "less" | "same" | "skip";
 
 export interface ScoreAssistResult {
-  /** Rounded to the nearest 0.5 and clamped to 0-10. */
+  /** Rounded to two decimal places and clamped to 0-10. */
   suggestedScore: number;
   kind: "converged" | "matched" | "aboveAll" | "belowAll";
   /** Bracketing works that contextualize how the suggestion was derived. */
@@ -157,7 +157,7 @@ export function answerComparison(
         pivot: undefined,
         result: {
           kind: "matched",
-          suggestedScore: clampScore(roundHalf(pivot.score)),
+          suggestedScore: clampScore(roundToTwoDecimals(pivot.score)),
           matchedWork: pivot,
         },
       };
@@ -260,19 +260,19 @@ function finishSession(session: ScoreAssistSession): ScoreAssistSession {
     // than jumping to the midpoint of (top, 10].
     result = {
       kind: "aboveAll",
-      suggestedScore: clampScore(roundHalf(lo + 0.5)),
+      suggestedScore: clampScore(roundToTwoDecimals(lo + 0.5)),
       lowerWork,
     };
   } else if (isDefined(upperWork) && !isDefined(lowerWork) && upperWork.score === poolMin?.score) {
     result = {
       kind: "belowAll",
-      suggestedScore: clampScore(roundHalf(hi - 0.5)),
+      suggestedScore: clampScore(roundToTwoDecimals(hi - 0.5)),
       upperWork,
     };
   } else {
     result = {
       kind: "converged",
-      suggestedScore: clampScore(roundHalf((lo + hi) / 2)),
+      suggestedScore: clampScore(roundToTwoDecimals((lo + hi) / 2)),
       lowerWork,
       upperWork,
     };
@@ -280,8 +280,8 @@ function finishSession(session: ScoreAssistSession): ScoreAssistSession {
   return { ...session, pivot: undefined, result };
 }
 
-function roundHalf(score: number): number {
-  return Math.round(score * 2) / 2;
+function roundToTwoDecimals(score: number): number {
+  return Math.round(score * 100) / 100;
 }
 
 function clampScore(score: number): number {

--- a/src/features/reviews/tests/scoreAssistLogic.spec.ts
+++ b/src/features/reviews/tests/scoreAssistLogic.spec.ts
@@ -221,7 +221,7 @@ describe("answerComparison", () => {
     let session = startSession(target(), [candidate("a", 7.3)]);
     session = answerComparison(session, "same");
     expect(session.result?.kind).toBe("matched");
-    expect(session.result?.suggestedScore).toBe(7.5);
+    expect(session.result?.suggestedScore).toBe(7.3);
     expect(session.result?.matchedWork?.workId).toBe("a");
   });
 
@@ -267,14 +267,24 @@ describe("termination and suggestions", () => {
     }
   });
 
-  it("rounds the converged midpoint to the nearest half", () => {
+  it("rounds the converged midpoint to two decimal places", () => {
     let session = startSession(target(), [candidate("a", 6), candidate("b", 8.5)]);
     session = answerComparison(session, "more"); // pivot a (6)
     session = answerComparison(session, "less"); // pivot b (8.5)
-    // Bracket (6, 8.5) -> midpoint 7.25 -> 7.5
+    // Bracket (6, 8.5) -> midpoint 7.25, kept as-is rather than snapped to 7.5.
     expect(session.result).toMatchObject({
       kind: "converged",
-      suggestedScore: 7.5,
+      suggestedScore: 7.25,
+    });
+
+    // A midpoint with more than two decimals is rounded to two.
+    let odd = startSession(target(), [candidate("c", 6), candidate("d", 8.55)]);
+    odd = answerComparison(odd, "more"); // pivot c (6)
+    odd = answerComparison(odd, "less"); // pivot d (8.55)
+    // Bracket (6, 8.55) -> midpoint 7.275 -> 7.28
+    expect(odd.result).toMatchObject({
+      kind: "converged",
+      suggestedScore: 7.28,
     });
   });
 

--- a/src/features/reviews/views/SharedReviewView.vue
+++ b/src/features/reviews/views/SharedReviewView.vue
@@ -76,10 +76,7 @@
                   </div>
 
                   <!-- Same spotlight fact the club sees in the review drawer. -->
-                  <ReviewFactCard
-                    v-if="isDefined(reviewFact)"
-                    :fact="reviewFact"
-                  />
+                  <ReviewFactCard v-if="isDefined(reviewFact)" :fact="reviewFact" />
 
                   <div
                     v-for="member in data.members"


### PR DESCRIPTION
## Summary

Score Assist previously snapped every suggestion to the nearest 0.5 via a `roundHalf()` helper, even though the score entry dial already accepts finer-grained values (e.g. `8.25`). This changes the suggestion rounding to **two decimal places** so a converged midpoint like `7.25` is preserved rather than pushed to `7.5`.

## Changes

- `src/features/reviews/composables/scoreAssistLogic.ts`
  - Replaced `roundHalf()` (nearest 0.5) with `roundToTwoDecimals()` (`Math.round(score * 100) / 100`).
  - Applied it to all suggestion paths: `matched`, `aboveAll`, `belowAll`, and `converged`. Scores are still clamped to 0–10.
  - Updated the `ScoreAssistResult.suggestedScore` doc comment.
- `src/features/reviews/tests/scoreAssistLogic.spec.ts`
  - Updated the "about the same" case (pivot `7.3` now suggests `7.3`, not `7.5`).
  - Renamed/expanded the midpoint-rounding test to assert two-decimal behaviour: a `7.25` midpoint is kept, and a `7.275` midpoint rounds to `7.28`.

## Testing

- `npx vitest run` on the score assist specs — 36 passed.
- `npm run type-check` — clean.
- `npx eslint` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKysVKAN7G2tcQZLRKiGTR)_