### PR TITLE
Point Claude Code hooks at oxc instead of prettier/eslint

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "f=$(jq -r '.tool_input.file_path // empty'); if [ -n \"$f\" ]; then npx prettier --write --ignore-unknown \"$f\"; fi",
-            "timeout": 15000
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); if [ -n \"$f\" ]; then npx oxfmt \"$f\" || true; fi",
+            "timeout": 15
           }
         ]
       }
@@ -17,8 +17,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npm run type-check && files=$(git diff --name-only --diff-filter=d HEAD | grep -E '\\.(vue|ts|mjs|cjs|js)$' || true); if [ -n \"$files\" ]; then echo \"$files\" | xargs npx eslint --max-warnings 0; fi",
-            "timeout": 60000
+            "command": "npm run type-check && files=$(git diff --name-only --diff-filter=d HEAD | grep -E '\\.(vue|ts|mjs|cjs|js)$' || true); if [ -n \"$files\" ]; then echo \"$files\" | xargs npx oxlint --deny-warnings; fi",
+            "timeout": 60
           }
         ]
       }


### PR DESCRIPTION
## Why

The oxc migration (#434) replaced prettier/eslint with oxfmt/oxlint across `package.json`, CI, and configs — but not `.claude/settings.json`. Nothing imports that file and no test covers it, so its two hooks kept shelling out to the old binaries.

That was live-but-wrong rather than obviously broken:

- **prettier only still ran because it lingered in `node_modules`.** It's no longer in `package.json`, so on a fresh `npm ci` the format hook fails outright.
- **Until then, every edited file got silently prettier-formatted** — which `oxfmt --check` then flags in CI.
- The unguarded prettier hook also **aborted the edit that triggered it** whenever it hit a file it couldn't parse (e.g. one still holding merge-conflict markers mid-rebase).

## What changed

| Event | Before | After |
|---|---|---|
| `PostToolUse` (`Write\|Edit`) | `npx prettier --write --ignore-unknown "$f"` | `npx oxfmt "$f" \|\| true` |
| `Stop` | `... xargs npx eslint --max-warnings 0` | `... xargs npx oxlint --deny-warnings` |

Dropping `--ignore-unknown` needs no replacement guard — `oxfmt` already leaves unsupported files untouched (verified on `README.md` and `package.json`: both unmodified, exit 0). `--deny-warnings` matches the `npm run lint` script.

### Two fixes beyond the swap

**Timeouts were in the wrong unit.** They read `15000` and `60000`, but the hook schema defines `timeout` in *seconds* — a 4-hour and a 16-hour budget, i.e. effectively none. Now `15` and `60`.

**The formatter hook gains `|| true`,** so a format failure no longer blocks the edit. `stderr` is deliberately *not* suppressed, so failures stay visible without halting the turn.

## Verification

- **Behavior probe** — `oxfmt` on `.md`/`.json` leaves them untouched, exit 0.
- **Pipe-test** — each hook fed its real stdin payload. The formatter fixed a mangled file; `oxlint --deny-warnings` returned **exit 1** on an unused variable, confirming the Stop gate can actually fail (a lint hook that always passes is the quiet failure mode here).
- **Schema** — `jq -e` on both event/matcher paths: exit 0, correct nesting.
- **Live proof** — an edit through the real hook re-sorted imports alphabetically, which only `oxfmt` does (`sortImports` in `.oxfmtrc.json`). Formatting-only checks would not have distinguished it from the cached prettier hook.

## Note

`.prettierignore` is intentionally left in place — it is **not** migration leftover. `oxfmt` reads `.gitignore` and `.prettierignore` by default, so it is still load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
