### PR TITLE
docs: Rewrite CLAUDE.md and .claude/rules for Claude-5 context engineering

### DIFF
--- a/.claude/rules/backend-architecture.md
+++ b/.claude/rules/backend-architecture.md
@@ -27,7 +27,7 @@ A handler is normally middleware + Zod body schema + repository + a helper from 
 
 ## Lists
 
-Lists are arbitrary and user-titled; the legacy `watchlist`/`backlog` enum was removed in `20260407_ArbitraryClubLists`. IDs are UUIDs. A club's _reviews_ list is a system list (`system_type = 'reviews'`) and is deliberately filtered out of the list-collection endpoint, fetched instead through a dedicated reviews-id route and a richer reviews shape. Rename and delete are rejected for system lists.
+Lists are arbitrary and user-titled, keyed by UUID. A club's _reviews_ list is a system list (`system_type = 'reviews'`) and is deliberately filtered out of the list-collection endpoint, fetched instead through a dedicated reviews-id route and a richer reviews shape. Rename and delete are rejected for system lists.
 
 `ListRepository.moveItem` is transactional with `ON CONFLICT DO NOTHING`, so moving into the reviews list and moving between user lists share one code path.
 

--- a/.claude/rules/backend-architecture.md
+++ b/.claude/rules/backend-architecture.md
@@ -126,3 +126,12 @@ Backend uses `loggedIn` (any authenticated user) and `secured` (authenticated + 
 - `netlify/functions/og-image.ts` - Open Graph image generation
 - `netlify/functions/services/SharedReviewService.ts` - Shared review data service
 - `lib/types/*.ts` - Shared type definitions (club, movie, reviews, awards, lists, common, watchlist, etc.)
+
+## Adding a New API Endpoint
+
+1. Create handler in appropriate `netlify/functions/` directory
+2. Use the custom Router class for routing
+3. Add middleware for validation (`validClubSlug`, `validListId` for list-scoped routes) and auth (`loggedIn`, `secured`)
+4. Use Zod schemas for request body validation
+5. Use Kysely with generated types for database queries
+6. Return responses using utility functions from `utils/responses.ts`

--- a/.claude/rules/backend-architecture.md
+++ b/.claude/rules/backend-architecture.md
@@ -5,133 +5,42 @@ paths:
 
 # Backend Architecture (Netlify Functions)
 
-## Custom Router System
+## Custom router
 
-Located in `netlify/functions/utils/router.ts`. A type-safe Express-like router supporting middleware chaining with type transformations, path parameter extraction via `path-parser`, method routing (GET, POST, PUT, DELETE), sub-routers with `use()`, and automatic 404/405 responses.
+`netlify/functions/utils/router.ts` is a hand-rolled, type-safe Express-like router — middleware chaining _with type transformations_, path params via `path-parser`, sub-routers through `use()`, automatic 404/405. Middleware widens the handler's first argument, so a route mounted behind `validClubSlug` receives `clubSlug` already resolved and typed:
 
 ```typescript
-const router = new Router("/api/club");
 router.use("/:clubSlug/list", validClubSlug, listRouter);
-router.get("/:clubSlug", validClubSlug, async ({ clubSlug }, res) => {
-  const club = await ClubRepository.getBySlug(clubSlug);
-  return res(ok(JSON.stringify(result)));
-});
+router.get("/:clubSlug", validClubSlug, async ({ clubSlug }, res) =>
+  res(ok(JSON.stringify(await ClubRepository.getBySlug(clubSlug)))),
+);
 ```
 
-## API Structure
+Routers are mounted from `netlify/functions/club/index.ts` and `member.ts` — read those for the current route surface rather than relying on a list here.
 
-- `/api/og-image` - Open Graph image generation for shared reviews
-- `/api/auth/*` - BetterAuth endpoints (handled automatically)
-- `/api/club/*` - All club-related endpoints
-  - `/:clubSlug/list` - Arbitrary user-defined lists per club. List IDs are
-    UUIDs; the legacy `watchlist` / `backlog` enum was removed in
-    `20260407_ArbitraryClubLists`. System lists (`reviews`) are always
-    filtered out from the collection endpoint.
-    - `GET /` - List a club's user lists with item counts (system lists excluded)
-    - `GET /reviews-id` - Return the reviews system list ID (`{ id: string }`)
-    - `POST /` - Create a new list (`{ title }`)
-    - `GET /reviews` - Special-case rich shape for the reviews system list
-    - `GET /:listId` - Items on a single list
-    - `PUT /:listId` - Rename a list (rejected for system lists)
-    - `DELETE /:listId` - Delete a list (rejected for system lists)
-    - `POST /:listId/items` - Add a work to a list
-    - `DELETE /:listId/items/:workId` - Remove a work from a list
-    - `PUT /:listId/reorder` - Reorder list items
-    - `PUT /:listId/items/:workId/added-date` - Update item added date
-    - `POST /:listId/items/:workId/move` - Move a work to another list
-  - `/:clubSlug/reviews` - Movie reviews
-    - `POST /` - Score a movie (`{ workId, score }`)
-    - `DELETE /:workId` - Remove a work from the reviews list
-    - `GET /:workId/shared` - Shared review data for external sharing
-    - `GET /:workId/comments` - Get comments for a work
-    - `POST /:workId/comments` - Add comment to a work
-    - `PUT /:workId/comments/:commentId` - Update a comment
-    - `DELETE /:workId/comments/:commentId` - Delete a comment
-  - `/:clubSlug/members` - Club membership
-  - `/:clubSlug/awards` - Awards system (categories, nominations, rankings)
-  - `/:clubSlug/invite` - Invite token management
-  - `/:clubSlug/settings` - Club settings
-  - `/:clubSlug/nextWork` - Current movie being watched
-  - `/:clubSlug/name` - Update club name (PUT)
-  - `/:clubSlug/slug` - Update club slug (PUT)
-  - `/join` - Join club via invite
-  - `/joinInfo/:token` - Get club info from invite token
-- `/api/member/*` - User-specific endpoints
-  - `/clubs` - Get user's clubs
-  - `POST /avatar` - Upload avatar
-  - `DELETE /avatar` - Delete avatar
-  - `PUT /name` - Update user name
+## Request pipeline
 
-## Key Backend Patterns
+A handler is normally middleware + Zod body schema + repository + a helper from `utils/responses.ts` (`ok`, `badRequest`, `unauthorized`, `notFound`, `svg`, `redirect`).
 
-- Repository pattern for data access (e.g., `ClubRepository`, `UserRepository`, `WorkRepository`)
-- Middleware for authentication (`loggedIn`, `secured`) and validation (`validClubSlug`, `validListId` — the latter loads a list by `:listId`, asserts it belongs to the resolved club, and exposes `listSystemType` so handlers can gate operations on system lists)
-- Zod schemas for request body validation
-- Kysely for type-safe database queries
-- Response helpers from `utils/responses.ts` (`ok`, `badRequest`, `unauthorized`, `notFound`, `svg`, `redirect`)
+- `loggedIn` — any authenticated user. `secured` — authenticated _and_ a member of the resolved club.
+- `validClubSlug` resolves `:clubSlug`. `validListId` loads `:listId`, asserts it belongs to that club, and exposes `listSystemType` so handlers can gate operations on system lists.
 
-## Repository Classes
+## Lists
 
-Located in `netlify/functions/repositories/`:
+Lists are arbitrary and user-titled; the legacy `watchlist`/`backlog` enum was removed in `20260407_ArbitraryClubLists`. IDs are UUIDs. A club's _reviews_ list is a system list (`system_type = 'reviews'`) and is deliberately filtered out of the list-collection endpoint, fetched instead through a dedicated reviews-id route and a richer reviews shape. Rename and delete are rejected for system lists.
 
-- `ClubRepository` - Club CRUD, membership checks, invites
-- `UserRepository` - User lookup and management
-- `WorkRepository` - Movie/work management
-- `ListRepository` - List CRUD and item operations; the reviews system list is distinguished by `system_type = 'reviews'` and looked up via `getReviewsListId`. `moveItem` is transactional with `ON CONFLICT DO NOTHING` so moving items into the reviews list and moving between user lists share the same code path.
-- `ReviewRepository` - Review data access
-- `AwardsRepository` - Awards system data
-- `SettingsRepository` - Club settings storage
-- `ImageRepository` - Cloudinary image management
-- `DatabaseCleanupRepository` - Preview database lifecycle management
-- `WorkCommentRepository` - Work comment CRUD
+`ListRepository.moveItem` is transactional with `ON CONFLICT DO NOTHING`, so moving into the reviews list and moving between user lists share one code path.
 
-Stale-metadata refresh is not a repository: each `MediaProvider`
-(`netlify/functions/utils/providers/`) implements `refreshStaleDetails(limit)`
-for its own source (TMDB, Google Books), and the scheduled refresh sweeps them.
+## Data access
 
-## Scheduled Functions
+Repository classes in `netlify/functions/repositories/` own all queries — one per aggregate, named `<Thing>Repository`. Kysely with generated types throughout.
 
-- `netlify/functions/scheduled-db-cleanup.ts` - Daily cleanup of stale preview databases
-- `netlify/functions/scheduled-work-refresh.ts` - Daily refresh of stale cached work metadata across all media providers (movies, books)
+Stale-metadata refresh is deliberately _not_ a repository: each `MediaProvider` in `netlify/functions/utils/providers/` implements `refreshStaleDetails(limit)` for its own source (TMDB, Google Books), and `scheduled-work-refresh.ts` sweeps them. `scheduled-db-cleanup.ts` reaps stale preview databases.
 
-## Edge Functions
+Deploy-time behavior lives in Netlify plugins: `netlify/plugins/preview-database/` (per-PR database selection, plus the shared-`dev` migration sync on production deploys) and `netlify/plugins/auth-config/`.
 
-- `netlify/edge-functions/shared-review.ts` - Edge function for shared review pages (`/share/club/:clubSlug/review/:workId`)
+## Auth
 
-## Netlify Plugins
+`netlify/functions/utils/auth.ts` is the BetterAuth server config — bcrypt hashing, Google OAuth, Resend emails, and a mixed ID strategy (auto-increment for users, UUIDs for sessions). See the `better-auth-best-practices` skill for general patterns.
 
-- `netlify/plugins/preview-database/` - Preview database management for deploy previews
-- `netlify/plugins/auth-config/` - Authentication configuration for deploys
-
-## Authentication (Backend)
-
-Backend uses `loggedIn` (any authenticated user) and `secured` (authenticated + club member) middleware. See `better-auth-best-practices` skill for general BetterAuth patterns.
-
-- `netlify/functions/utils/auth.ts` — BetterAuth server config (bcrypt hashing, Google OAuth, Resend emails, mixed ID generation: auto-increment for users, UUIDs for sessions)
-
-## Key Backend Files
-
-- `netlify/functions/club/index.ts` - Main club API router
-- `netlify/functions/auth.ts` - BetterAuth handler
-- `netlify/functions/member.ts` - Member API endpoints
-- `netlify/functions/utils/router.ts` - Custom routing framework
-- `netlify/functions/utils/database.ts` - Database connection singleton
-- `netlify/functions/utils/auth.ts` - Auth configuration and middleware
-- `netlify/functions/utils/responses.ts` - HTTP response helpers
-- `netlify/functions/utils/validation.ts` - Request validation middleware
-- `netlify/functions/utils/slug.ts` - Slug generation and validation
-- `netlify/functions/utils/email.ts` - Resend email templates
-- `netlify/functions/utils/workDetailsMapper.ts` - Work-to-external-data mapper
-- `netlify/functions/utils/movieDetailsUpdater.ts` - Movie details update utility
-- `netlify/functions/og-image.ts` - Open Graph image generation
-- `netlify/functions/services/SharedReviewService.ts` - Shared review data service
-- `lib/types/*.ts` - Shared type definitions (club, movie, reviews, awards, lists, common, watchlist, etc.)
-
-## Adding a New API Endpoint
-
-1. Create handler in appropriate `netlify/functions/` directory
-2. Use the custom Router class for routing
-3. Add middleware for validation (`validClubSlug`, `validListId` for list-scoped routes) and auth (`loggedIn`, `secured`)
-4. Use Zod schemas for request body validation
-5. Use Kysely with generated types for database queries
-6. Return responses using utility functions from `utils/responses.ts`
+**Set-Cookie gotcha:** `Headers.forEach` folds repeated `Set-Cookie` values into one malformed header. Use `getSetCookie()` and return them via Netlify's `multiValueHeaders`.

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -7,120 +7,44 @@ paths:
   - "scripts/**"
 ---
 
-# Code Quality Rules
+# Code Quality
 
-## Type Guards and Utility Functions
+## Type guards
 
-**Location:** `lib/checks/checks.ts`
+`lib/checks/checks.ts` holds this codebase's null/empty checks — `hasValue`, `isDefined`, `isString`, `isTrue`, `hasElements`, `ensure`, `filterUndefinedProperties`. Read the signatures there; they're written to narrow types and to satisfy oxlint's `typescript/strict-boolean-expressions`, which rejects most hand-rolled truthiness checks anyway. Reach for these before writing a manual `x && x.trim() !== ""`.
 
-Always use these utilities instead of manual null/undefined checks. They maintain consistency and satisfy oxlint's `typescript/strict-boolean-expressions` rule.
+## `as` casts
 
-```typescript
-// PREFERRED: Check if string has value (not null/undefined/empty)
-import { hasValue } from "@/lib/checks/checks";
+Treat an `as` cast as a signal that something upstream is wrong, and fix that instead. `as unknown as T` in particular silences the compiler without buying safety.
 
-if (hasValue(myString)) {
-  // TypeScript knows myString is string here
-  console.log(myString.toUpperCase());
-}
+The common case is a test casting to build an input the types forbid (`undefined as unknown as number`). That test is usually asserting on a state the type system already prevents — deleting it is the right fix, not casting to keep it alive.
 
-// AVOID: Manual checks that ESLint will flag
-if (myString && myString.trim() !== "") {}
-if (typeof myString === "string" && myString.length > 0) {}
-```
+## Prefer keyed components to `watch()`
 
-**Available Utilities:**
-
-- `hasValue(s: string | undefined | null): s is string` - Returns true if string is defined and not empty
-- `isDefined<T>(value: T | null | undefined): value is T` - Returns true if not null/undefined
-- `isString(s: unknown): s is string` - Type guard for strings
-- `isTrue(b: unknown): b is true` - Type guard for true boolean
-- `hasElements<T>(arr: ReadonlyArray<T> | null | undefined): arr is NonEmptyArray<T>` - Returns true if array is defined and non-empty
-- `ensure<T>(val: T | undefined | null, message?: string): T` - Throws if value is null/undefined, otherwise returns the value
-- `filterUndefinedProperties(obj: Record<string, string | undefined>): Record<string, string>` - Filters out undefined properties
-
-**When to Use Each:**
-
-- `hasValue()` for **string checks** (most common)
-- `isDefined()` for **object/number/boolean checks**
-- `hasElements()` for **array checks**
-- `ensure()` when you want to **throw on null/undefined** (guard clauses)
-
-## Avoid `as` Type Casting
-
-Never use `as` casts (especially `as unknown as T`) in tests or production code. These silence TypeScript without providing type safety and can mask real bugs. If a test requires casting to simulate an invalid state, that is a sign the test should be removed — our type system prevents that state from occurring.
-
-```ts
-// AVOID:
-const input = [2, undefined as unknown as number, 6]; // masks a type violation
-
-// PREFERRED: Only test states that TypeScript types actually permit.
-```
-
-## Avoid `watch()` - Prefer Keyed Components
-
-Using `watch()` on query values is often a code smell. Instead, prefer higher-order components that pass data down as props and use the `:key` attribute to force re-renders when data changes.
-
-```typescript
-// AVOID: Using watch for query data
-const { data: club } = useClub(clubSlug);
-watch(club, (newClub) => {
-  updateSomething(newClub);
-});
-```
+For query data, pass values down as props and key the child on the identity that changed:
 
 ```vue
-<!-- PREFERRED: Keyed components that re-render -->
-<template>
-  <ClubDetails v-if="club" :key="club?.id" :club="club" />
-</template>
+<ClubDetails v-if="club" :key="club.id" :club="club" />
 ```
 
-When `club` data changes, Vue destroys and recreates `ClubDetails` with clean state. This makes data flow explicit, avoids timing issues with watchers, and reduces bugs from stale closures.
+Vue tears down and rebuilds with clean state, which makes data flow explicit and sidesteps stale closures and watcher ordering. `watch()` on a query result is usually a sign this pattern was skipped.
 
-**When `watch()` is acceptable:**
+Watchers are the right tool for genuinely reactive side effects — syncing to localStorage or a browser API, driving an animation.
 
-- Syncing with external systems (localStorage, browser APIs)
-- Triggering animations or side effects that are truly reactive in nature
+## Club-type variation: registry, not conditionals
 
-## Club-Type Variation: Registry over Conditionals
-
-Anything that varies by club type — copy, icons, labels, behavior, per-type data
-construction — must be driven by a registry, never an inline `clubType === ...`
-(or `review.type === ...`) branch. Adding a new club type should mean adding one
-registry entry, not hunting down conditionals scattered across widgets and views.
+Anything varying by club type — copy, icons, labels, behavior, per-type data construction — belongs in a registry rather than an inline `clubType === ...` / `review.type === ...` branch. Adding a club type should mean adding one registry entry, not hunting conditionals across widgets and views.
 
 ```ts
-// AVOID: inline enum ternary, one per component
-const countLabel = computed(() =>
-  props.clubType === ClubType.movie ? "movies watched" : "books read",
-);
-
-// PREFERRED: read it from the registry
+// Instead of a per-component ternary on props.clubType:
 const stats = computed(() => clubTypeStats(props.clubType));
-const countLabel = computed(() => stats.value.countLabel);
 ```
 
-Which registry depends on what the value depends on — there are two tiers:
+Which registry depends on what the value depends on:
 
-1. **Cross-feature display/behavior → shared `CLUB_TYPE_CONFIG`** in
-   `src/common/clubType.ts` (a `Record<ClubType, ClubTypeConfig>`). Add a field
-   (or a sub-block like `stats`) and read it via a helper such as
-   `clubTypeConfig(type)` / `clubTypeStats(type)`. Components take `clubType` as a
-   prop and look it up.
+1. **Cross-feature display/behavior** → the shared `CLUB_TYPE_CONFIG` in `src/common/clubType.ts`. Add a field or sub-block, read it via a helper like `clubTypeConfig(type)`. Components take `clubType` as a prop and look it up.
+2. **Logic depending on a feature's own types** → a feature-local `Record<Enum, ...>`, _not_ `src/common`. Putting it in `clubType.ts` would force the shared module to import feature types (e.g. statistics' `WorkStatsData`), inverting the `common → feature` dependency. Mirror the pattern locally instead — `WORK_STATS_BUILDERS` in `useStatisticsData.ts` is the example.
 
-2. **Feature-specific logic that depends on the feature's own types → a
-   feature-local `Record<Enum, ...>`**, NOT `src/common`. Putting it in
-   `clubType.ts` would make the shared service import feature types (e.g.
-   statistics' `WorkStatsData`), inverting the `common → feature` dependency.
-   Mirror the same pattern locally instead — e.g. `WORK_STATS_BUILDERS:
-   Record<WorkType, (base, review) => WorkStatsData | null>` in
-   `useStatisticsData.ts` replaces an inline `if (review.type === ...)`.
+Typing registries as `Record<Enum, ...>` buys exhaustiveness: a new club/work type won't compile until every registry covers it.
 
-Typing the registry as `Record<Enum, ...>` gives exhaustiveness: a new club/work
-type won't compile until every registry has an entry for it.
-
-**Gotcha:** icons pulled from a registry reach templates through a computed, so
-they're invisible to `icons.test.ts`'s static scan. When you add an icon field to
-`CLUB_TYPE_CONFIG`, extend that test's registry check to cover it (see
-`frontend-architecture.md` → Icons).
+**Gotcha:** registry icons reach templates through a computed, so `icons.test.ts`'s static scan can't see them. Adding an icon field to `CLUB_TYPE_CONFIG` means extending that test's registry check too — see `frontend-architecture.md` → Icons.

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -1,10 +1,19 @@
+---
+paths:
+  - "src/**"
+  - "netlify/**"
+  - "lib/**"
+  - "migrations/**"
+  - "scripts/**"
+---
+
 # Code Quality Rules
 
 ## Type Guards and Utility Functions
 
 **Location:** `lib/checks/checks.ts`
 
-Always use these utilities instead of manual null/undefined checks. They maintain consistency and satisfy ESLint's `@typescript-eslint/strict-boolean-expressions` rule.
+Always use these utilities instead of manual null/undefined checks. They maintain consistency and satisfy oxlint's `typescript/strict-boolean-expressions` rule.
 
 ```typescript
 // PREFERRED: Check if string has value (not null/undefined/empty)
@@ -36,23 +45,6 @@ if (typeof myString === "string" && myString.length > 0) {}
 - `isDefined()` for **object/number/boolean checks**
 - `hasElements()` for **array checks**
 - `ensure()` when you want to **throw on null/undefined** (guard clauses)
-
-## Import Order
-
-`eslint-plugin-import` is configured in `eslint.config.mjs` with two declared groups (`builtin+external` and `internal+parent+sibling+index`), but because no path resolver is wired up, `@/*` alias imports are not classified as `internal` and end up in their own de-facto third group. In practice, `<script setup>` imports should form three blocks separated by single blank lines, alphabetized case-insensitively within each:
-
-```ts
-import { computed, shallowRef } from "vue";            // 1. external
-
-import { hasElements } from "../../../../lib/checks/checks";  // 2. relative parent/sibling
-import AddMovieModal from "../components/AddMovieModal.vue";
-import ListItems from "../components/ListItems.vue";
-
-import { useClubSlug } from "@/service/useClub";       // 3. @/ alias
-import { useClubLists } from "@/service/useList";
-```
-
-Blank lines within a group trigger `no empty line within import group`; missing blank lines between groups trigger `at least one empty line between import groups`. When adding a new import, slot it into the correct block in alphabetical position — do not append to the end. `npx eslint <file> --fix` handles this mechanically.
 
 ## Avoid `as` Type Casting
 

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -69,3 +69,9 @@ npm run db:cleanup arbitrary_lists
 - **Cannot drop an enum while a column still references it.** Drop the column first, then `DROP TYPE`.
 - **Embedded data backfills inside schema migrations** (like `20260315_AddPersonProfilePaths.ts`) require their full env (e.g. `TMDB_API_KEY`). Migrations aren't pure schema in this repo.
 
+## Adding a Database Table
+
+1. Create migration in `migrations/schema/` with ISO date prefix (YYYYMMDD)
+2. Run `npm run migrate:dev` to apply migration
+3. Run `npm run codegen` to regenerate TypeScript types
+4. Create repository class in `netlify/functions/repositories/` for data access

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -5,73 +5,48 @@ paths:
   - "netlify/functions/repositories/**"
 ---
 
-# Database Architecture
+# Database
 
-**ORM:** Kysely with CockroachDB dialect (PostgreSQL-compatible). See `kysely` skill for query patterns, migration syntax, and type helpers.
+Kysely with the CockroachDB dialect (PostgreSQL-compatible). See the `kysely` skill for query patterns, migration syntax, and type helpers.
 
-**Key Files:**
+- Connection: `netlify/functions/utils/database.ts` (singleton `Kysely<DB>`)
+- **Schema of record: `lib/types/generated/db.ts`** — every table, column, and enum. Read it rather than trusting any prose summary; run `npm run codegen` after schema changes to regenerate it.
+- Migrations: `migrations/schema/`, named `YYYYMMDD_Description.ts`
 
-- Connection: `netlify/functions/utils/database.ts` (singleton `Kysely<DB>` instance)
-- Generated types: `lib/types/generated/db.ts` (run `npm run codegen` after schema changes)
-- Migrations: `migrations/schema/` (naming: `YYYYMMDD_Description.ts`)
+The shape worth knowing before you read: a `work` is a movie or book; `work_list` holds a club's lists, either user-defined (`system_type IS NULL`, free-form title) or system (`system_type = 'reviews'`), with a partial unique index enforcing at most one of each system list per club. Movie and book metadata are cached in separate `*_details` tables with their own junction tables.
 
-**Key Tables:**
+## Query gotcha: `selectAll()` after a join
 
-- `club` - Movie clubs (id, name, slug, legacy_id)
-- `club_member` - Club membership with roles (club_id, user_id, role)
-- `club_invite` - Invite tokens with expiration
-- `club_settings` - Key-value settings storage (JSON values)
-- `user` - User profiles (BetterAuth managed)
-- `account` - OAuth accounts (BetterAuth managed)
-- `session` - User sessions (BetterAuth managed)
-- `verification` - Email verification tokens (BetterAuth managed)
-- `movie_details` - Cached movie metadata from TMDB
-- `work_list` - Generic list table. Each club has one or more user-defined lists (free-form titles, `system_type IS NULL`) plus optional system lists (`system_type = 'reviews'`). A partial unique index `uq_work_list_club_system_type` enforces at most one of each system list per club. The legacy `type` enum was removed in `20260407_ArbitraryClubLists`.
-- `work_comment` - Comments on movie works (club_id, content, spoiler, user_id, work_id)
-- `review` - Movie reviews with scores
-- `awards_temp` - Temporary awards data storage (JSON)
-- `movie_directors` - Movie-to-director junction table
-- Various movie metadata junction tables (genres, production companies, countries)
+`selectAll()` with a join lets joined columns silently shadow base-table ones of the same name — the row typechecks, but you read the wrong value at runtime. Use `selectAll("table")` to scope it. Worth grepping for whenever a migration adds a column to a table that appears on the joined side of an existing query.
 
-**Enums:** `WorkListSystemType` (reviews), `WorkType` (movie)
+## Migration workflow
 
-## Migration Workflow
+**Validate schema migrations against a freshly spawned database, never your `.env`-pointed one.**
 
-Always validate schema migrations against a **freshly spawned dev database**, never against your personal `.env`-pointed DB.
-
-**Guard rail:** `schemaMigrator.ts` refuses to apply migrations against the shared `dev` database (`DATABASE_URL` path `/dev`) when `migrations/schema/` contains files not on `origin/main` — including uncommitted ones. It fails open if git is unavailable, does not apply to `migrate:down` (the cleanup path), and can be bypassed deliberately with `FORCE_DEV_MIGRATE=1`. If it false-positives on a freshly merged migration, run `git fetch` to update `origin/main`.
-
-**Why this matters — blast radius of shared `dev`.** The Netlify `preview-database` plugin (`netlify/plugins/preview-database/index.js`) points every PR that *does not* change migrations straight at shared `dev`. So if you run `migrate:dev` with `.env` still pointing at `postgresql://.../dev`, you rewrite the schema underneath every other open PR's deploy preview at once — their code still expects the old schema and their previews 500 until the migration is reverted on shared `dev` and the previews are rebuilt. The spawn-first rule isn't about cleanliness; it's the only thing that keeps this blast radius from firing.
-
-**After a migration merges, shared `dev` syncs automatically.** The `preview-database` plugin's `onSuccess` hook runs the schema migrator against shared `dev` on every *production* deploy (i.e. every merge to `main`), so `dev` tracks `main` without anyone running `migrate:dev` by hand. This closes the old gap where a merged migration reached prod but not `dev`, leaving every non-migration preview 500ing on the new column. The sync is non-fatal (a failure warns but does not fail the deploy) and a no-op when `dev` is already current. You should therefore only need to run `npm run migrate:dev` against shared `dev` yourself as a **fallback** — when the deploy hook failed, or to apply a migration before it has merged (which the guard rail blocks unless it is already on `origin/main`).
+This isn't tidiness. The `preview-database` plugin points every PR that _doesn't_ change migrations straight at shared `dev`. Running `migrate:dev` with `.env` on `postgresql://.../dev` rewrites the schema underneath every other open PR's deploy preview at once — their code expects the old schema, and their previews 500 until it's reverted and they're rebuilt.
 
 ```bash
-# 1. Spawn a fresh DB from the latest snapshot. Names must use only
-#    lowercase letters, numbers, and underscores — hyphens are rejected.
+# 1. Spawn from the latest snapshot (lowercase, numbers, underscores — no hyphens).
 npm run db:spawn arbitrary_lists
 
-# 2. Run the migrator + codegen against the new DB without touching .env.
-#    Inline DATABASE_URL takes precedence over the value loaded from
-#    --env-file=.env. The .env file is still needed so TMDB_API_KEY is
-#    available for the data-backfill step inside
-#    20260315_AddPersonProfilePaths.ts (it calls TMDB and 401s without it).
+# 2. Migrate + codegen against it without touching .env. An inline DATABASE_URL
+#    beats the --env-file value; .env is still needed because some migrations
+#    call external APIs during backfill (see below).
 DATABASE_URL='<spawned-url>' npx tsx --env-file=.env ./migrations/schemaMigrator.ts
 DATABASE_URL='<spawned-url>' npm run codegen
 
-# 3. Clean up when done.
+# 3. Clean up.
 npm run db:cleanup arbitrary_lists
 ```
 
-### CockroachDB migration gotchas
+**Guard rail.** `schemaMigrator.ts` refuses to run against shared `dev` when `migrations/schema/` contains files not on `origin/main`, including uncommitted ones. It does _not_ cover `migrate:down`, can be bypassed with `FORCE_DEV_MIGRATE=1`, and **fails open when git is unavailable** — so it reduces the blast radius above, it doesn't remove it. If it false-positives on a freshly merged migration, `git fetch` to update `origin/main`.
 
-- **No transactional DDL.** A migration that errors midway leaves the database in an intermediate state — created enums and columns persist. Plan to either make `up()` idempotent or expect to manually drop the orphans (`DROP TYPE IF EXISTS ...`, `ALTER TABLE ... DROP COLUMN IF EXISTS ...`) before re-running.
-- **Cannot drop UNIQUE constraints with `ALTER TABLE DROP CONSTRAINT`.** CockroachDB stores unique constraints as unique indexes; use `DROP INDEX <name> CASCADE` instead. (See crdb issue #42840.)
-- **Cannot drop an enum while a column still references it.** Drop the column first, then `DROP TYPE`.
-- **Embedded data backfills inside schema migrations** (like `20260315_AddPersonProfilePaths.ts`) require their full env (e.g. `TMDB_API_KEY`). Migrations aren't pure schema in this repo.
+**Shared `dev` self-syncs after merge.** The plugin's `onSuccess` hook migrates shared `dev` on every production deploy, so it tracks `main` unattended. Running `migrate:dev` against `dev` yourself is a fallback for when that hook failed.
 
-## Adding a Database Table
+## CockroachDB gotchas
 
-1. Create migration in `migrations/schema/` with ISO date prefix (YYYYMMDD)
-2. Run `npm run migrate:dev` to apply migration
-3. Run `npm run codegen` to regenerate TypeScript types
-4. Create repository class in `netlify/functions/repositories/` for data access
+- **No transactional DDL.** A migration erroring midway leaves created enums and columns behind. Either make `up()` idempotent or expect to drop orphans by hand (`DROP TYPE IF EXISTS`, `ALTER TABLE ... DROP COLUMN IF EXISTS`) before re-running.
+- **`ALTER TABLE DROP CONSTRAINT` can't drop UNIQUE** — CockroachDB stores those as unique indexes. Use `DROP INDEX <name> CASCADE` (crdb #42840).
+- **An enum can't be dropped while a column references it.** Drop the column first.
+- **`up()`/`down()` already run inside a transaction** — don't open another with `db.transaction()`.
+- **Migrations here aren't pure schema.** Some embed data backfills that call external APIs and need the matching env var (`20260315_AddPersonProfilePaths.ts` calls TMDB and 401s without `TMDB_API_KEY`).

--- a/.claude/rules/frontend-architecture.md
+++ b/.claude/rules/frontend-architecture.md
@@ -5,107 +5,33 @@ paths:
 
 # Frontend Architecture (Vue 3 + Vite)
 
-## Project Structure
+Feature-based layout: `src/features/<feature>/` holds views, components, and composables for one domain; `src/common/` holds shared UI and utilities; `src/service/` holds the TanStack Query composables every feature fetches through. `@/*` aliases `src/*`.
 
-- `src/features/` - Feature-based modules containing views, components, and composables
-  - `auth/` - Authentication views (verify email, password reset)
-  - `awards/` - Awards system with nominations, rankings, and results
-  - `clubs/` - Club listing and creation
-  - `profile/` - User profile management
-  - `reviews/` - Movie reviews with gallery and table views
-  - `settings/` - Club settings and member management
-  - `statistics/` - Club statistics and charts
-  - `watch-list/` - Watchlist and backlog management
-- `src/common/` - Shared components and utilities
-  - `components/` - Reusable UI components (VBtn, VModal, VSelect, etc.)
-  - `composables/` - Shared Vue composables
-  - `errorCodes.ts` - Error code definitions
-- `src/service/` - TanStack Query composables for data fetching
-- `src/stores/` - Pinia stores (currently `auth.ts`)
-- `src/router/` - Vue Router configuration with auth guards
-- `src/lib/` - Library code (auth client)
-- `src/directives/` - Custom Vue directives (LazyLoad)
-- `src/mocks/` - MSW handlers and test data
+A handful of components are registered globally in `src/main.ts` (`v-btn`, `v-modal`, `page-header`, …) — they appear in templates with no import, so check there before assuming a tag is undefined.
 
-## Key Technologies
+## Icons (mdi-vue): the silent-failure trap
 
-- **Vue 3** with Composition API and `<script setup>`
-- **Vite** for build tooling
-- **TypeScript** with strict mode
-- **Pinia** for state management
-- **Vue Router 4** with route-based code splitting
-- **TanStack Query (Vue Query)** for server state management with persistence
-- **BetterAuth** (better-auth/vue) for authentication with email/password and Google OAuth
-- **Tailwind CSS** for styling
-- **Vitest** for testing with jsdom environment
-- **mdi-vue** for Material Design Icons
-- **vue-toastification** for toast notifications
-- **AG Charts** for statistics visualizations
-- **Headless UI** for accessible UI primitives
+Icons are referenced by kebab-case name (`<mdicon name="movie-open-outline">`), but **only icons registered in `src/icons.ts` exist** — that file imports a curated set of `mdiPascalCase` paths from `@mdi/js` so the bundler can tree-shake the other ~7,000. An unregistered name doesn't error; mdi-vue silently renders an `mdiAlert` triangle.
 
-## Global Components
+So: when you add or change an icon name, register the matching `mdiPascalCase` export in `src/icons.ts` (import + the `icons` object, alphabetized).
 
-Registered in `src/main.ts`: `v-avatar`, `v-backdrop`, `v-btn`, `v-select`, `v-switch`, `loading-spinner`, `movie-table`, `menu-card`, `v-modal`, `page-header`, `empty-state`
+`icons.test.ts` enforces this, but its scan is **static** — it only sees literal names in `.vue` templates (`name="..."` and ternary literals). Names produced by a function or computed are invisible to it:
 
-## Custom Directives
+- Names from `CLUB_TYPE_CONFIG` (`src/common/clubType.ts`) are covered by a dedicated registry test in `icons.test.ts`. A new club type needs its `icon` there **and** in `src/icons.ts`.
+- Any other computed/ref name (`copyIcon`, default `fallback-icon` props) is covered by nothing. Register those by hand.
 
-- `v-lazy-load` - Intersection Observer-based lazy loading for images
+## Router
 
-## Icons (mdi-vue)
+- Routes carry a `depth` meta. `App.vue` has a single `<transition name="route">`; the router compares depths and writes the direction to `document.documentElement.dataset.routeTransition`, and `tailwind.css` selects the animation with `html[data-route-transition="..."] .route-enter-active` rules.
+- That indirection is deliberate: a dynamic `:name` on `<transition>` **cannot** change the _leave_ classes, because Vue resolves them before the name updates. Drive variants from the html data attribute, not the name.
+- `checkClubAccess` guards club-scoped routes on membership. `noAuth: true` opts a route out of auth; `authRequired: true` redirects to Clubs when logged out.
 
-Icons are referenced by kebab-case name (`<mdicon name="movie-open-outline">`), but **only the icons explicitly registered in `src/icons.ts` exist** — that file imports a curated set of `mdiPascalCase` paths from `@mdi/js` so the bundler can tree-shake the other ~7,000 icons out of the bundle. An unregistered name does not error; mdi-vue silently renders an `mdiAlert` triangle.
+## Service layer
 
-**When you add or change an icon name, register the matching `mdiPascalCase` export in `src/icons.ts` (import + the `icons` object, alphabetized).**
+`src/service/use<Feature>.ts` wraps every API call in TanStack Query hooks — components should not fetch directly. Several accept `MaybeRef` so IDs can be reactive (e.g. `useList(slug, listIdRef)`).
 
-`icons.test.ts` enforces this in CI, but its scan is **static** — it only sees literal names in `.vue` templates (`name="..."` and ternary literals). Icon names produced by a function/computed are invisible to it and are the classic source of a runtime triangle:
+See the `tanstack-query-vue` skill for query-key conventions, mutation patterns, caching config, and optimistic updates.
 
-- Names from the `CLUB_TYPE_CONFIG` registry (`src/common/clubType.ts`), e.g. `:name="clubTypeIcon(club.type)"` — covered by a dedicated registry test in `icons.test.ts`. Adding a new club type means adding its `icon` there **and** registering that icon in `src/icons.ts`.
-- Any other computed/ref name (e.g. `copyIcon`, default `fallback-icon` props) — not covered by any test, so register those by hand.
+## Adding a feature
 
-## Path Alias
-
-- `@/*` maps to `src/*`
-
-## Router Architecture
-
-- Routes use a `depth` meta property for slide-in/slide-out transitions
-- `checkClubAccess` guard ensures users are club members before accessing club routes
-- Route transitions use animate.css classes (`animate__slideInRight`, `animate__slideInLeft`, etc.)
-- Routes with `noAuth: true` meta are accessible without authentication
-- Routes with `authRequired: true` meta redirect to Clubs page if not logged in
-
-## Service Layer
-
-Located in `src/service/`, these composables provide TanStack Query hooks for data fetching:
-
-- `useClub.ts` - Club CRUD, membership, invites, settings
-- `useReviews.ts` - Review management and scoring
-- `useList.ts` - Arbitrary user-list CRUD (`useClubLists`, `useList(slug, listIdRef)`, `useCreateList`, `useRenameList`, `useDeleteList`, `useAddListItem`, `useDeleteListItem`, `useReorderList`, `useMoveListItem`) plus reviews-list helpers (`useReviewsList`, `useDeleteReview`, `useAddToReviewsList`, `useQueueReview`, `useUpdateReviewAddedDate`, `useAllUserListItems`). `useList` accepts a `MaybeRef<string>` so the active list ID can be reactive.
-- `useAwards.ts` - Awards system data
-- `useUser.ts` - User profile and clubs
-- `useTMDB.ts` - TMDB movie search integration
-
-See `tanstack-query-vue` skill for query key conventions, mutation patterns, caching config, and optimistic update strategies.
-
-## Authentication (Frontend)
-
-Auth store (Pinia) manages user state via `authClient.useSession()`. Router guards check auth before accessing protected routes.
-
-- `src/lib/auth-client.ts` — BetterAuth Vue client
-- `src/stores/auth.ts` — Authentication state and session management
-
-## Key Frontend Files
-
-- `src/main.ts` - Vue app initialization, global components, plugins
-- `src/App.vue` - Root component with router view and transitions
-- `src/router/index.ts` - Route definitions and navigation guards
-- `vite.config.ts` - Vite and Vitest configuration
-- `tailwind.config.cjs` - Tailwind CSS configuration
-
-## Adding a Frontend Feature
-
-1. Create feature directory in `src/features/<feature-name>/`
-2. Add views to `views/` subdirectory
-3. Create service composable in `src/service/use<Feature>.ts` for API calls
-4. Add routes in `src/router/index.ts` with appropriate `depth` meta
-5. Apply `beforeEnter: checkClubAccess` guard for club-scoped routes
+Create `src/features/<name>/` with a `views/` subdirectory, add a `src/service/use<Feature>.ts` for its API calls, then register routes in `src/router/index.ts` with a `depth` meta and `beforeEnter: checkClubAccess` if club-scoped.

--- a/.claude/rules/frontend-architecture.md
+++ b/.claude/rules/frontend-architecture.md
@@ -101,3 +101,11 @@ Auth store (Pinia) manages user state via `authClient.useSession()`. Router guar
 - `src/router/index.ts` - Route definitions and navigation guards
 - `vite.config.ts` - Vite and Vitest configuration
 - `tailwind.config.cjs` - Tailwind CSS configuration
+
+## Adding a Frontend Feature
+
+1. Create feature directory in `src/features/<feature-name>/`
+2. Add views to `views/` subdirectory
+3. Create service composable in `src/service/use<Feature>.ts` for API calls
+4. Add routes in `src/router/index.ts` with appropriate `depth` meta
+5. Apply `beforeEnter: checkClubAccess` guard for club-scoped routes

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -8,10 +8,19 @@ paths:
 
 # Testing
 
-- **Framework:** Vitest with jsdom environment
-- **Setup file:** `src/tests/setup.ts`
-- **API mocking:** Mock Service Worker (MSW) — handlers in `src/mocks/handlers.ts`
-- **Helper utilities:** `src/tests/utils.ts`
-- **Test data:** `src/mocks/data/`
-- **Coverage:** excludes mocks and test directories
-- **Test location:** feature tests live in `src/features/<feature>/tests/`
+Vitest with jsdom and `globals: true`, rooted at `src/`. Feature tests live in `src/features/<feature>/tests/`; render helpers in `src/tests/utils.ts`.
+
+## What `src/tests/setup.ts` does for you
+
+Read it before writing a test — it makes several things global, which explains behavior that otherwise looks like magic:
+
+- **`vue-router` is mocked wholesale.** `useRoute()` always returns `params.clubSlug === "test-club"`, and `useRouter()` returns stubs. Don't set up a real router; do assert against those stubs for navigation.
+- **A Pinia helper component is rendered before every test**, so stores are initialized without per-test setup.
+- **`window.matchMedia` is stubbed** to always report `matches: false` — media-query-driven branches take the false path unless you override it.
+- **MSW is started once and `resetHandlers()` runs after each test**, so per-test `server.use(...)` overrides don't leak.
+
+API calls are mocked with MSW — handlers in `src/mocks/handlers.ts`, fixtures in `src/mocks/data/`. Unhandled requests only warn, so a request with no handler surfaces as a confusing empty/failed response rather than a clear error; add the handler.
+
+## Environment-dependent tests
+
+To simulate a missing secret, use `vi.stubEnv(KEY, "")` rather than `vi.unstubAllEnvs()`. The latter passes locally but fails on Netlify, where the real secret is injected into the environment.

--- a/.claude/skills/kysely/SKILL.md
+++ b/.claude/skills/kysely/SKILL.md
@@ -18,6 +18,7 @@ Singleton in `netlify/functions/utils/database.ts`. Uses `pg` Pool with Cockroac
 **Generated types:** `lib/types/generated/db.ts` (auto-generated via `npm run codegen` / kysely-codegen).
 
 **Key type helpers:**
+
 - `Generated<T>` — column with database-generated default (optional on insert)
 - `Int8` — CockroachDB bigint (string on select, accepts number/string/bigint on insert)
 - `Timestamp` — Date on select, accepts Date or string on insert
@@ -27,11 +28,11 @@ Singleton in `netlify/functions/utils/database.ts`. Uses `pg` Pool with Cockroac
 
 ## Query Execution Methods
 
-| Method | Returns | Use when |
-|--------|---------|----------|
-| `execute()` | Array of rows | Expecting multiple results |
-| `executeTakeFirst()` | Single row or `undefined` | Optional single result |
-| `executeTakeFirstOrThrow()` | Single row (throws if none) | Required single result |
+| Method                      | Returns                     | Use when                   |
+| --------------------------- | --------------------------- | -------------------------- |
+| `execute()`                 | Array of rows               | Expecting multiple results |
+| `executeTakeFirst()`        | Single row or `undefined`   | Optional single result     |
+| `executeTakeFirstOrThrow()` | Single row (throws if none) | Required single result     |
 
 ---
 
@@ -45,7 +46,7 @@ db.selectFrom("club").selectAll().where("slug", "=", slug).executeTakeFirst();
 db.selectFrom("club").select(["club.id as club_id", "club.name as club_name", "club.slug"]);
 
 // Aggregate functions
-db.fn.agg<string[]>("array_agg", ["genre_name"]).distinct().as("genres")
+db.fn.agg<string[]>("array_agg", ["genre_name"]).distinct().as("genres");
 
 // Dynamic WHERE (queries are immutable — reassign)
 let query = db.selectFrom("club").select("id").where("slug", "=", slug);
@@ -120,12 +121,17 @@ db.insertInto("club_settings").values({...})
 db.updateTable("club").set({ name }).where("id", "=", clubId).executeTakeFirst();
 
 // Multiple set calls
-db.updateTable("review").set("score", score).set("created_date", new Date()).where("id", "=", id).execute();
+db.updateTable("review")
+  .set("score", score)
+  .set("created_date", new Date())
+  .where("id", "=", id)
+  .execute();
 
 // Raw SQL in set (bulk positional update)
 db.updateTable("work_list_item")
   .set({ position: sql`CASE work_id ${sql.join(whenClauses, sql` `)} END` })
-  .where("list_id", "=", listId).execute();
+  .where("list_id", "=", listId)
+  .execute();
 ```
 
 ---
@@ -143,12 +149,19 @@ db.deleteFrom("club_invite").where("expires_at", "<", now).where("club_id", "=",
 ```typescript
 await db.transaction().execute(async (trx) => {
   // SELECT FOR UPDATE to lock row
-  const row = await trx.selectFrom("awards_temp").select("data")
-    .where("club_id", "=", clubId).forUpdate().executeTakeFirst();
+  const row = await trx
+    .selectFrom("awards_temp")
+    .select("data")
+    .where("club_id", "=", clubId)
+    .forUpdate()
+    .executeTakeFirst();
 
   // All queries in transaction use `trx`, not `db`
-  await trx.updateTable("awards_temp").set({ data: JSON.stringify(newData) })
-    .where("club_id", "=", clubId).execute();
+  await trx
+    .updateTable("awards_temp")
+    .set({ data: JSON.stringify(newData) })
+    .where("club_id", "=", clubId)
+    .execute();
 });
 // Implicit commit on success, implicit rollback on throw
 ```
@@ -160,13 +173,20 @@ await db.transaction().execute(async (trx) => {
 ```typescript
 import { expressionBuilder } from "kysely";
 
-function listIdFromType(clubId: string, type: WorkListType): ValueExpression<DB, "work_list_item", string> {
+function systemListId(
+  clubId: string,
+  systemType: WorkListSystemType,
+): ValueExpression<DB, "work_list_item", string> {
   const eb = expressionBuilder<DB, "work_list_item">();
-  return eb.selectFrom("work_list").where("club_id", "=", clubId).where("type", "=", type).select("id");
+  return eb
+    .selectFrom("work_list")
+    .where("club_id", "=", clubId)
+    .where("system_type", "=", systemType)
+    .select("id");
 }
 
 // Use as value in WHERE
-.where("work_list_item.list_id", "=", listIdFromType(clubId, listType))
+.where("work_list_item.list_id", "=", systemListId(clubId, WorkListSystemType.reviews))
 ```
 
 ---
@@ -175,16 +195,18 @@ function listIdFromType(clubId: string, type: WorkListType): ValueExpression<DB,
 
 ```typescript
 // Typed raw expression
-sql<number>`COALESCE(MAX(position), 0) + 1`.as("next_position")
+sql<number>`COALESCE(MAX(position), 0) + 1`.as("next_position");
 
 // Existence check
-sql<number>`1`.as("exists")
+sql<number>`1`.as("exists");
 
 // Identifier escaping (for DDL)
 await sql`DROP DATABASE IF EXISTS ${sql.id(dbName)}`.execute(db);
 
 // Multi-line raw SQL (migrations)
-await sql`ALTER TABLE club ADD CONSTRAINT club_slug_format_check CHECK (slug ~ '^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]$')`.execute(db);
+await sql`ALTER TABLE club ADD CONSTRAINT club_slug_format_check CHECK (slug ~ '^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]$')`.execute(
+  db,
+);
 ```
 
 ---
@@ -194,6 +216,7 @@ await sql`ALTER TABLE club ADD CONSTRAINT club_slug_format_check CHECK (slug ~ '
 **Location:** `migrations/schema/`. Naming: `YYYYMMDD_Description.ts`.
 
 **Structure:**
+
 ```typescript
 import { Kysely } from "kysely";
 
@@ -202,37 +225,55 @@ export async function down(db: Kysely<unknown>) { ... }
 ```
 
 **Create table:**
+
 ```typescript
-await db.schema.createTable("club_member")
+await db.schema
+  .createTable("club_member")
   .addColumn("club_id", "int8")
   .addColumn("role", "varchar(50)")
   .addPrimaryKeyConstraint("pk_club_member", ["club_id", "user_id"])
-  .addForeignKeyConstraint("fk_club_member_club_id", ["club_id"], "club", ["id"], cb => cb.onDelete("cascade"))
+  .addForeignKeyConstraint("fk_club_member_club_id", ["club_id"], "club", ["id"], (cb) =>
+    cb.onDelete("cascade"),
+  )
   .addUniqueConstraint("uq_name", ["col1", "col2"])
   .execute();
 ```
 
 **Create enum:**
+
 ```typescript
-await db.schema.createType("work_list_type").asEnum(["backlog", "watchlist", "reviews"]).execute();
+await db.schema.createType("club_type").asEnum(["movie", "book"]).execute();
 ```
 
 **Create index:**
+
 ```typescript
-await db.schema.createIndex("idx_work_list_type").on("work_list").column("type").execute();
+await db.schema.createIndex("idx_work_list_club_id").on("work_list").column("club_id").execute();
 ```
 
 **Alter table:**
+
 ```typescript
 await db.schema.alterTable("work_list_item").addColumn("position", "integer").execute();
-await db.schema.alterTable("work_list_item").alterColumn("position", col => col.setNotNull()).execute();
-await db.schema.alterTable("work_list_item").alterColumn("position", col => col.setDefault(0)).execute();
+await db.schema
+  .alterTable("work_list_item")
+  .alterColumn("position", (col) => col.setNotNull())
+  .execute();
+await db.schema
+  .alterTable("work_list_item")
+  .alterColumn("position", (col) => col.setDefault(0))
+  .execute();
 await db.schema.alterTable("work_list_item").dropColumn("old_column").execute();
 ```
 
 **`withTables` for type safety during migrations** (when schema doesn't match generated types):
+
 ```typescript
-interface MigrationClubTable { id: string; name: string; slug: string; }
+interface MigrationClubTable {
+  id: string;
+  name: string;
+  slug: string;
+}
 const typedDb = db.withTables<{ club: MigrationClubTable }>();
 const clubs = await typedDb.selectFrom("club").select(["id", "name"]).execute();
 ```
@@ -254,7 +295,7 @@ npm run codegen        # Regenerate TypeScript types from schema
 ## Common Gotchas
 
 1. **CockroachDB Int8:** Primary keys are `int8` (bigint), which Kysely returns as `string`. Convert with `String()` or `Number()` as needed.
-2. **JSON columns:** Insert with `JSON.stringify()`, cast after retrieval: `result.value as MyType`. Use Zod for runtime validation.
+2. **JSON columns:** typed `Json` (a structural `JsonValue`) in the generated types, so the driver gives you a parsed value, not a string — but one the compiler can't narrow. Insert with `JSON.stringify()`; on the way out, parse with a Zod schema rather than `as MyType`, which asserts a shape nothing checked. (`SettingsRepository` still casts; that's the older pattern, not the one to copy — see `code-quality.md` on `as`.)
 3. **Immutable queries:** `.where()` returns a new query — always reassign: `query = query.where(...)`.
 4. **Migration types:** Use `Kysely<unknown>` in migration functions, not `Kysely<DB>` — the schema may not match during migration.
 5. **Named constraints:** Always name constraints (`pk_`, `fk_`, `uq_`, `idx_` prefixes) for debugging and `ON CONFLICT` references.

--- a/.claude/skills/tanstack-query-vue/SKILL.md
+++ b/.claude/skills/tanstack-query-vue/SKILL.md
@@ -17,9 +17,11 @@ Configured in `src/main.ts`. Key defaults:
 
 - `refetchOnWindowFocus: false`
 - `cacheTime`: 1 week
-- `refetchOnMount`: Custom logic — allows first refetch per query hash, suppresses subsequent remounts
-- **Persistence:** localStorage via `clientPersister`, 1-week maxAge
+- `refetchOnMount`: custom — always refetches an invalidated query, otherwise counts fetches per query hash in an in-memory map and stops refetching after the first couple of mounts
+- **Persistence:** IndexedDB (`idb-keyval` behind `createAsyncStoragePersister`), 1-week maxAge. Deliberately **not** localStorage: no ~5MB quota to silently blow past on a large club's cached lists, and no synchronous main-thread serialization
 - **User queries excluded from persistence:** `shouldDehydrateQuery` filters out `queryKey[0] === "user"`
+
+The persister and that in-memory map are one mechanism: the map is empty on every page load, so a hard refresh paints instantly from IndexedDB and then revalidates in the background, while navigation within the session stays quiet. A fixed `staleTime` can't express that — it can't distinguish a remount from a reload.
 
 ---
 
@@ -27,12 +29,14 @@ Configured in `src/main.ts`. Key defaults:
 
 Always use **string arrays** (not objects). Patterns:
 
-| Pattern | Example | Used for |
-|---------|---------|----------|
-| `[resource, id]` | `["club", clubSlug]` | Single resource |
-| `[resource, id, sub]` | `["club", clubSlug, "settings"]` | Nested resource |
-| `[resource, id, type]` | `["list", clubSlug, WorkListType.reviews]` | Typed sub-resource |
-| `[domain, action, param]` | `["tmdb", "search", query]` | External API |
+| Pattern                   | Example                          | Used for           |
+| ------------------------- | -------------------------------- | ------------------ |
+| `[resource, id]`          | `["club", clubSlug]`             | Single resource    |
+| `[resource, id, sub]`     | `["club", clubSlug, "settings"]` | Nested resource    |
+| `[resource, id, subId]`   | `["list", clubSlug, listId]`     | Sub-resource by id |
+| `[domain, action, param]` | `["tmdb", "search", query]`      | External API       |
+
+`src/service/useList.ts` exports key factories — `clubListsKey`, `listKey`, `reviewsListKey`, `workDetailsKey`. Call those instead of re-typing the array; a mutation that invalidates a hand-written key that has drifted fails silently.
 
 Prefix matching for invalidation: `invalidateQueries(["club"])` invalidates all queries starting with `"club"`.
 
@@ -41,6 +45,7 @@ Prefix matching for invalidation: `invalidateQueries(["club"])` invalidates all 
 ## useQuery Patterns
 
 **Standard query:**
+
 ```typescript
 export function useClub(clubSlug: string) {
   return useQuery<ClubPreview>({
@@ -51,6 +56,7 @@ export function useClub(clubSlug: string) {
 ```
 
 **Conditional fetching with `enabled`:**
+
 ```typescript
 export function useUserClubs() {
   const auth = useAuthStore();
@@ -64,17 +70,30 @@ export function useUserClubs() {
 ```
 
 **Reactive query keys with Refs** — query auto-refetches when Ref values change:
+
 ```typescript
 export function useAwards(clubId: Ref<string>, year: Ref<string>) {
   return useQuery({ queryKey: ["awards", clubId, year], queryFn: ... });
 }
 ```
 
-**Function overloads for type-safe return types:**
+**`MaybeRef` ids** — take the id as `MaybeRef<string>`, unwrap it into a `computed`, build the key from a `computed`, and guard the empty case with `enabled` so the query doesn't fire against a not-yet-resolved id:
+
 ```typescript
-export function useList(clubSlug: string, type: WorkListType.reviews): UseQueryReturnType<DetailedReviewListItem[], AxiosError>;
-export function useList(clubSlug: string, type: WorkListType.backlog | WorkListType.watchlist): UseQueryReturnType<DetailedWorkListItem[], AxiosError>;
+export function useList(
+  clubSlug: string,
+  listId: MaybeRef<string>,
+): UseQueryReturnType<DetailedWorkListItem[], AxiosError> {
+  const listIdRef = computed(() => unref(listId));
+  return useQuery({
+    queryKey: computed(() => listKey(clubSlug, listIdRef.value)),
+    queryFn: async () => (await axios.get(`/api/club/${clubSlug}/list/${listIdRef.value}`)).data,
+    enabled: () => listIdRef.value !== "",
+  });
+}
 ```
+
+This matters where an id is itself fetched — a list view resolving `reviewsListId` through `useReviewsListId` first. Callers pass either a plain string or a ref and get the same composable.
 
 ---
 
@@ -100,12 +119,11 @@ export function useCreateClub() {
 return useMutation({
   mutationFn: ({ workId, score }) => auth.request.post(...),
   onMutate: ({ workId, score }) => {
-    queryClient.setQueryData<DetailedReviewListItem[]>(
-      ["list", clubSlug, WorkListType.reviews],
-      (current) => current?.map(item => item.id === workId ? { ...item, updatedField } : item),
+    queryClient.setQueryData<DetailedReviewListItem[]>(reviewsListKey(clubSlug), (current) =>
+      current?.map(item => item.id === workId ? { ...item, updatedField } : item),
     );
   },
-  onSettled: () => queryClient.invalidateQueries({ queryKey: ["list", clubSlug, WorkListType.reviews] }),
+  onSettled: () => queryClient.invalidateQueries({ queryKey: reviewsListKey(clubSlug) }),
 });
 ```
 
@@ -148,14 +166,14 @@ return useMutation({
 
 - Register `VueQueryPlugin` in test globals (handled by custom `render` in `src/tests/utils.ts`)
 - VueQueryPlugin auto-creates a default QueryClient for tests
-- Clear `localStorage` between tests to reset persisted cache
-- Use MSW for API mocking — do not mock query hooks directly
+- Persistence is not wired up in tests — the IndexedDB persister lives in `src/main.ts`, which tests never run, so there is no cache to clear between them
+- Use MSW for API mocking (`src/mocks/server`, started in `src/tests/setup.ts`) — do not mock query hooks directly
 
 ---
 
 ## Common Gotchas
 
 1. **v4 vs v5 API:** This project uses v4. Key differences from v5: `cacheTime` (not `gcTime`), array-form `invalidateQueries(["key"])` (not always object-form), `isLoading` (not `isPending` for queries), `onSuccess`/`onError`/`onSettled` callbacks exist on useQuery (removed in v5)
-2. **User queries never persisted:** `queryKey[0] === "user"` is excluded from localStorage dehydration
-3. **Refetch suppression:** Custom `refetchOnMount` only allows first refetch per query hash — subsequent component mounts skip refetch
+2. **User queries never persisted:** `queryKey[0] === "user"` is excluded from dehydration, so auth-dependent data never survives a reload
+3. **Refetch suppression:** custom `refetchOnMount` counts fetches per query hash and goes quiet after the first couple of mounts, so a component that mounts repeatedly in one session will _not_ refetch. Invalidate explicitly after a mutation rather than expecting a remount to refresh anything
 4. **Reactive keys:** Pass `Ref` values directly in queryKey arrays — Vue Query unwraps them automatically

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,40 +25,12 @@ Runs the full application including Netlify functions with hot-reload. This is t
 - Use the `cobresunofficial@gmail.com` account for development
 - The `.env` file for development is documented in the Cobresun Notion
 
-### Building and Testing
-
-```bash
-npm run build          # Migrate, type-check, lint, test, then build for production
-npm run type-check     # Run TypeScript type checking without emitting files
-npm run lint           # Lint src, migrations, netlify/functions, lib, and scripts directories
-npm test               # Run tests once
-npm run test:watch     # Run tests in watch mode
-npm run coverage       # Run tests with coverage report
-```
-
 ### Database Migrations
 
-**Schema Migrations:**
+Build, test, lint, and migration scripts are all in `package.json`. Two things that aren't obvious from the script names:
 
-```bash
-npm run migrate:dev    # Apply schema migrations for development (uses .env file)
-npm run migrate:down   # Revert last schema migration (development only)
-npm run migrate        # Apply schema migrations for deployment (no .env file)
-```
-
-**Data Migrations:**
-
-```bash
-npm run migrate:data -- <YourDataMigration>  # Run specific data migration
-```
-
-**Code Generation:**
-
-```bash
-npm run codegen        # Generate TypeScript types from database schema using kysely-codegen
-```
-
-Migration files are located in `migrations/schema/` and must follow the naming convention: `<dateISO>_<yourchanges>` (e.g., `20240201_AddClubTable.ts`).
+- Data migrations take the migration name as an argument: `npm run migrate:data -- <YourDataMigration>`
+- Migration files live in `migrations/schema/` and must follow the naming convention `<dateISO>_<yourchanges>` (e.g. `20240201_AddClubTable.ts`)
 
 ### Database Management
 
@@ -82,32 +54,6 @@ Snapshots are stored in `s3://movie-club-crdb-dev-exports`. The spawn command cr
 - **Type guards:** Always use utilities from `lib/checks/checks.ts` (`hasValue`, `isDefined`, `hasElements`, `ensure`) instead of manual null/undefined checks. See `.claude/rules/code-quality.md` for details.
 - **No `as` casts:** Never use `as` type casting in tests or production code.
 - **No `watch()`:** Prefer keyed components over `watch()` for query data. See `.claude/rules/code-quality.md` for rationale and exceptions.
-
-## Common Patterns
-
-### Adding a New API Endpoint
-
-1. Create handler in appropriate `netlify/functions/` directory
-2. Use the custom Router class for routing
-3. Add middleware for validation (`validClubSlug`, `validListId` for list-scoped routes) and auth (`loggedIn`, `secured`)
-4. Use Zod schemas for request body validation
-5. Use Kysely with generated types for database queries
-6. Return responses using utility functions from `utils/responses.ts`
-
-### Adding a Database Table
-
-1. Create migration in `migrations/schema/` with ISO date prefix (YYYYMMDD)
-2. Run `npm run migrate:dev` to apply migration
-3. Run `npm run codegen` to regenerate TypeScript types
-4. Create repository class in `netlify/functions/repositories/` for data access
-
-### Adding a Frontend Feature
-
-1. Create feature directory in `src/features/<feature-name>/`
-2. Add views to `views/` subdirectory
-3. Create service composable in `src/service/use<Feature>.ts` for API calls
-4. Add routes in `src/router/index.ts` with appropriate `depth` meta
-5. Apply `beforeEnter: checkClubAccess` guard for club-scoped routes
 
 ## External Services
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,81 +1,18 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. Detailed architecture docs are in `.claude/rules/`.
+Movie Club is a Vue 3 app for managing movie/book clubs, reviews, custom lists, and awards. Netlify Functions for the API, CockroachDB via Kysely, BetterAuth for auth. Architecture notes live in `.claude/rules/`, loaded by path.
 
-## Project Overview
+## Non-obvious setup
 
-Movie Club is a Vue 3 web application for managing movie clubs, reviews, custom lists, and awards. It uses Netlify Functions for the backend API, CockroachDB (PostgreSQL-compatible) for data storage, and BetterAuth for authentication.
+- **Run the app with `netlify dev`**, not `npm run dev` — the functions backend won't exist otherwise.
+- Sign in locally as `cobresunofficial@gmail.com`. The dev `.env` contents are in the Cobresun Notion.
+- `GEMINI_API_KEY` is the one env var **not** synced to local `.env` — it's a Netlify-console-only secret. To exercise the discussion-questions feature locally, get your own key at https://aistudio.google.com/apikey.
+- Lint/format is oxlint + oxfmt, not ESLint/Prettier. `type-check` and `lint` run automatically via hooks after each edit, so you rarely need to invoke them; `npm test` is manual.
 
-## Code Quality
+## Database workflow
 
-Code quality checks (`npm run type-check` and `npm run lint`) run automatically via Claude Code hooks after every file edit. Run `npm test` manually when changes affect tested code. Linting uses oxlint (with `oxlint.config.ts`) and formatting uses oxfmt (with `.oxfmtrc.json`).
+Schema migrations live in `migrations/schema/` and must be named `<YYYYMMDD>_<Description>.ts` — the migrator orders by filename. (`migrations/data/` and `npm run migrate:data -- <Name>` are the legacy path; new data rewrites go in schema migrations.)
 
-## Development Commands
+`npm run db:snapshot | db:spawn | db:list | db:cleanup` back a snapshot/restore workflow that gives you a throwaway CockroachDB from a copy of dev data — see the scripts in `package.json`. Spawned names take underscores, not hyphens.
 
-### Running the Application
-
-```bash
-netlify dev
-```
-
-Runs the full application including Netlify functions with hot-reload. This is the primary development command.
-
-**Important Development Setup:**
-
-- Use the `cobresunofficial@gmail.com` account for development
-- The `.env` file for development is documented in the Cobresun Notion
-
-### Database Migrations
-
-Build, test, lint, and migration scripts are all in `package.json`. Two things that aren't obvious from the script names:
-
-- Data migrations take the migration name as an argument: `npm run migrate:data -- <YourDataMigration>`
-- Migration files live in `migrations/schema/` and must follow the naming convention `<dateISO>_<yourchanges>` (e.g. `20240201_AddClubTable.ts`)
-
-### Database Management
-
-The project uses CockroachDB's BACKUP/RESTORE with S3 to create isolated database environments for development and deploy previews.
-
-```bash
-npm run db:snapshot         # Create backup snapshot of dev database to S3
-npm run db:snapshot prod    # Snapshot production database
-npm run db:spawn my_feature # Create personal dev database from latest snapshot (use underscores, not hyphens)
-npm run db:list             # List all databases with metadata
-npm run db:cleanup my_feature       # Delete personal database when done
-npm run db:cleanup --older-than 7   # Clean up databases older than 7 days
-```
-
-Snapshots are stored in `s3://movie-club-crdb-dev-exports`. The spawn command creates `dev_{username}_my-feature` by restoring from the latest S3 snapshot.
-
-**Required env vars:** `DATABASE_URL`, `AWS_ACCESS_KEY_COCKROACH_BACKUP`, `AWS_SECRET_ACCESS_KEY_COCKROACH_BACKUP`
-
-## Key Conventions
-
-- **Type guards:** Always use utilities from `lib/checks/checks.ts` (`hasValue`, `isDefined`, `hasElements`, `ensure`) instead of manual null/undefined checks. See `.claude/rules/code-quality.md` for details.
-- **No `as` casts:** Never use `as` type casting in tests or production code.
-- **No `watch()`:** Prefer keyed components over `watch()` for query data. See `.claude/rules/code-quality.md` for rationale and exceptions.
-
-## External Services
-
-- **TMDB** — Movie metadata API (`netlify/functions/utils/tmdb.ts`)
-- **Google Books** — Book metadata API (`netlify/functions/utils/providers/googleBooks.ts`)
-- **BetterAuth** — Authentication (email/password + Google OAuth)
-- **CockroachDB** — PostgreSQL-compatible distributed database
-- **Cloudinary** — Image hosting for profile photos
-- **Resend** — Transactional email (verification, password reset)
-
-## Environment Variables
-
-Required environment variables (documented in Cobresun Notion):
-
-- `DATABASE_URL` - CockroachDB connection string
-- `AWS_ACCESS_KEY_COCKROACH_BACKUP` / `AWS_SECRET_ACCESS_KEY_COCKROACH_BACKUP` - S3 backups
-- `BETTER_AUTH_URL` - Base URL for BetterAuth
-- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` - Google OAuth
-- `RESEND_API_KEY` - Resend email API key
-- `CLOUDINARY_URL` - Cloudinary configuration URL
-- `TMDB_API_KEY` - TMDB API key for movie data
-- `GOOGLE_BOOKS_API_KEY` / `VITE_GOOGLE_BOOKS_API_KEY` - Google Books API key for book metadata (backend) and book search/browse (frontend); one Google Cloud key can back both
-- `GEMINI_API_KEY` - Google AI Studio key used by the experimental "discussion questions" feature (calls the `gemini-3.5-flash` model). **This is a Netlify-console-only secret and is NOT synced to your local `.env`.** To exercise the feature locally, generate your own key at https://aistudio.google.com/apikey and add `GEMINI_API_KEY=<your-key>` to `.env`. Deploys read the value from the Netlify console.
-
-Netlify provides automatically: `URL` (production), `DEPLOY_PRIME_URL` (deploy preview)
+**Never point `migrate:dev` at shared `dev`.** Spawn first. `.claude/rules/database.md` explains the blast radius; there is a guard rail, but it fails open.


### PR DESCRIPTION
## Why

Applies the principles from [The new rules of context engineering for Claude 5 generation models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models) to `CLAUDE.md` and all five `.claude/rules/` files.

This PR started as a trim of the always-loaded files and grew into a full rewrite, because the audit turned up something worth acting on: **every doc claim that contradicted the code was in a hand-maintained mirror of something the code already stated.** The two problems are the same problem. Nobody updates a prose copy of `ls src/service/`, so the content that costs the most tokens is also the content most likely to be wrong.

Net **442 lines deleted, 122 added**.

## Stale claims found and fixed

Each of these was live in a rules file and contradicted by the working tree:

| File                       | Claimed                                                     | Actual                                                                                                         |
| -------------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| `frontend-architecture.md` | route transitions use animate.css (`animate__slideInRight`) | animate.css removed; `<transition name="route">` + `html[data-route-transition]` CSS                           |
| `database.md`              | `club` has `legacy_id`                                      | dropped in a5cf78c                                                                                             |
| `database.md`              | `WorkType` is `(movie)`                                     | `movie` **and** `book`                                                                                         |
| `database.md`              | "Key Tables" list                                           | missing `book_details`, `book_authors`, `book_subjects`, `movie_actors`, `next_work`, `work`, `work_list_item` |
| `frontend-architecture.md` | service layer file list                                     | missing `useDiscussionQuestions.ts`, `useMediaSearch.ts`                                                       |
| `code-quality.md`          | "manual checks that **ESLint** will flag"                   | oxlint (missed in #434)                                                                                        |

The animate.css one was the most costly: it would have sent a reader writing `animate__` classes against a stylesheet that no longer defines them.

## What changed

**Cut — content the repo already states.** The `src/features/` directory tree, "Key Technologies" (prose copy of `package.json`), "Key Frontend/Backend Files", the 40-line REST route inventory, repository/service/table lists, the env-var catalogue, "External Services". Where a reader needs the real answer, the docs now point at the source of truth — `lib/types/generated/db.ts` for schema, the router files for routes.

**Reframed — prohibitions into judgment.** "Never use `as` casts" became _treat an `as` cast as a signal that something upstream is wrong_, with the reasoning attached, so it transfers to cases the rule never anticipated. Same treatment for `watch()` and the type guards. The `lib/checks` section dropped its signature table and "when to use each" mapping in favour of pointing at the file — the signatures are the interface.

**Kept and promoted — what the code can't tell you.** The `icons.ts` silent-triangle trap, the shared-`dev` blast radius, the CockroachDB DDL gotchas, the club-type registry pattern, the `Set-Cookie` header-folding bug. Reading the source never surfaces _"this fails silently by rendering a warning triangle."_ That's what these files are for, and it's most of what's left.

**`testing.md` rewritten against the actual config.** The first draft described a Vitest client/server projects split, strict MSW, and coverage thresholds. `vite.config.ts` has none of that — it's on the unmerged `test-suite-overhaul` branch. The file now documents what `src/tests/setup.ts` really does, including the global `vue-router` mock that pins `route.params.clubSlug` to `"test-club"` for every test, which otherwise reads as magic.

## Correction to this PR's earlier reasoning

The previous description argued that path-scoping `code-quality.md` was safe _because_ `CLAUDE.md`'s always-loaded "Key Conventions" summarized the prohibitions. This rewrite removes that section as duplication — the blog's point about not repeating guidance across locations.

The scoping still holds up, by a different argument: `code-quality.md` globs `src/**`, `netlify/**`, `lib/**`, `migrations/**`, and `scripts/**`, so it loads on essentially any code edit. The conventions are present whenever they could apply; they're just no longer stated twice.

## Follow-up worth noting

That `code-quality.md` glob set makes it effectively always-loaded. At 50 lines of genuinely cross-cutting conventions that's a fine trade, but if it grows, splitting the club-type registry section into a narrower-scoped file is the natural next move.

Docs only; no source or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
