### PR TITLE
Remove unused getErrorMessage helper

### DIFF
--- a/netlify/functions/utils/validation.ts
+++ b/netlify/functions/utils/validation.ts
@@ -5,11 +5,6 @@ import ListRepository from "../repositories/ListRepository";
 import { notFound } from "./responses";
 import { MiddlewareCallback, Request } from "./router";
 
-export function getErrorMessage(error: unknown) {
-  if (error instanceof Error) return error.message;
-  return String(error);
-}
-
 export type ClubRequest<T extends Request = Request> = T & {
   clubId: string;
   clubSlug: string;


### PR DESCRIPTION
## Summary
- Removed `getErrorMessage` from `netlify/functions/utils/validation.ts` — a dead export with no callers anywhere in the codebase.

## Why
While scanning for unused code, I confirmed via repo-wide search that `getErrorMessage` was never imported or called outside its own declaration:

```
$ grep -rn "getErrorMessage" .
netlify/functions/utils/validation.ts:8:export function getErrorMessage(error: unknown) {
```

It wasn't wired into any error-handling path, so it was just dead weight in a file that otherwise holds actively-used middleware (`validClubSlug`, `validListId`) and types (`ClubRequest`, `ListRequest`).

## Test plan
- [x] `npm run lint` (oxlint) passes
- [x] `npm run type-check` (vue-tsc) passes
- [x] No other references to `getErrorMessage` exist in the repo


---
_Generated by [Claude Code](https://claude.ai/code/session_016AJ6vCzt5byFdZyFTS98wV)_