### PR TITLE
Remove unused useSearch and useCollection TMDB composables

### DIFF
--- a/src/service/useTMDB.ts
+++ b/src/service/useTMDB.ts
@@ -9,32 +9,6 @@ const key = import.meta.env.VITE_TMDB_API_KEY;
 
 export type TMDBCollection = "popular" | "now_playing" | "upcoming" | "top_rated";
 
-export function useSearch(query: Ref<string>, enabled: boolean) {
-  return useQuery<TMDBPageResponse>({
-    queryKey: ["tmdb", "search", query],
-    enabled,
-    queryFn: async ({ signal }) =>
-      (
-        await axios.get<TMDBPageResponse>(
-          `https://api.themoviedb.org/3/search/movie?api_key=${key}&query=${query.value}&language=en-US&include_adult=false`,
-          { signal },
-        )
-      ).data,
-  });
-}
-
-export function useCollection(collection: Ref<TMDBCollection>) {
-  return useQuery<TMDBPageResponse>({
-    queryKey: ["tmdb", "collection", collection],
-    queryFn: async () =>
-      (
-        await axios.get<TMDBPageResponse>(
-          `https://api.themoviedb.org/3/movie/${collection.value}?api_key=${key}&language=en-US`,
-        )
-      ).data,
-  });
-}
-
 export function useInfiniteCollection(collection: Ref<TMDBCollection>) {
   return useInfiniteQuery<TMDBPageResponse>({
     queryKey: ["tmdb", "collection", "infinite", collection],


### PR DESCRIPTION
## What

Removes two dead composables from `src/service/useTMDB.ts`:

- `useSearch` — a direct TMDB search wrapper with no remaining callers.
- `useCollection` — a non-paginated TMDB collection fetch with no remaining callers.

## Why

Both were superseded by newer composables and never cleaned up:

- `useSearch` is superseded by `useMediaSearch` (`src/service/useMediaSearch.ts`), which routes through the `clubTypeConfig` registry so search works for both movies and books, not just TMDB movie search.
- `useCollection` is superseded by `useInfiniteCollection` (same file), the paginated version used everywhere collections are fetched today.

Confirmed via a repo-wide word-boundary grep that neither symbol has any importer/caller outside its own definition:

```
$ grep -rn -w "useSearch" --include="*.ts" --include="*.vue" .
./src/service/useTMDB.ts:12:export function useSearch(...)

$ grep -rn -w "useCollection" --include="*.ts" --include="*.vue" .
./src/service/useTMDB.ts:26:export function useCollection(...)
```

## Testing

- `npm run lint` — passes
- `npm run type-check` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJMFfMJ5dNfPx4y1QmkxxX)_