### PR TITLE
Scope taste similarity to the current user

### DIFF
--- a/src/features/statistics/components/TasteSimilarityWidget.vue
+++ b/src/features/statistics/components/TasteSimilarityWidget.vue
@@ -1,14 +1,17 @@
 <template>
   <WidgetShell v-if="hasData" title="Taste Similarity" :subtitle="subtitle">
     <template #controls>
-      <SegmentedToggle v-model="mode" :options="modeOptions" />
+      <div class="flex flex-wrap items-center gap-2">
+        <SegmentedToggle v-if="scopeOptions.length > 1" v-model="scope" :options="scopeOptions" />
+        <SegmentedToggle v-model="mode" :options="modeOptions" />
+      </div>
     </template>
 
     <div v-if="activePair" class="text-left">
       <div class="mb-4 flex items-center justify-center gap-3">
         <div class="flex flex-col items-center">
           <v-avatar :src="activePair.memberA.image" :name="activePair.memberA.name" :size="48" />
-          <span class="mt-1 text-xs text-slate-300">{{ firstName(activePair.memberA.name) }}</span>
+          <span class="mt-1 text-xs text-slate-300">{{ memberLabel(activePair.memberA) }}</span>
         </div>
         <div class="flex flex-col items-center px-3">
           <span class="text-2xl font-bold" :class="accentTextClass"
@@ -18,7 +21,7 @@
         </div>
         <div class="flex flex-col items-center">
           <v-avatar :src="activePair.memberB.image" :name="activePair.memberB.name" :size="48" />
-          <span class="mt-1 text-xs text-slate-300">{{ firstName(activePair.memberB.name) }}</span>
+          <span class="mt-1 text-xs text-slate-300">{{ memberLabel(activePair.memberB) }}</span>
         </div>
       </div>
 
@@ -55,7 +58,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 
-import { isDefined } from "../../../../lib/checks/checks.js";
+import { hasValue, isDefined } from "../../../../lib/checks/checks.js";
 import { Member } from "../../../../lib/types/club";
 import { computeTasteSimilarity } from "../statsComputers";
 import type { WorkStatsData } from "../types";
@@ -65,13 +68,48 @@ import WidgetShell from "@/common/components/WidgetShell.vue";
 import { firstName } from "@/common/memberName";
 
 type Mode = "most" | "least";
+type Scope = "club" | "you";
 
 const props = defineProps<{
   workData: WorkStatsData[];
   members: Member[];
+  /** Set when the viewer is signed in; unlocks the "You" scope if they're a club member. */
+  currentUserId?: string;
 }>();
 
-const tasteSimilarity = computed(() => computeTasteSimilarity(props.workData, props.members));
+const clubSimilarity = computed(() => computeTasteSimilarity(props.workData, props.members));
+
+// Only worth computing when the viewer is actually one of this club's members
+// — an anonymous or non-member viewer has no pairs of their own.
+const userSimilarity = computed(() => {
+  if (!hasValue(props.currentUserId)) return { mostSimilar: null, leastSimilar: null };
+  return computeTasteSimilarity(props.workData, props.members, props.currentUserId);
+});
+
+const scopeOptions = computed(() => {
+  const options: { value: Scope; label: string }[] = [{ value: "club", label: "Club" }];
+  if (isDefined(userSimilarity.value.mostSimilar)) {
+    options.push({ value: "you", label: "You" });
+  }
+  return options;
+});
+
+// Fall back to the first tab with data rather than watching for changes
+// (see code-quality.md on avoiding watch()).
+const selectedScope = ref<Scope>("club");
+const scope = computed<Scope>({
+  get: () =>
+    scopeOptions.value.some((option) => option.value === selectedScope.value)
+      ? selectedScope.value
+      : "club",
+  set: (value) => {
+    selectedScope.value = value;
+  },
+});
+
+const tasteSimilarity = computed(() =>
+  scope.value === "you" ? userSimilarity.value : clubSimilarity.value,
+);
 
 const modeOptions = computed(() => {
   const options: { value: Mode; label: string }[] = [];
@@ -86,8 +124,6 @@ const modeOptions = computed(() => {
 
 const hasData = computed(() => modeOptions.value.length > 0);
 
-// Fall back to the first tab with data rather than watching for changes
-// (see code-quality.md on avoiding watch()).
 const selectedMode = ref<Mode>("most");
 const mode = computed<Mode>({
   get: () =>
@@ -112,9 +148,21 @@ const accentTextClass = computed(() =>
   mode.value === "most" ? "text-emerald-400" : "text-rose-400",
 );
 
-const subtitle = computed(() =>
-  mode.value === "most"
-    ? "The pair whose scores line up the closest"
-    : "The pair whose scores clash the hardest",
-);
+const SUBTITLES: Record<Scope, Record<Mode, string>> = {
+  club: {
+    most: "The pair whose scores line up the closest",
+    least: "The pair whose scores clash the hardest",
+  },
+  you: {
+    most: "The member whose scores line up closest with yours",
+    least: "The member whose scores clash hardest with yours",
+  },
+};
+
+const subtitle = computed(() => SUBTITLES[scope.value][mode.value]);
+
+function memberLabel(member: { id: string; name: string }): string {
+  if (scope.value === "you" && member.id === props.currentUserId) return "You";
+  return firstName(member.name);
+}
 </script>

--- a/src/features/statistics/statisticsWidgets.ts
+++ b/src/features/statistics/statisticsWidgets.ts
@@ -31,6 +31,9 @@ export interface StatWidgetContext {
   members: Member[];
   histogramData: HistogramData[];
   clubType: ClubType;
+  /** The signed-in viewer, when there is one. Widgets that offer a "you" scope
+   * read it; it is undefined on the public shared page and for non-members. */
+  currentUserId?: string;
 }
 
 /**
@@ -96,7 +99,11 @@ const reviewerLeaderboardWidget: StatWidgetDef = {
 const tasteSimilarityWidget: StatWidgetDef = {
   key: "taste-similarity",
   component: TasteSimilarityWidget,
-  props: (ctx) => ({ workData: ctx.workData, members: ctx.members }),
+  props: (ctx) => ({
+    workData: ctx.workData,
+    members: ctx.members,
+    currentUserId: ctx.currentUserId,
+  }),
   visible: hasMoreThan(2),
 };
 const memberOutliersWidget: StatWidgetDef = {

--- a/src/features/statistics/statsComputers.ts
+++ b/src/features/statistics/statsComputers.ts
@@ -15,6 +15,7 @@ import type {
   MemberLeaderboardEntry,
   MemberPairSimilarity,
   MonthlyActivityPoint,
+  MovieAgreement,
   MovieData,
   ScoreTrendPoint,
   ScoreVariancePoint,
@@ -180,9 +181,37 @@ export function computeMemberLeaderboard(
 const MIN_SHARED_REVIEWS = 3;
 const MAX_RAW_SCORE_DIFF = 10;
 
+/**
+ * Puts `memberId` in the `memberA` slot, swapping the paired scores along with
+ * the members so a caller rendering "A vs B" stays aligned.
+ */
+function orientPairToMember(pair: MemberPairSimilarity, memberId: string): MemberPairSimilarity {
+  if (pair.memberA.id === memberId) return pair;
+
+  const swapScores = (agreement: MovieAgreement): MovieAgreement => ({
+    ...agreement,
+    scoreA: agreement.scoreB,
+    scoreB: agreement.scoreA,
+  });
+
+  return {
+    ...pair,
+    memberA: pair.memberB,
+    memberB: pair.memberA,
+    bestAgreements: pair.bestAgreements.map(swapScores),
+    worstAgreements: pair.worstAgreements.map(swapScores),
+  };
+}
+
+/**
+ * The closest and furthest-apart member pairs by average score difference.
+ * Passing `memberId` scopes the comparison to that member's own pairs (who
+ * they're most and least alike), with them oriented into the `memberA` slot.
+ */
 export function computeTasteSimilarity(
   workData: WorkStatsData[],
   members: Member[],
+  memberId?: string,
 ): {
   mostSimilar: MemberPairSimilarity | null;
   leastSimilar: MemberPairSimilarity | null;
@@ -246,11 +275,17 @@ export function computeTasteSimilarity(
     }
   }
 
-  if (pairs.length === 0) {
+  const scopedPairs = isDefined(memberId)
+    ? pairs
+        .filter((pair) => pair.memberA.id === memberId || pair.memberB.id === memberId)
+        .map((pair) => orientPairToMember(pair, memberId))
+    : pairs;
+
+  if (scopedPairs.length === 0) {
     return { mostSimilar: null, leastSimilar: null };
   }
 
-  const sortedPairs = [...pairs].sort((a, b) => b.similarityPercent - a.similarityPercent);
+  const sortedPairs = [...scopedPairs].sort((a, b) => b.similarityPercent - a.similarityPercent);
 
   return {
     mostSimilar: sortedPairs[0],

--- a/src/features/statistics/tests/TasteSimilarityWidget.spec.ts
+++ b/src/features/statistics/tests/TasteSimilarityWidget.spec.ts
@@ -1,0 +1,94 @@
+import { screen } from "@testing-library/vue";
+
+import { Member } from "../../../../lib/types/club";
+import { WorkType } from "../../../../lib/types/generated/db";
+import TasteSimilarityWidget from "../components/TasteSimilarityWidget.vue";
+import type { BookData } from "../types";
+import { mockIntersectionObserver } from "@/mocks/IntersectionObserver";
+import { render } from "@/tests/utils";
+
+mockIntersectionObserver();
+
+const members: Member[] = [
+  { id: "m1", name: "Ann Adams", email: "ann@example.com" },
+  { id: "m2", name: "Bo Baker", email: "bo@example.com" },
+  { id: "m3", name: "Cal Chan", email: "cal@example.com" },
+];
+
+// Ann/Bo differ by 1 (90%), Ann/Cal by 4 (60%), Bo/Cal by 5 (50%).
+const scoresByWork: Record<string, number>[] = [
+  { m1: 6, m2: 7, m3: 2 },
+  { m1: 7, m2: 8, m3: 3 },
+  { m1: 5, m2: 6, m3: 1 },
+];
+
+const workData: BookData[] = scoresByWork.map((userScores, index) => ({
+  id: `b${index}`,
+  type: WorkType.book,
+  title: `Book ${index}`,
+  createdDate: "2024-01-01T00:00:00.000Z",
+  externalId: undefined,
+  imageUrl: undefined,
+  average: 5,
+  userScores,
+  scores: {},
+  dateWatched: "1/1/2024",
+}));
+
+/** The two names flanking the similarity percentage, in render order. */
+function pairLabels(): string[] {
+  return screen
+    .getAllByText(/.+/, { selector: "span.mt-1" })
+    .map((element) => element.textContent ?? "");
+}
+
+describe("TasteSimilarityWidget", () => {
+  it("shows the club-wide pair and no scope toggle for a signed-out viewer", () => {
+    render(TasteSimilarityWidget, { props: { workData, members } });
+
+    expect(screen.queryByRole("tab", { name: "You" })).not.toBeInTheDocument();
+    expect(screen.getByText("90%")).toBeInTheDocument();
+    expect(screen.getByText("Ann")).toBeInTheDocument();
+    expect(screen.getByText("Bo")).toBeInTheDocument();
+  });
+
+  it("hides the scope toggle when the viewer is not a club member", () => {
+    render(TasteSimilarityWidget, {
+      props: { workData, members, currentUserId: "outsider" },
+    });
+
+    expect(screen.queryByRole("tab", { name: "You" })).not.toBeInTheDocument();
+  });
+
+  it("scopes to the signed-in member's own pairs", async () => {
+    const { user } = render(TasteSimilarityWidget, {
+      props: { workData, members, currentUserId: "m3" },
+    });
+
+    // Defaults to the club-wide view.
+    expect(screen.getByText("90%")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "You" }));
+
+    // Cal's closest is Ann at 60%, even though Ann's own closest is Bo.
+    expect(screen.getByText("60%")).toBeInTheDocument();
+    expect(pairLabels()).toEqual(["You", "Ann"]);
+    expect(
+      screen.getByText("The member whose scores line up closest with yours"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the mode selection when switching scope", async () => {
+    const { user } = render(TasteSimilarityWidget, {
+      props: { workData, members, currentUserId: "m3" },
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Least Similar" }));
+    expect(screen.getByText("50%")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "You" }));
+
+    // Cal's furthest is Bo at 50% — same number here, so assert on the pair.
+    expect(pairLabels()).toEqual(["You", "Bo"]);
+  });
+});

--- a/src/features/statistics/tests/statsComputers.test.ts
+++ b/src/features/statistics/tests/statsComputers.test.ts
@@ -477,6 +477,52 @@ describe("computeTasteSimilarity", () => {
     expect(mostSimilar.memberA.id).toBe(leastSimilar.memberA.id);
     expect(mostSimilar.memberB.id).toBe(leastSimilar.memberB.id);
   });
+
+  describe("scoped to a member", () => {
+    const members = [
+      makeMember({ id: "m1", name: "A" }),
+      makeMember({ id: "m2", name: "B" }),
+      makeMember({ id: "m3", name: "C" }),
+    ];
+    // A/B differ by 1 (90%), B/C by 4 (60%), A/C by 5 (50%).
+    const movies = [
+      makeMovie({ userScores: { m1: 7, m2: 6, m3: 2 } }),
+      makeMovie({ userScores: { m1: 8, m2: 7, m3: 3 } }),
+      makeMovie({ userScores: { m1: 6, m2: 5, m3: 1 } }),
+    ];
+
+    it("only considers pairs involving the given member", () => {
+      const result = computeTasteSimilarity(movies, members, "m1");
+      const mostSimilar = ensure(result.mostSimilar);
+      const leastSimilar = ensure(result.leastSimilar);
+
+      expect(mostSimilar.memberB.name).toBe("B");
+      expect(leastSimilar.memberB.name).toBe("C");
+    });
+
+    it("scopes independently per member", () => {
+      // C's closest is B (60%), even though B's own closest is A (90%).
+      const result = computeTasteSimilarity(movies, members, "m3");
+      expect(ensure(result.mostSimilar).memberB.name).toBe("B");
+      expect(ensure(result.leastSimilar).memberB.name).toBe("A");
+    });
+
+    it("puts the scoped member in the memberA slot with their scores", () => {
+      // m3 is memberB in the unscoped m2/m3 pair, so the pair gets flipped.
+      const mostSimilar = ensure(computeTasteSimilarity(movies, members, "m3").mostSimilar);
+
+      expect(mostSimilar.memberA.id).toBe("m3");
+      expect(mostSimilar.bestAgreements[0].scoreA).toBe(2);
+      expect(mostSimilar.bestAgreements[0].scoreB).toBe(6);
+    });
+
+    it("returns nulls for a member with no qualifying pairs", () => {
+      const withNewcomer = [...members, makeMember({ id: "m4", name: "D" })];
+      const result = computeTasteSimilarity(movies, withNewcomer, "m4");
+      expect(result.mostSimilar).toBeNull();
+      expect(result.leastSimilar).toBeNull();
+    });
+  });
 });
 
 // ---------- computeTopDirectors ----------

--- a/src/features/statistics/views/InsightsView.vue
+++ b/src/features/statistics/views/InsightsView.vue
@@ -16,6 +16,7 @@ import { Member } from "../../../../lib/types/club";
 import { ClubType } from "../../../../lib/types/generated/db";
 import { STAT_WIDGETS, type StatWidgetContext } from "../statisticsWidgets";
 import { isBookStats, isMovieStats, type HistogramData, type WorkStatsData } from "../types";
+import { useUser } from "@/service/useUser";
 
 const props = defineProps<{
   workData: WorkStatsData[];
@@ -23,6 +24,11 @@ const props = defineProps<{
   histogramData: HistogramData[];
   clubType: ClubType;
 }>();
+
+// Read here rather than threaded through every parent view: the shared
+// (public) statistics page renders the same widgets, and a signed-in viewer
+// who happens to be a member of that club gets their own scope there too.
+const currentUser = useUser();
 
 // Media-specific widgets read metadata off the narrowed slice: genres/TMDB for
 // movies, subjects/authors for books. Era and activity widgets are
@@ -35,6 +41,7 @@ const context = computed<StatWidgetContext>(() => ({
   members: props.members,
   histogramData: props.histogramData,
   clubType: props.clubType,
+  currentUserId: currentUser.value?.id,
 }));
 
 const widgets = computed(() =>


### PR DESCRIPTION
## What

The Taste Similarity widget only ever answered "which two members of this club are most/least alike". It now has a **Club / You** scope toggle, so a signed-in member can also see who *they* line up with and clash with.

- `computeTasteSimilarity` takes an optional `memberId`. It narrows to pairs involving that member and orients each one so they land in the `memberA` slot — the per-work scores are swapped along with the members, so the rendered "7 vs 4" stays aligned with the avatars.
- The widget computes both scopes and only offers the **You** tab when the viewer is a club member with at least one qualifying pair (3+ shared reviews). Anonymous viewers and non-members see exactly what they see today — no extra toggle.
- In the You scope the viewer's own avatar is labelled "You", and the subtitle changes to "The member whose scores line up closest with yours" / "…clash hardest with yours".
- Most/Least selection is preserved across a scope switch.
- `InsightsView` reads the signed-in user via `useUser()` and passes `currentUserId` through `StatWidgetContext`. It's read there rather than threaded through both parent views, which also means a signed-in member viewing the public shared statistics page for their own club gets the scope too.

## Testing

- Four new cases in `statsComputers.test.ts` cover the scoped computer: filtering to the member's pairs, per-member independence (C's closest is B even though B's closest is A), the memberA orientation and score swap, and a member with no qualifying pairs.
- New `TasteSimilarityWidget.spec.ts` covers the widget: no scope toggle for signed-out viewers or non-members, switching to You surfaces the viewer's own pair and subtitle, and mode selection survives a scope switch.
- `npm test` (271 passing), `type-check`, `lint`, and `format:check` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HH5zm4P8JUF4XBujNuRPyw)_