### PR TITLE
Fix awards sub-routes still matching numeric club IDs

### DIFF
--- a/netlify/functions/club/awards/category.ts
+++ b/netlify/functions/club/awards/category.ts
@@ -7,7 +7,7 @@ import { badRequest, ok } from "../../utils/responses";
 import { Router } from "../../utils/router";
 import { ClubAwardRequest } from "./utils";
 
-const router = new Router<ClubAwardRequest>("/api/club/:clubId<\\d+>/awards/:year<\\d+>/category");
+const router = new Router<ClubAwardRequest>("/api/club/:clubSlug/awards/:year<\\d+>/category");
 
 const addCategorySchema = z.object({
   title: z.string(),

--- a/netlify/functions/club/awards/nomination.ts
+++ b/netlify/functions/club/awards/nomination.ts
@@ -8,9 +8,7 @@ import { badRequest, ok } from "../../utils/responses";
 import { Router } from "../../utils/router";
 import { ClubAwardRequest } from "./utils";
 
-const router = new Router<ClubAwardRequest>(
-  "/api/club/:clubId<\\d+>/awards/:year<\\d+>/nomination",
-);
+const router = new Router<ClubAwardRequest>("/api/club/:clubSlug/awards/:year<\\d+>/nomination");
 
 const addNominationSchema = z.object({
   awardTitle: z.string(),

--- a/netlify/functions/club/awards/ranking.ts
+++ b/netlify/functions/club/awards/ranking.ts
@@ -8,7 +8,7 @@ import { badRequest, ok } from "../../utils/responses";
 import { Router } from "../../utils/router";
 import { ClubAwardRequest } from "./utils";
 
-const router = new Router<ClubAwardRequest>("/api/club/:clubId<\\d+>/awards/:year<\\d+>/ranking");
+const router = new Router<ClubAwardRequest>("/api/club/:clubSlug/awards/:year<\\d+>/ranking");
 
 const addRankingSchema = z.object({
   awardTitle: z.string(),

--- a/netlify/functions/club/awards/step.ts
+++ b/netlify/functions/club/awards/step.ts
@@ -7,7 +7,7 @@ import { badRequest, ok } from "../../utils/responses";
 import { Router } from "../../utils/router";
 import { ClubAwardRequest } from "./utils";
 
-const router = new Router<ClubAwardRequest>("/api/club/:clubId<\\d+>/awards/:year<\\d+>/step");
+const router = new Router<ClubAwardRequest>("/api/club/:clubSlug/awards/:year<\\d+>/step");
 
 const updateStepSchema = z.object({
   step: z.number(),


### PR DESCRIPTION
> Part 1 of 16 splitting #375 into reviewable pieces. Merge in stack order.

The four awards sub-routers (category, nomination, ranking, step) were
left on the pre-slug-migration pattern `:clubId<\d+>` while every sibling
router under /api/club — including awards/index.ts itself — moved to
`:clubSlug`. The frontend sends slugs to all of them, so these four
routes never matched and returned 404.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
