### PR TITLE
Fix watchUntil TDZ crash and ListItems empty-state props

### DIFF
--- a/src/common/composables/watchUntil.ts
+++ b/src/common/composables/watchUntil.ts
@@ -5,15 +5,24 @@ export function watchUntil<T>(
   predicate: (value: T) => boolean,
 ): Promise<void> {
   return new Promise<void>((resolve) => {
-    const unwatch = watch(
+    // `immediate: true` invokes the callback synchronously inside `watch()`, so
+    // when the predicate already holds the handle does not exist yet — hence
+    // the nullable binding and the post-assignment unregister below. A `const`
+    // here throws a TDZ ReferenceError on that path.
+    let unwatch: (() => void) | undefined;
+    let settled = false;
+
+    unwatch = watch(
       source,
       (value) => {
-        if (predicate(value)) {
-          unwatch();
-          resolve();
-        }
+        if (!predicate(value)) return;
+        settled = true;
+        unwatch?.();
+        resolve();
       },
       { immediate: true },
     );
+
+    if (settled) unwatch();
   });
 }

--- a/src/features/watch-list/components/ListItems.vue
+++ b/src/features/watch-list/components/ListItems.vue
@@ -11,8 +11,8 @@
     <div v-if="isLoading" class="flex justify-center"><loading-spinner /></div>
     <empty-state
       v-else-if="!items || items.length === 0"
-      header="Empty list"
-      message="Add items to this list to see them here."
+      title="Empty list"
+      description="Add items to this list to see them here."
     />
     <template v-else>
       <div class="w-full">


### PR DESCRIPTION
> Part 2 of 16 splitting #375 into reviewable pieces. Merge in stack order.

Two unrelated one-line bugs, one commit each.

**`watchUntil` crashed when the predicate already held.** `watch(..., { immediate: true })` invokes the callback synchronously inside the `watch()` call itself, before the returned stop handle is assigned. On that path the callback's `unwatch()` hit the `const` binding in its temporal dead zone and threw a `ReferenceError` instead of resolving the promise. Now uses a nullable binding and unregisters after assignment.

**`ListItems` passed the wrong props to `EmptyState`.** `EmptyState` declares required `title` and `description`; `ListItems` passed `header` and `message`, so the empty-list state rendered with a blank heading and body.

