### PR TITLE
Add accessible names to comment actions; export toMovieDataSummary

### DIFF
--- a/netlify/functions/utils/providers/movieProvider.ts
+++ b/netlify/functions/utils/providers/movieProvider.ts
@@ -124,7 +124,12 @@ function num(value: string | null): number | undefined {
   return isDefined(value) ? Number(value) : undefined;
 }
 
-function toMovieDataSummary(row: MovieSummaryRow): MovieDataSummary {
+/**
+ * Maps a raw `movie_details` aggregate row to the public {@link MovieDataSummary}
+ * shape: nullable Int8/decimal columns become `number | undefined`, dates become
+ * ISO strings, and aggregate arrays default to `[]`. Exported for unit testing.
+ */
+export function toMovieDataSummary(row: MovieSummaryRow): MovieDataSummary {
   return {
     kind: "movie",
     castNames: row.cast_names?.filter(Boolean) ?? [],

--- a/src/common/components/CommentThread.vue
+++ b/src/common/components/CommentThread.vue
@@ -25,10 +25,18 @@
             <span v-if="comment.spoiler" class="text-yellow-500"> &middot; Spoiler </span>
           </div>
           <template v-if="comment.userId === currentUserId">
-            <button class="text-gray-500 hover:text-primary" @click="startEditing(comment)">
+            <button
+              aria-label="Edit comment"
+              class="text-gray-500 hover:text-primary"
+              @click="startEditing(comment)"
+            >
               <mdicon name="pencil-outline" :size="14" />
             </button>
-            <button class="text-gray-500 hover:text-red-400" @click="promptDelete(comment.id)">
+            <button
+              aria-label="Delete comment"
+              class="text-gray-500 hover:text-red-400"
+              @click="promptDelete(comment.id)"
+            >
               <mdicon name="delete-outline" :size="14" />
             </button>
           </template>
@@ -119,6 +127,7 @@
           </span>
         </div>
         <v-btn
+          aria-label="Send comment"
           :disabled="!hasValue(newComment.trim()) || newComment.length > MAX_LENGTH"
           @click="sendComment"
         >


### PR DESCRIPTION
> Part 3 of 16 splitting #375 into reviewable pieces. Merge in stack order.

The comment edit/delete buttons and the send button are icon-only, so
they had no accessible name — screen readers announced them as bare
"button", and they were unaddressable by role+name. Add aria-labels.

Also export `toMovieDataSummary` from movieProvider so its Int8/decimal/
date column mapping can be exercised directly rather than only through a
database round-trip.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
