### PR TITLE
Split Vitest into client and server projects; make MSW strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ netlify/functions/utils/auth-config.json
 *.tsbuildinfo
 
 # Test coverage
+coverage
 src/coverage
 
 # Playwright CLI skill snapshots

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -22,17 +22,6 @@ export default defineConfig({
     "@tanstack/query/no-void-query-fn": "error",
     "@tanstack/query/mutation-property-order": "error",
   },
-  overrides: [
-    {
-      // `expect(Repo.method)` and `vi.mocked(Repo.method)` are the idiomatic
-      // way to assert on a mocked module, and they trip unbound-method on
-      // every call — the rule has no signal to give in a test file.
-      files: ["**/*.test.ts", "**/*.spec.ts"],
-      rules: {
-        "typescript/unbound-method": "off",
-      },
-    },
-  ],
   options: {
     typeAware: true,
   },

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -8,21 +8,11 @@ export default defineConfig({
     "eslint/eqeqeq": "error",
     "eslint/no-var": "error",
     "eslint/prefer-arrow-callback": "error",
-    "eslint/no-restricted-globals": [
-      "error",
-      "event",
-      "length",
-      "stop",
-      "toString",
-      "alert",
-    ],
+    "eslint/no-restricted-globals": ["error", "event", "length", "stop", "toString", "alert"],
     "typescript/method-signature-style": "error",
     "typescript/switch-exhaustiveness-check": "error",
     "typescript/no-non-null-assertion": "error",
-    "typescript/strict-boolean-expressions": [
-      "error",
-      { allowNumber: false },
-    ],
+    "typescript/strict-boolean-expressions": ["error", { allowNumber: false }],
     "import/newline-after-import": "error",
     "@tanstack/query/exhaustive-deps": "error",
     "@tanstack/query/stable-query-client": "error",
@@ -32,6 +22,17 @@ export default defineConfig({
     "@tanstack/query/no-void-query-fn": "error",
     "@tanstack/query/mutation-property-order": "error",
   },
+  overrides: [
+    {
+      // `expect(Repo.method)` and `vi.mocked(Repo.method)` are the idiomatic
+      // way to assert on a mocked module, and they trip unbound-method on
+      // every call — the rule has no signal to give in a test file.
+      files: ["**/*.test.ts", "**/*.spec.ts"],
+      rules: {
+        "typescript/unbound-method": "off",
+      },
+    },
+  ],
   options: {
     typeAware: true,
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "oxlint --deny-warnings src migrations netlify/functions lib scripts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:unit": "vitest run --project client --project server",
     "coverage": "vitest run --coverage",
     "type-check": "vue-tsc --noEmit --composite false",
     "migrate": "tsx ./migrations/schemaMigrator.ts && npm run codegen",

--- a/src/mocks/IntersectionObserver.ts
+++ b/src/mocks/IntersectionObserver.ts
@@ -1,4 +1,14 @@
-export function mockIntersectionObserver(): void {
+/**
+ * Stub `IntersectionObserver`, which jsdom does not implement. Anything using
+ * `v-lazy-load` or `v-reveal` constructs one on mount and throws without this.
+ *
+ * By default `observe` records the call and never fires, so observed elements
+ * stay in their pre-intersection state — a `v-lazy-load` image keeps its real
+ * URL parked in `data-src` with an empty `src`. Pass `intersecting: true` when
+ * a test needs the browser's "already in the viewport" behaviour instead, so
+ * lazy images resolve their `src` and revealed elements become visible.
+ */
+export function mockIntersectionObserver({ intersecting = false } = {}): void {
   vi.stubGlobal(
     "IntersectionObserver",
     class {
@@ -7,9 +17,32 @@ export function mockIntersectionObserver(): void {
         public options?: IntersectionObserverInit,
       ) {}
 
-      observe = vi.fn();
+      readonly root = null;
+      readonly rootMargin = "";
+      readonly thresholds: ReadonlyArray<number> = [];
+
+      observe = vi.fn((target: Element) => {
+        if (!intersecting) return;
+        const rect = new DOMRectReadOnly();
+        this.callback(
+          [
+            {
+              target,
+              isIntersecting: true,
+              intersectionRatio: 1,
+              boundingClientRect: rect,
+              intersectionRect: rect,
+              rootBounds: null,
+              time: 0,
+            },
+          ],
+          this,
+        );
+      });
+
       unobserve = vi.fn();
       disconnect = vi.fn();
+      takeRecords = vi.fn(() => []);
     },
   );
 }

--- a/src/mocks/agCharts.ts
+++ b/src/mocks/agCharts.ts
@@ -1,0 +1,73 @@
+import type { AgChartOptions } from "ag-charts-community";
+import { defineComponent, ref, watchEffect, h, type PropType } from "vue";
+
+import { ensure } from "@/../lib/checks/checks";
+
+/**
+ * Stand-in for `<ag-charts>` from `ag-charts-vue3`.
+ *
+ * AG Charts paints into a `<canvas>`, and jsdom provides no 2D context — the
+ * real component throws while building its scene and again on unmount. Widget
+ * tests care that a chart is rendered and that it is reconfigured when the user
+ * changes mode, not that pixels are drawn; the option builders themselves are
+ * covered directly by `chartOptions.spec.ts`.
+ *
+ * Opt in per spec file (mirroring `mockIntersectionObserver`) with:
+ *
+ * ```ts
+ * vi.mock("ag-charts-vue3", async () => await import("@/mocks/agCharts"));
+ * ```
+ *
+ * The dynamic import matters: `vi.mock` is hoisted above the file's imports, so
+ * a factory that referenced a statically-imported stub would hit a TDZ error.
+ */
+export const AgCharts = defineComponent({
+  name: "AgCharts",
+  props: {
+    options: { type: Object as PropType<AgChartOptions>, required: true },
+  },
+  setup(props) {
+    const element = ref<Element | null>(null);
+    // Re-runs whenever the element mounts or the options are rebuilt, so the
+    // recorded options always match what the widget most recently passed.
+    // Sync flush: tests read the options straight after `render()` / `click()`,
+    // before Vue's default pre-flush queue would have run.
+    watchEffect(
+      () => {
+        if (element.value !== null) OPTIONS.set(element.value, props.options);
+      },
+      { flush: "sync" },
+    );
+    return () => h("div", { ref: element, role: "img", "aria-label": "chart" });
+  },
+});
+
+const OPTIONS = new WeakMap<Element, AgChartOptions>();
+
+/** The options a stubbed chart element was last rendered with. */
+export function chartOptions(element: Element): AgChartOptions {
+  return ensure(OPTIONS.get(element), "element was not rendered by the ag-charts stub");
+}
+
+interface KeyedSeries {
+  yKey: string;
+  yName?: string;
+}
+
+function isKeyedSeries(series: unknown): series is KeyedSeries {
+  return typeof series === "object" && series !== null && "yKey" in series;
+}
+
+/**
+ * The `yName ?? yKey` of each plotted series, in order — enough to tell one
+ * chart configuration from another (which is what mode-switching tests assert)
+ * without duplicating chartOptions.spec.ts's detailed option checks.
+ *
+ * ag-charts types `series` as a wide union whose members don't all carry a
+ * `yKey`, and the codebase forbids `as` casts, so narrowing happens at runtime
+ * (the convention noted in testing.md).
+ */
+export function chartSeriesNames(element: Element): string[] {
+  const series: unknown[] = chartOptions(element).series ?? [];
+  return series.filter(isKeyedSeries).map((one) => one.yName ?? one.yKey);
+}

--- a/src/mocks/data/club.json
+++ b/src/mocks/data/club.json
@@ -1,4 +1,5 @@
 {
   "clubId": 1,
-  "clubName": "Test club"
+  "clubName": "Test club",
+  "type": "movie"
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -31,6 +31,12 @@ export const handlers = [
   http.get("/api/club/:id/settings", () => {
     return HttpResponse.json({});
   }),
+  http.get("/api/club/:id/list/reviews-id", () => {
+    return HttpResponse.json({ id: "reviews" });
+  }),
+  http.get("/api/club/:id/reviews/:workId/comments", () => {
+    return HttpResponse.json([]);
+  }),
   http.get("/api/club/:id/list/reviews", () => {
     return HttpResponse.json(reviews);
   }),

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -10,7 +10,8 @@ vi.mock("vue-router", () => ({
     },
   })),
   useRouter: vi.fn(() => ({
-    push: vi.fn(),
+    // Real router.push returns a Promise; code under test may chain .catch()
+    push: vi.fn(() => Promise.resolve()),
     // `useBackButtonClose` registers a navigation guard; return an unregister fn.
     beforeEach: vi.fn(() => vi.fn()),
   })),
@@ -33,7 +34,7 @@ Object.defineProperty(window, "matchMedia", {
 });
 
 beforeAll(() => {
-  server.listen();
+  server.listen({ onUnhandledRequest: "error" });
 });
 
 beforeEach(() => {

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -8,14 +8,19 @@ import { TransitionGroup } from "vue";
 import Toast from "vue-toastification";
 
 import PiniaStoreHelperTest from "./PiniaStoreHelper.test.vue";
+import EmptyState from "@/common/components/EmptyState.vue";
 import LoadingSpinner from "@/common/components/LoadingSpinner.vue";
 import PageHeader from "@/common/components/PageHeader.vue";
 import VAvatar from "@/common/components/VAvatar.vue";
+import VBackdrop from "@/common/components/VBackdrop.vue";
 import VBtn from "@/common/components/VBtn.vue";
 import VModal from "@/common/components/VModal.vue";
+import VSelect from "@/common/components/VSelect.vue";
+import VSwitch from "@/common/components/VSwitch.vue";
 import VTable from "@/common/components/VTable.vue";
 import LazyLoad from "@/directives/LazyLoad";
 import Reveal from "@/directives/Reveal";
+import MenuCard from "@/features/clubs/components/MenuCard.vue";
 
 export const render = <C>(component: C, options: Partial<RenderOptions<C>> = {}) => {
   const user = userEvent.setup();
@@ -29,15 +34,33 @@ export const render = <C>(component: C, options: Partial<RenderOptions<C>> = {})
       global: {
         ...options.global,
         components: {
+          // Mirror the global components registered in src/main.ts so view
+          // tests render real markup instead of unresolved custom elements.
           "v-avatar": VAvatar,
+          "v-backdrop": VBackdrop,
           "v-btn": VBtn,
+          "v-select": VSelect,
+          "v-switch": VSwitch,
+          "empty-state": EmptyState,
           "loading-spinner": LoadingSpinner,
+          "menu-card": MenuCard,
           "movie-table": VTable,
           "v-modal": VModal,
           "page-header": PageHeader,
           DraggableTransitionGroup: TransitionGroup,
+          ...options.global?.components,
         },
-        plugins: [VueQueryPlugin, pinia, [mdiVue, { icons: mdijs }], Toast],
+        plugins: [
+          // Disable query retries so error-path tests surface the error state
+          // immediately instead of racing the default 3× exponential backoff.
+          [
+            VueQueryPlugin,
+            { queryClientConfig: { defaultOptions: { queries: { retry: false } } } },
+          ],
+          pinia,
+          [mdiVue, { icons: mdijs }],
+          Toast,
+        ],
         directives: { "lazy-load": LazyLoad, reveal: Reveal },
         stubs: {
           "router-link": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,14 +30,50 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    environment: "jsdom",
-    setupFiles: "tests/setup.ts",
-    root: "src/",
+    // Restore every spy/mock to its original implementation after each test so
+    // mock state never leaks between tests (a vi.spyOn or mockResolvedValue set
+    // in one test cannot silently change the next). Inherited by both projects
+    // via `extends: true`.
+    restoreMocks: true,
+    // Pin the timezone so date assertions mean the same thing everywhere.
+    // Components format date-only strings with `new Date(...)` (parsed as UTC)
+    // and `toLocaleDateString` (rendered locally), so west of Greenwich a
+    // release date renders as the previous day — CI runs UTC and would
+    // disagree with a developer's machine. Inherited by both projects.
+    env: { TZ: "UTC" },
     coverage: {
       all: true,
       provider: "istanbul",
       reporter: ["text", "json", "html"],
       exclude: ["**/mocks/**", "**/tests/**"],
     },
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "client",
+          globals: true,
+          environment: "jsdom",
+          setupFiles: "src/tests/setup.ts",
+          include: ["src/**/*.{test,spec}.ts"],
+        },
+      },
+      {
+        // Pure units with no DOM and no database. The previous `root: "src/"`
+        // made everything outside src/ invisible to the runner, so no backend
+        // test could exist at all.
+        extends: true,
+        test: {
+          name: "server",
+          globals: true,
+          environment: "node",
+          include: [
+            "lib/**/*.{test,spec}.ts",
+            "netlify/functions/utils/**/*.{test,spec}.ts",
+            "scripts/**/*.{test,spec}.ts",
+          ],
+        },
+      },
+    ],
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,16 +30,10 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    // Restore every spy/mock to its original implementation after each test so
-    // mock state never leaks between tests (a vi.spyOn or mockResolvedValue set
-    // in one test cannot silently change the next). Inherited by both projects
-    // via `extends: true`.
+    // Both inherited by the projects below via `extends: true`.
     restoreMocks: true,
-    // Pin the timezone so date assertions mean the same thing everywhere.
-    // Components format date-only strings with `new Date(...)` (parsed as UTC)
-    // and `toLocaleDateString` (rendered locally), so west of Greenwich a
-    // release date renders as the previous day — CI runs UTC and would
-    // disagree with a developer's machine. Inherited by both projects.
+    // Test-runner only; does not affect the app. Keeps date assertions
+    // agreeing between a developer's machine and CI, which runs UTC.
     env: { TZ: "UTC" },
     coverage: {
       all: true,


### PR DESCRIPTION
> Part 5 of 16 splitting #375 into reviewable pieces. Merge in stack order.

`test.root: "src/"` made netlify/functions/ and lib/ invisible to the
runner, so no backend test could exist. Replace it with two projects:

- client: jsdom + MSW, matching src/**/*.{test,spec}.ts
- server: node, pure units under lib/, netlify/functions/utils/, scripts/

Shared settings sit on the root config and reach both via `extends: true`:
`restoreMocks` so spies cannot leak across tests, and `TZ=UTC` so date
assertions mean the same thing on a developer's machine as on CI.

MSW now runs with `onUnhandledRequest: "error"` — an unhandled request
fails the test instead of silently leaking to the network. This needs the
previously missing `reviews-id` and `reviews/:workId/comments` baseline
handlers, added here.

Also: register the remaining src/main.ts global components in the render
helper so view tests render real markup instead of unresolved custom
elements, disable Vue Query retries in tests so error-path assertions do
not race the 3x exponential backoff, make the IntersectionObserver stub
able to report intersection, and add an ag-charts stub (it throws on mount
in jsdom).

The existing tests pass unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
