### PR TITLE
Add the integration test harness and core handler tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,8 @@ jobs:
       - run: npm run format:check
       - run: npm run type-check
       - run: npm run lint
+      # The `integration` Vitest project starts a CockroachDB container with
+      # testcontainers, so this step needs a Docker daemon. GitHub-hosted
+      # `ubuntu-latest` runners ship one; a self-hosted runner would need it
+      # installed, or `npm run test:unit` in its place.
       - run: npm test

--- a/netlify/functions/tests/auth.test.ts
+++ b/netlify/functions/tests/auth.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration tests for `netlify/functions/auth.ts` — the adapter that bridges
+ * a Netlify event to BetterAuth's Web `Request`/`Response` handler.
+ *
+ * Nothing about auth is stubbed: real bcrypt hashing, real `account` and
+ * `session` rows in CockroachDB, real signed cookies. Only the verification
+ * email leaves the process, and MSW catches that at Resend's endpoint — which
+ * is also how these tests read the confirmation link, exactly as a user would.
+ */
+import { describe, expect, it } from "vitest";
+
+import { handler } from "../auth";
+import { handler as clubHandler } from "../club/index";
+import { AUTH_HEADERS } from "./helpers/auth";
+import { requester } from "./helpers/http";
+import { lastEmailTo } from "./setup/externalApis";
+
+const api = requester(handler);
+const clubApi = requester(clubHandler);
+
+const PASSWORD = "correct-horse-battery-staple";
+
+let counter = 0;
+const freshEmail = () => `signup-${Date.now().toString(36)}-${(counter += 1)}@movie.club`;
+
+function signUp<T = { user: { id: string } }>(email: string, password = PASSWORD) {
+  return api.post<T>("/api/auth/sign-up/email", {
+    body: { email, password, name: "New User" },
+    headers: AUTH_HEADERS,
+  });
+}
+
+function signInRequest(email: string, password = PASSWORD) {
+  return api.post("/api/auth/sign-in/email", {
+    body: { email, password },
+    headers: AUTH_HEADERS,
+  });
+}
+
+/** Click the link out of the verification email, as a new user would. */
+async function followVerificationLink(email: string) {
+  const message = lastEmailTo(email);
+  if (!message) throw new Error(`No email was sent to ${email}`);
+  const link = /href="([^"]*verify-email[^"]*)"/.exec(message.html)?.[1];
+  if (link === undefined) throw new Error(`The email to ${email} carried no verification link`);
+  const url = new URL(link.replaceAll("&amp;", "&"));
+  return api.get(`${url.pathname}${url.search}`, { headers: AUTH_HEADERS });
+}
+
+function cookieFrom(response: { multiValueHeaders: Record<string, string[]> }) {
+  return (response.multiValueHeaders["Set-Cookie"] ?? [])
+    .map((setCookie) => setCookie.split(";")[0])
+    .join("; ");
+}
+
+describe("POST /api/auth/sign-up/email", () => {
+  it("emails the new address a verification link", async () => {
+    const email = freshEmail();
+
+    const res = await signUp(email);
+
+    expect(res.statusCode).toBe(200);
+    const message = lastEmailTo(email);
+    expect(message?.subject).toMatch(/verify/i);
+    expect(message?.html).toContain("verify-email");
+  });
+
+  it("refuses to sign the new account in until that link is followed", async () => {
+    const email = freshEmail();
+    await signUp(email);
+
+    expect((await signInRequest(email)).statusCode).toBe(403);
+
+    const verified = await followVerificationLink(email);
+    expect(verified.statusCode).toBeLessThan(400);
+    expect((await signInRequest(email)).statusCode).toBe(200);
+  });
+
+  it("answers a repeat sign-up with a decoy rather than touching the account", async () => {
+    const email = freshEmail();
+    const first = await signUp(email);
+    await followVerificationLink(email);
+
+    const second = await signUp(email, "a-different-password");
+
+    // BetterAuth deliberately reports success so the endpoint cannot be used
+    // to enumerate registered addresses — the id it hands back is a decoy.
+    expect(second.statusCode).toBe(200);
+    expect(second.body.user.id).not.toBe(first.body.user.id);
+
+    // The original credentials still work and the second password does not, so
+    // nothing about the real account changed.
+    expect((await signInRequest(email)).statusCode).toBe(200);
+    expect((await signInRequest(email, "a-different-password")).statusCode).toBe(401);
+  });
+});
+
+describe("POST /api/auth/sign-in/email", () => {
+  it("returns both session cookies through multiValueHeaders", async () => {
+    const email = freshEmail();
+    await signUp(email);
+    await followVerificationLink(email);
+
+    const res = await signInRequest(email);
+
+    expect(res.statusCode).toBe(200);
+    // The Headers API folds repeated Set-Cookie into one comma-joined value,
+    // which browsers parse as a single broken cookie. With the session
+    // cookieCache on, sign-in legitimately sets two, so they have to travel
+    // through multiValueHeaders.
+    const cookies = res.multiValueHeaders["Set-Cookie"];
+    expect(cookies.length).toBeGreaterThanOrEqual(2);
+    expect(cookies.some((cookie) => cookie.startsWith("better-auth.session_token="))).toBe(true);
+    expect(res.headers).not.toHaveProperty("set-cookie");
+  });
+
+  it("opens a session the rest of the API accepts", async () => {
+    const email = freshEmail();
+    await signUp(email);
+    await followVerificationLink(email);
+    const cookie = cookieFrom(await signInRequest(email));
+
+    const session = await api.get<{ user: { email: string } }>("/api/auth/get-session", {
+      headers: { ...AUTH_HEADERS, cookie },
+    });
+    expect(session.statusCode).toBe(200);
+    expect(session.body.user.email).toBe(email);
+
+    // The same cookie satisfies `loggedIn` on an ordinary club route.
+    const clubs = await clubApi.post<{ slug: string }>("/api/club", {
+      body: { name: "Brand New Club", members: [email] },
+      headers: { cookie },
+    });
+    expect(clubs.statusCode).toBe(200);
+  });
+
+  it("refuses the wrong password", async () => {
+    const email = freshEmail();
+    await signUp(email);
+    await followVerificationLink(email);
+
+    const res = await signInRequest(email, "not-the-password");
+
+    expect(res.statusCode).toBe(401);
+    expect(res.multiValueHeaders["Set-Cookie"]).toBeUndefined();
+  });
+
+  it("refuses an unknown address", async () => {
+    const res = await signInRequest("nobody@movie.club");
+
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+  });
+});
+
+describe("GET /api/auth/get-session", () => {
+  it("returns an empty session for a request with no cookie", async () => {
+    const res = await api.get("/api/auth/get-session", { headers: AUTH_HEADERS });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBeNull();
+  });
+
+  it("returns an empty session for a forged cookie", async () => {
+    const res = await api.get("/api/auth/get-session", {
+      headers: { ...AUTH_HEADERS, cookie: "better-auth.session_token=not-a-real-token" },
+    });
+
+    expect(res.body).toBeNull();
+  });
+});

--- a/netlify/functions/tests/club.test.ts
+++ b/netlify/functions/tests/club.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Integration tests for `netlify/functions/club/index.ts`.
+ *
+ * Every layer below the HTTP boundary is real: the router, `validClubSlug`,
+ * BetterAuth's `loggedIn` / `secured`, the repositories and CockroachDB. Only
+ * TMDB is faked, and that at the network level (MSW).
+ */
+import { describe, expect, it } from "vitest";
+
+import { ClubPreview, Member } from "../../../lib/types/club";
+import { ClubType, WorkType } from "../../../lib/types/generated/db";
+import { DetailedMovieData } from "../../../lib/types/movie";
+import { handler } from "../club/index";
+import { signIn } from "./helpers/auth";
+import { addWork, createClub, setNextWork } from "./helpers/factories";
+import { requester } from "./helpers/http";
+import { requestsTo } from "./setup/externalApis";
+
+const api = requester(handler);
+
+interface ListSummary {
+  id: string;
+  title: string;
+  systemType: string | null;
+  itemCount: number;
+}
+
+interface ClubSettings {
+  features: { awards: boolean; discussionQuestions: boolean };
+}
+
+describe("GET /api/club/:clubSlug", () => {
+  it("returns the club preview", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { name: "Film Buffs" });
+
+    const res = await api.get<ClubPreview>(`/api/club/${club.slug}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      clubId: club.id,
+      clubName: "Film Buffs",
+      slug: club.slug,
+      type: ClubType.movie,
+    });
+  });
+
+  it("reports the club type for a book club", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { type: ClubType.book });
+
+    const res = await api.get<ClubPreview>(`/api/club/${club.slug}`);
+
+    expect(res.body.type).toBe(ClubType.book);
+  });
+
+  it("returns 404 for an unknown slug", async () => {
+    const res = await api.get("/api/club/nobody-here");
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 405 for a method the route does not define", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.post(`/api/club/${club.slug}`);
+
+    expect(res.statusCode).toBe(405);
+  });
+});
+
+describe("POST /api/club", () => {
+  it("creates a club reachable at a slug derived from its name", async () => {
+    const alice = await signIn("alice");
+
+    const res = await api.post<{ clubId: string; slug: string }>("/api/club", {
+      body: { name: "The Late Night Crew", members: [alice.email] },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.slug).toBe("the-late-night-crew");
+
+    const club = await api.get<ClubPreview>("/api/club/the-late-night-crew");
+    expect(club.body).toMatchObject({
+      clubId: res.body.clubId,
+      clubName: "The Late Night Crew",
+      type: ClubType.movie,
+    });
+    // Left unset on creation so a brand-new club can still change its URL.
+    expect(club.body.slugUpdatedAt).toBeUndefined();
+  });
+
+  it("gives the new club one user list and a reviews list it keeps hidden", async () => {
+    const alice = await signIn("alice");
+
+    const res = await api.post<{ slug: string }>("/api/club", {
+      body: { name: "List Club", members: [alice.email] },
+      as: alice,
+    });
+
+    const lists = await api.get<ListSummary[]>(`/api/club/${res.body.slug}/list`);
+    expect(lists.body).toEqual([
+      { id: expect.any(String), title: "Watch List", systemType: null, itemCount: 0 },
+    ]);
+
+    const reviews = await api.get<{ id: string }>(`/api/club/${res.body.slug}/list/reviews-id`, {
+      as: alice,
+    });
+    expect(reviews.statusCode).toBe(200);
+    expect(reviews.body.id).not.toBe(lists.body[0].id);
+  });
+
+  it("names the default list for the club's media type", async () => {
+    const alice = await signIn("alice");
+
+    const res = await api.post<{ slug: string }>("/api/club", {
+      body: { name: "Book Club", members: [alice.email], type: ClubType.book },
+      as: alice,
+    });
+
+    const lists = await api.get<ListSummary[]>(`/api/club/${res.body.slug}/list`);
+    expect(lists.body[0].title).toBe("Reading List");
+  });
+
+  it("seeds default settings with every feature off", async () => {
+    const alice = await signIn("alice");
+
+    const res = await api.post<{ slug: string }>("/api/club", {
+      body: { name: "Settings Club", members: [alice.email] },
+      as: alice,
+    });
+
+    const settings = await api.get<ClubSettings>(`/api/club/${res.body.slug}/settings`, {
+      as: alice,
+    });
+    expect(settings.body).toEqual({ features: { awards: false, discussionQuestions: false } });
+  });
+
+  it("adds the listed members, making the first one an admin", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+
+    const res = await api.post<{ slug: string }>("/api/club", {
+      body: { name: "Crew", members: [alice.email, bob.email] },
+      as: alice,
+    });
+
+    const members = await api.get<Member[]>(`/api/club/${res.body.slug}/members`);
+    expect(members.body).toHaveLength(2);
+    expect(members.body).toContainEqual(
+      expect.objectContaining({ id: alice.userId, name: "Alice", role: "admin" }),
+    );
+    expect(members.body).toContainEqual(
+      expect.objectContaining({ id: bob.userId, name: "Bob", role: "member" }),
+    );
+  });
+
+  it("appends a suffix when the derived slug is taken", async () => {
+    const alice = await signIn("alice");
+    await createClub(alice, { name: "Duplicate" });
+
+    const res = await api.post<{ slug: string }>("/api/club", {
+      body: { name: "Duplicate", members: [alice.email] },
+      as: alice,
+    });
+
+    expect(res.body.slug).toMatch(/^duplicate-[0-9a-f]{6}$/);
+    expect((await api.get(`/api/club/${res.body.slug}`)).statusCode).toBe(200);
+  });
+
+  it("reports failure but still creates the club when a member email is unknown", async () => {
+    const alice = await signIn("alice");
+
+    const res = await api.post("/api/club", {
+      body: { name: "Ghost Club", members: ["nobody@movie.club"] },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+    const club = await api.get<ClubPreview>("/api/club/ghost-club");
+    expect(club.statusCode).toBe(200);
+    expect(club.body.clubName).toBe("Ghost Club");
+  });
+
+  it("returns 401 when the request has no session", async () => {
+    const res = await api.post("/api/club", { body: { name: "Anon Club", members: [] } });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 401 when the session cookie is not a real session", async () => {
+    const res = await api.post("/api/club", {
+      body: { name: "Forged", members: [] },
+      headers: { cookie: "better-auth.session_token=not-a-real-token" },
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 400 without a body", async () => {
+    const alice = await signIn("alice");
+
+    const res = await api.post("/api/club", { as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 when the body does not match the schema", async () => {
+    const alice = await signIn("alice");
+
+    const res = await api.post("/api/club", { body: { invalid: "data" }, as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("PUT /api/club/:clubSlug/name", () => {
+  it("renames the club", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { name: "Old Name" });
+
+    const res = await api.put(`/api/club/${club.slug}/name`, {
+      body: { name: "New Name" },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const after = await api.get<ClubPreview>(`/api/club/${club.slug}`);
+    expect(after.body.clubName).toBe("New Name");
+  });
+
+  it("returns 401 for a signed-in user who is not a member", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { name: "Members Only", members: [alice] });
+
+    const res = await api.put(`/api/club/${club.slug}/name`, { body: { name: "Hi" }, as: bob });
+
+    expect(res.statusCode).toBe(401);
+    const after = await api.get<ClubPreview>(`/api/club/${club.slug}`);
+    expect(after.body.clubName).toBe("Members Only");
+  });
+
+  it("returns 400 for an empty name", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put(`/api/club/${club.slug}/name`, { body: { name: "" }, as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 without a body", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put(`/api/club/${club.slug}/name`, { as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("PUT /api/club/:clubSlug/slug", () => {
+  it("moves the club to the new url and records when it changed", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put<{ slug: string }>(`/api/club/${club.slug}/slug`, {
+      body: { slug: "new-slug" },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.slug).toBe("new-slug");
+
+    const moved = await api.get<ClubPreview>("/api/club/new-slug");
+    expect(moved.statusCode).toBe(200);
+    expect(moved.body.slugUpdatedAt).toEqual(expect.any(String));
+    expect((await api.get(`/api/club/${club.slug}`)).statusCode).toBe(404);
+  });
+
+  it("returns 400 when another club already uses the slug", async () => {
+    const alice = await signIn("alice");
+    await createClub(alice, { name: "Taken Slug" });
+    const club = await createClub(alice);
+
+    const res = await api.put<{ error: string }>(`/api/club/${club.slug}/slug`, {
+      body: { slug: "taken-slug" },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("This url is already in use by another club");
+  });
+
+  it("allows a club to re-save its own slug", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put(`/api/club/${club.slug}/slug`, {
+      body: { slug: club.slug },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it.each([
+    ["uppercase and spaces", "INVALID SLUG"],
+    ["a leading hyphen", "-leading"],
+    ["fewer than three characters", "ab"],
+    ["a reserved word", "settings"],
+  ])("returns 400 for a slug with %s", async (_label, slug) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put(`/api/club/${club.slug}/slug`, { body: { slug }, as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 401 for a non-member", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+
+    const res = await api.put(`/api/club/${club.slug}/slug`, { body: { slug: "mine" }, as: bob });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("/api/club/:clubSlug/nextWork", () => {
+  it("returns the club's next work", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addWork(club, alice, { title: "Up Next" });
+    await setNextWork(club, alice, work.id);
+
+    const res = await api.get<{ workId: string }>(`/api/club/${club.slug}/nextWork`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.workId).toBe(work.id);
+  });
+
+  it("returns an empty payload when nothing is queued", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.get<{ workId?: string }>(`/api/club/${club.slug}/nextWork`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.workId).toBeUndefined();
+  });
+
+  it("replaces the previous next work rather than adding a second one", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const first = await addWork(club, alice);
+    const second = await addWork(club, alice);
+    await setNextWork(club, alice, first.id);
+
+    const res = await api.put(`/api/club/${club.slug}/nextWork`, {
+      body: { workId: second.id },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const after = await api.get<{ workId: string }>(`/api/club/${club.slug}/nextWork`);
+    expect(after.body.workId).toBe(second.id);
+  });
+
+  it("clears the next work", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addWork(club, alice);
+    await setNextWork(club, alice, work.id);
+
+    const res = await api.delete(`/api/club/${club.slug}/nextWork`, { as: alice });
+
+    expect(res.statusCode).toBe(200);
+    const after = await api.get<{ workId?: string }>(`/api/club/${club.slug}/nextWork`);
+    expect(after.body.workId).toBeUndefined();
+  });
+
+  it("returns 401 when a non-member sets the next work", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+    const work = await addWork(club, alice);
+
+    const res = await api.put(`/api/club/${club.slug}/nextWork`, {
+      body: { workId: work.id },
+      as: bob,
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 400 without a body", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put(`/api/club/${club.slug}/nextWork`, { as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("GET /api/club/:clubSlug/work/:workId/details", () => {
+  it("returns the work's cached metadata including its full cast", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addWork(club, alice, { title: "Fight Club", externalId: "550" });
+
+    const res = await api.get<DetailedMovieData>(`/api/club/${club.slug}/work/${work.id}/details`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.kind).toBe("movie");
+    expect(res.body.overview).toBe("Overview for movie 550");
+    expect(res.body.directors).toEqual([
+      { name: "Director 550", profilePath: "/director-550.jpg" },
+    ]);
+    expect(res.body.actors).toEqual([
+      { name: "Lead 550", character: "Hero 550", profilePath: "/lead-550.jpg" },
+      { name: "Support 550", character: "Sidekick 550", profilePath: null },
+    ]);
+    // Adding the work cached the details; reading them makes no further call.
+    expect(requestsTo("api.themoviedb.org/3/movie/550")).toHaveLength(1);
+  });
+
+  it("returns null for a work with no external id", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addWork(club, alice, { externalId: null });
+
+    const res = await api.get(`/api/club/${club.slug}/work/${work.id}/details`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBeNull();
+  });
+
+  it("returns 404 for a work belonging to another club", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const otherClub = await createClub(alice);
+    const work = await addWork(otherClub, alice, { type: WorkType.movie });
+
+    const res = await api.get(`/api/club/${club.slug}/work/${work.id}/details`);
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/netlify/functions/tests/club.test.ts
+++ b/netlify/functions/tests/club.test.ts
@@ -14,7 +14,7 @@ import { handler } from "../club/index";
 import { signIn } from "./helpers/auth";
 import { addWork, createClub, setNextWork } from "./helpers/factories";
 import { requester } from "./helpers/http";
-import { requestsTo } from "./setup/externalApis";
+import { failOnRequest, TMDB } from "./setup/externalApis";
 
 const api = requester(handler);
 
@@ -415,6 +415,9 @@ describe("GET /api/club/:clubSlug/work/:workId/details", () => {
     const club = await createClub(alice);
     const work = await addWork(club, alice, { title: "Fight Club", externalId: "550" });
 
+    // Adding the work cached the details, so serving them must not need TMDB.
+    failOnRequest("get", `${TMDB}/movie/550`);
+
     const res = await api.get<DetailedMovieData>(`/api/club/${club.slug}/work/${work.id}/details`);
 
     expect(res.statusCode).toBe(200);
@@ -427,8 +430,6 @@ describe("GET /api/club/:clubSlug/work/:workId/details", () => {
       { name: "Lead 550", character: "Hero 550", profilePath: "/lead-550.jpg" },
       { name: "Support 550", character: "Sidekick 550", profilePath: null },
     ]);
-    // Adding the work cached the details; reading them makes no further call.
-    expect(requestsTo("api.themoviedb.org/3/movie/550")).toHaveLength(1);
   });
 
   it("returns null for a work with no external id", async () => {

--- a/netlify/functions/tests/helpers.ts
+++ b/netlify/functions/tests/helpers.ts
@@ -1,0 +1,64 @@
+import { HandlerContext, HandlerEvent, HandlerResponse } from "@netlify/functions";
+
+import { ensure } from "../../../lib/checks/checks";
+
+/**
+ * Narrow a `void | HandlerResponse` to `HandlerResponse`, throwing if the
+ * handler returned void (which should never happen in these tests).
+ */
+export function assertResponse(result: void | HandlerResponse): HandlerResponse {
+  return ensure(result ?? undefined, "Handler returned void — expected a HandlerResponse");
+}
+
+/**
+ * Build a minimal HandlerEvent for testing.
+ * All required fields are provided; optional fields can be overridden.
+ */
+export function makeEvent(
+  overrides: Partial<HandlerEvent> & {
+    path: string;
+    httpMethod: string;
+  },
+): HandlerEvent {
+  return {
+    rawUrl: `https://localhost${overrides.path}`,
+    rawQuery: overrides.rawQuery ?? "",
+    path: overrides.path,
+    httpMethod: overrides.httpMethod,
+    headers: overrides.headers ?? {},
+    multiValueHeaders: overrides.multiValueHeaders ?? {},
+    queryStringParameters: overrides.queryStringParameters ?? null,
+    multiValueQueryStringParameters: overrides.multiValueQueryStringParameters ?? null,
+    body: overrides.body ?? null,
+    isBase64Encoded: overrides.isBase64Encoded ?? false,
+  };
+}
+
+/**
+ * A stub HandlerContext — no real Netlify context needed in unit tests.
+ */
+export const stubContext: HandlerContext = {
+  callbackWaitsForEmptyEventLoop: false,
+  functionName: "test",
+  functionVersion: "test",
+  invokedFunctionArn: "test",
+  memoryLimitInMB: "128",
+  awsRequestId: "test",
+  logGroupName: "test",
+  logStreamName: "test",
+  getRemainingTimeInMillis: () => 30000,
+  done: () => undefined,
+  fail: () => undefined,
+  succeed: () => undefined,
+};
+
+/**
+ * Parse the JSON body of a HandlerResponse.
+ *
+ * Like `axios.get<T>`, this types the JSON boundary unchecked — the test's
+ * assertions are what actually verify the shape.
+ */
+export function parseBody<T = unknown>(body: string | null | undefined): T {
+  const parse: (text: string) => T = JSON.parse;
+  return parse(body ?? "{}");
+}

--- a/netlify/functions/tests/helpers/auth.ts
+++ b/netlify/functions/tests/helpers/auth.ts
@@ -1,0 +1,156 @@
+import { handler as authHandler } from "../../auth";
+import { handler as memberHandler } from "../../member";
+import { lastEmailTo, sentEmails } from "../setup/externalApis";
+import { requester } from "./http";
+
+/**
+ * Real BetterAuth identities for the integration suite.
+ *
+ * Nothing here is faked or shortcut. A fixture user is created by posting to
+ * `/api/auth/sign-up/email`, confirmed by following the link out of the
+ * verification email BetterAuth sends (captured at Resend's endpoint by MSW),
+ * and signed in through `/api/auth/sign-in/email` — the same three requests a
+ * browser makes. The cookie a test then sends is the real signed session
+ * cookie, and `loggedIn` / `secured` verify it against real `session` rows.
+ */
+
+const auth = requester(authHandler);
+
+const PASSWORD = "integration-test-password";
+
+/** BetterAuth reads the host header to build absolute URLs. */
+const AUTH_HEADERS = { "content-type": "application/json", host: "localhost:8888" };
+
+/**
+ * Stable identities shared by the whole run. `helpers/database.ts` leaves the
+ * auth tables alone between tests, so these are created once and thereafter
+ * only signed in again — a handful of bcrypt hashes per file rather than per
+ * test.
+ */
+export const FIXTURE_USERS = {
+  alice: { email: "alice@movie.club", name: "Alice" },
+  bob: { email: "bob@movie.club", name: "Bob" },
+  carol: { email: "carol@movie.club", name: "Carol" },
+  dave: { email: "dave@movie.club", name: "Dave" },
+  erin: { email: "erin@movie.club", name: "Erin" },
+} as const;
+
+export type FixtureUser = keyof typeof FIXTURE_USERS;
+
+export interface TestSession {
+  userId: string;
+  email: string;
+  name: string;
+  /** `cookie` request header carrying the signed BetterAuth session token. */
+  cookie: string;
+}
+
+const sessions = new Map<string, TestSession>();
+
+/** Collapse a Set-Cookie list into the `cookie` header a browser would send back. */
+function toCookieHeader(setCookies: string[]): string {
+  return setCookies.map((setCookie) => setCookie.split(";")[0]).join("; ");
+}
+
+/**
+ * Pull the verification link out of the email BetterAuth just sent and follow
+ * it, which is what confirms the address. Returns the path + query so the
+ * request goes back through the auth handler rather than over the network.
+ */
+async function confirmEmailAddress(email: string) {
+  const message = lastEmailTo(email);
+  if (!message) {
+    throw new Error(`No verification email was sent to ${email}`);
+  }
+
+  const link = /href="([^"]*verify-email[^"]*)"/.exec(message.html)?.[1];
+  if (link === undefined) {
+    throw new Error(`The email sent to ${email} carried no verification link`);
+  }
+
+  const url = new URL(link.replaceAll("&amp;", "&"));
+  const verified = await auth.get(`${url.pathname}${url.search}`, { headers: AUTH_HEADERS });
+
+  // BetterAuth redirects to the callback URL once the token checks out.
+  if (verified.statusCode >= 400) {
+    throw new Error(`Verifying ${email} failed: ${verified.statusCode} ${verified.raw ?? ""}`);
+  }
+}
+
+async function signUp(email: string, name: string) {
+  const response = await auth.post("/api/auth/sign-up/email", {
+    body: { email, password: PASSWORD, name },
+    headers: AUTH_HEADERS,
+  });
+  if (response.statusCode >= 400) {
+    throw new Error(`Signing up ${email} failed: ${response.statusCode} ${response.raw ?? ""}`);
+  }
+  await confirmEmailAddress(email);
+}
+
+/**
+ * Sign a fixture user in, creating and verifying the account on first use. The
+ * session is cached, so repeated calls within a file are free.
+ */
+export async function signIn(who: FixtureUser): Promise<TestSession> {
+  const cached = sessions.get(who);
+  if (cached) return cached;
+
+  const { email, name } = FIXTURE_USERS[who];
+
+  let response = await auth.post("/api/auth/sign-in/email", {
+    body: { email, password: PASSWORD },
+    headers: AUTH_HEADERS,
+  });
+
+  // 403 means the account exists but is unverified, 401 that it does not exist
+  // at all; either way this is the first time this run has needed it.
+  if (response.statusCode >= 400) {
+    await signUp(email, name);
+    response = await auth.post("/api/auth/sign-in/email", {
+      body: { email, password: PASSWORD },
+      headers: AUTH_HEADERS,
+    });
+  }
+
+  if (response.statusCode >= 400) {
+    throw new Error(`Signing in ${email} failed: ${response.statusCode} ${response.raw ?? ""}`);
+  }
+
+  const cookie = toCookieHeader(response.multiValueHeaders["Set-Cookie"] ?? []);
+  const session = await auth.get<{ user: { id: string } } | null>("/api/auth/get-session", {
+    headers: { ...AUTH_HEADERS, cookie },
+  });
+  const userId = session.body?.user.id;
+  if (userId === undefined) {
+    throw new Error(`Signed in ${email} but the session cookie did not resolve to a user`);
+  }
+
+  const testSession: TestSession = { userId, email, name, cookie };
+  sessions.set(who, testSession);
+  return testSession;
+}
+
+/** Sign-up/sign-in for an address outside the fixture set, e.g. to test the flow itself. */
+export async function signUpNewUser(email: string, name = "New User") {
+  await signUp(email, name);
+  sentEmails.length = 0;
+}
+
+/**
+ * Undo any profile change a test made to a fixture user.
+ *
+ * The auth tables survive `resetDatabase()`, so a rename or an avatar upload
+ * would otherwise leak into the next test — and, because sessions are cached
+ * for the whole file, into the next file. Restoring goes through the profile
+ * endpoints rather than the database, for the same reason the tests do.
+ */
+export async function restoreFixtureUsers() {
+  const member = requester(memberHandler);
+  for (const session of sessions.values()) {
+    await member.put("/api/member/name", { body: { name: session.name }, as: session });
+    await member.delete("/api/member/avatar", { as: session });
+  }
+}
+
+export { PASSWORD as FIXTURE_PASSWORD, AUTH_HEADERS };

--- a/netlify/functions/tests/helpers/database.ts
+++ b/netlify/functions/tests/helpers/database.ts
@@ -39,6 +39,7 @@ const DOMAIN_TABLES = [
   "book_authors",
   "book_subjects",
   "book_details",
+  "metric_snapshot",
 ] as const satisfies readonly DomainTable[];
 
 /**

--- a/netlify/functions/tests/helpers/database.ts
+++ b/netlify/functions/tests/helpers/database.ts
@@ -1,0 +1,72 @@
+import { DB } from "../../../../lib/types/generated/db";
+import { pool } from "../../utils/database";
+
+/**
+ * Tables `resetDatabase()` deliberately leaves alone.
+ *
+ * Signing a user up costs two bcrypt hashes, so the auth fixtures create their
+ * users once per file and reuse them (see `helpers/auth.ts`). Nothing a test
+ * asserts on is user-global — club membership, lists and reviews all hang off
+ * `club`, which is wiped — so keeping the accounts around is invisible to tests
+ * and saves the suite tens of seconds.
+ */
+const PRESERVED_TABLES = ["account", "session", "user", "verification"] as const;
+
+type DomainTable = Exclude<keyof DB, (typeof PRESERVED_TABLES)[number]>;
+
+/**
+ * Everything else, children before parents so a single multi-statement DELETE
+ * never trips a foreign key (CockroachDB checks constraints per statement).
+ */
+const DOMAIN_TABLES = [
+  "review",
+  "work_list_item",
+  "work_comment",
+  "next_work",
+  "work_list",
+  "work",
+  "club_settings",
+  "club_invite",
+  "club_member",
+  "awards_temp",
+  "club",
+  "movie_actors",
+  "movie_directors",
+  "movie_genres",
+  "movie_production_companies",
+  "movie_production_countries",
+  "movie_details",
+  "book_authors",
+  "book_subjects",
+  "book_details",
+] as const satisfies readonly DomainTable[];
+
+/**
+ * Fails to compile when `npm run codegen` adds a table that is neither listed
+ * above nor preserved, naming the offender:
+ *
+ *   Type '"new_table"' does not satisfy the constraint 'never'.
+ *
+ * The fix is to decide which list it belongs on — silently leaving a table
+ * un-reset would leak rows between tests.
+ */
+type AssertEveryTableHandled<T extends never> = T;
+type _EveryTableHandled = AssertEveryTableHandled<
+  Exclude<DomainTable, (typeof DOMAIN_TABLES)[number]>
+>;
+
+/**
+ * Empty every domain table between tests.
+ *
+ * `DELETE` rather than `TRUNCATE`: Cockroach implements TRUNCATE as a schema
+ * change that costs ~750ms per call, while deleting from all twenty tables in
+ * one round trip takes ~15ms.
+ */
+export async function resetDatabase() {
+  await pool.query(DOMAIN_TABLES.map((table) => `DELETE FROM "${table}"`).join("; "));
+}
+
+/** Closes the connection pool so the worker can exit. */
+export async function closeDatabase() {
+  await pool.end();
+}

--- a/netlify/functions/tests/helpers/factories.ts
+++ b/netlify/functions/tests/helpers/factories.ts
@@ -1,0 +1,298 @@
+import { AwardsData } from "../../../../lib/types/awards";
+import { ClubType, WorkListSystemType, WorkType } from "../../../../lib/types/generated/db";
+import { DetailedWorkListItem } from "../../../../lib/types/lists";
+import { handler as clubHandler } from "../../club/index";
+import { db } from "../../utils/database";
+import { TestSession } from "./auth";
+import { requester } from "./http";
+
+/**
+ * Arrange-phase seeding for the integration suite.
+ *
+ * Everything here drives the same endpoints a client uses, so a fixture cannot
+ * describe a state the app is incapable of producing, and a bug in the write
+ * path shows up as a failing test rather than as a fixture quietly papering
+ * over it.
+ *
+ * Two exceptions are marked below — expiring an invite and opening an awards
+ * year have no endpoint at all — and they are the only direct database writes
+ * left in the suite.
+ */
+
+const api = requester(clubHandler);
+
+let counter = 0;
+const unique = () => `${Date.now().toString(36)}-${(counter += 1)}`;
+
+/** Throw with the response body when a fixture's own request fails. */
+function assertOk(what: string, response: { statusCode: number; raw?: string }) {
+  if (response.statusCode >= 400) {
+    throw new Error(`${what} failed: ${response.statusCode} ${response.raw ?? ""}`);
+  }
+}
+
+export interface SeededClub {
+  id: string;
+  slug: string;
+  name: string;
+  type: ClubType;
+  /** The club's single user-facing list ("Watch List" / "Reading List"). */
+  listId: string;
+  /** The `reviews` system list. */
+  reviewsListId: string;
+}
+
+interface ListSummary {
+  id: string;
+  title: string;
+  systemType: WorkListSystemType | null;
+  itemCount: number;
+}
+
+/**
+ * Create a club through `POST /api/club`, so it is born with exactly the lists
+ * and settings a real club gets.
+ *
+ * `owner` is the session that creates it. By default the owner is also its
+ * first member (and therefore its admin); pass `members` to change that — an
+ * empty array leaves the club with no members at all.
+ */
+export async function createClub(
+  owner: TestSession,
+  options: {
+    name?: string;
+    type?: ClubType;
+    members?: TestSession[];
+    features?: { awards?: boolean; discussionQuestions?: boolean };
+  } = {},
+): Promise<SeededClub> {
+  const name = options.name ?? `Test Club ${unique()}`;
+  const members = options.members ?? [owner];
+
+  const created = await api.post<{ clubId: string; slug: string }>("/api/club", {
+    body: {
+      name,
+      type: options.type ?? ClubType.movie,
+      members: members.map((member) => member.email),
+    },
+    as: owner,
+  });
+  assertOk(`Creating club "${name}"`, created);
+
+  const slug = created.body.slug;
+  const lists = await api.get<ListSummary[]>(`/api/club/${slug}/list`);
+  assertOk(`Reading lists for "${slug}"`, lists);
+
+  // `reviews-id` and the settings write are both member-only. A club seeded
+  // with no members still needs its reviews list id, so the owner joins for
+  // the two reads and leaves again — cheaper than exposing the id another way.
+  const seededWithoutMembers = members.length === 0;
+  if (seededWithoutMembers) await joinClub({ slug }, owner);
+  const member = members[0] ?? owner;
+
+  const reviews = await api.get<{ id: string }>(`/api/club/${slug}/list/reviews-id`, {
+    as: member,
+  });
+  assertOk(`Reading the reviews list id for "${slug}"`, reviews);
+
+  if (options.features) {
+    const updated = await api.post(`/api/club/${slug}/settings`, {
+      body: { features: options.features },
+      as: member,
+    });
+    assertOk(`Enabling features on "${slug}"`, updated);
+  }
+
+  if (seededWithoutMembers) await leaveClub({ slug }, owner);
+
+  return {
+    id: created.body.clubId,
+    slug,
+    name,
+    type: options.type ?? ClubType.movie,
+    listId: lists.body[0].id,
+    reviewsListId: reviews.body.id,
+  };
+}
+
+/** Join a club as `session` — the same route the invite-less join link uses. */
+export async function joinClub(club: { slug: string }, session: TestSession) {
+  const joined = await api.get(`/api/club/${club.slug}/members/join`, { as: session });
+  assertOk(`${session.email} joining "${club.slug}"`, joined);
+}
+
+export async function leaveClub(club: { slug: string }, session: TestSession) {
+  const left = await api.delete(`/api/club/${club.slug}/members/self`, { as: session });
+  assertOk(`${session.email} leaving "${club.slug}"`, left);
+}
+
+/** Add a list beyond the club's default one. */
+export async function createList(club: SeededClub, session: TestSession, title: string) {
+  const created = await api.post<ListSummary>(`/api/club/${club.slug}/list`, {
+    body: { title },
+    as: session,
+  });
+  assertOk(`Creating list "${title}"`, created);
+  return created.body.id;
+}
+
+export interface SeededWork {
+  id: string;
+  title: string;
+  externalId: string | undefined;
+  type: WorkType;
+  /** The list the work was added to. */
+  listId: string;
+}
+
+/**
+ * Add a work to a list. The endpoint answers with no body, so the work is read
+ * back off the list — which also proves the add landed.
+ */
+export async function addWork(
+  club: SeededClub,
+  session: TestSession,
+  options: {
+    listId?: string;
+    title?: string;
+    type?: WorkType;
+    /** `null` adds a work with no external id, so it carries no metadata. */
+    externalId?: string | null;
+    imageUrl?: string;
+    addedDate?: Date;
+  } = {},
+): Promise<SeededWork> {
+  const listId = options.listId ?? club.listId;
+  const type = options.type ?? WorkType.movie;
+  const externalId =
+    options.externalId === null ? undefined : (options.externalId ?? String(1000 + (counter += 1)));
+  const title = options.title ?? `Work ${externalId ?? unique()}`;
+
+  const added = await api.post(`/api/club/${club.slug}/list/${listId}/items`, {
+    body: {
+      type,
+      title,
+      ...(externalId === undefined ? {} : { externalId }),
+      ...(options.imageUrl === undefined ? {} : { imageUrl: options.imageUrl }),
+    },
+    as: session,
+  });
+  assertOk(`Adding "${title}" to list ${listId}`, added);
+
+  const items = await api.get<DetailedWorkListItem[]>(`/api/club/${club.slug}/list/${listId}`);
+  assertOk(`Reading list ${listId}`, items);
+  const item = items.body.findLast((candidate) => candidate.title === title);
+  if (!item) {
+    throw new Error(`Added "${title}" to list ${listId} but it is not on the list`);
+  }
+
+  if (options.addedDate) {
+    await setAddedDate(club, session, listId, item.id, options.addedDate);
+  }
+
+  return { id: item.id, title, externalId, type, listId };
+}
+
+export async function setAddedDate(
+  club: SeededClub,
+  session: TestSession,
+  listId: string,
+  workId: string,
+  addedDate: Date,
+) {
+  const updated = await api.put(
+    `/api/club/${club.slug}/list/${listId}/items/${workId}/added-date`,
+    { body: { addedDate: addedDate.toISOString() }, as: session },
+  );
+  assertOk(`Setting the added date of work ${workId}`, updated);
+}
+
+/** A work on the club's `reviews` list — the precondition for scoring it. */
+export function addReviewedWork(
+  club: SeededClub,
+  session: TestSession,
+  options: Parameters<typeof addWork>[2] = {},
+): Promise<SeededWork> {
+  return addWork(club, session, { ...options, listId: club.reviewsListId });
+}
+
+export async function scoreWork(
+  club: SeededClub,
+  session: TestSession,
+  workId: string,
+  score: number,
+) {
+  const scored = await api.post(`/api/club/${club.slug}/reviews`, {
+    body: { workId, score },
+    as: session,
+  });
+  assertOk(`${session.email} scoring work ${workId}`, scored);
+}
+
+export async function addComment(
+  club: SeededClub,
+  session: TestSession,
+  workId: string,
+  content: string,
+  spoiler = false,
+) {
+  const added = await api.post(`/api/club/${club.slug}/reviews/${workId}/comments`, {
+    body: { content, spoiler },
+    as: session,
+  });
+  assertOk(`${session.email} commenting on work ${workId}`, added);
+
+  const comments = await api.get<{ id: string; content: string }[]>(
+    `/api/club/${club.slug}/reviews/${workId}/comments`,
+    { as: session },
+  );
+  const comment = comments.body.findLast((candidate) => candidate.content === content);
+  if (!comment) {
+    throw new Error(`Added a comment to work ${workId} but it is not on the work`);
+  }
+  return comment.id;
+}
+
+export async function setNextWork(club: SeededClub, session: TestSession, workId: string) {
+  const set = await api.put(`/api/club/${club.slug}/nextWork`, { body: { workId }, as: session });
+  assertOk(`Setting the next work of "${club.slug}"`, set);
+}
+
+export async function createInvite(club: SeededClub, session: TestSession) {
+  const created = await api.post<{ token: string }>(`/api/club/${club.slug}/invite`, {
+    as: session,
+  });
+  assertOk(`Creating an invite for "${club.slug}"`, created);
+  return created.body.token;
+}
+
+// --- The two states no endpoint can produce -------------------------------
+
+/**
+ * Backdate an invite so it is already expired.
+ *
+ * `POST /invite` always issues a 24-hour token and nothing can shorten it, so
+ * the expiry branches are unreachable through the API. Direct write, kept to
+ * this one column.
+ */
+export async function expireInvite(token: string) {
+  await db
+    .updateTable("club_invite")
+    .set({ expires_at: new Date(Date.now() - 60_000) })
+    .where("token", "=", token)
+    .execute();
+}
+
+/**
+ * Open an awards year for a club.
+ *
+ * Every awards route runs through `validYear`, which 404s unless the year's row
+ * already exists, and no endpoint creates it — the rows predate the API and are
+ * seeded out of band. Direct write until an "open a year" route exists.
+ */
+export async function createAwardsYear(club: SeededClub, year: number, data: AwardsData) {
+  await db
+    .insertInto("awards_temp")
+    .values({ club_id: club.id, year: String(year), data: JSON.stringify(data) })
+    .execute();
+}

--- a/netlify/functions/tests/helpers/http.ts
+++ b/netlify/functions/tests/helpers/http.ts
@@ -1,0 +1,170 @@
+import { Handler, HandlerContext, HandlerEvent, HandlerResponse } from "@netlify/functions";
+
+import { ensure } from "../../../../lib/checks/checks";
+import type { TestSession } from "./auth";
+
+/** A stub HandlerContext — Netlify's context carries nothing the routers read. */
+export const stubContext: HandlerContext = {
+  callbackWaitsForEmptyEventLoop: false,
+  functionName: "test",
+  functionVersion: "test",
+  invokedFunctionArn: "test",
+  memoryLimitInMB: "128",
+  awsRequestId: "test",
+  logGroupName: "test",
+  logStreamName: "test",
+  getRemainingTimeInMillis: () => 30000,
+  done: () => undefined,
+  fail: () => undefined,
+  succeed: () => undefined,
+};
+
+export interface RequestOptions {
+  /** Serialized to JSON. Pass a string to send a body verbatim (malformed JSON, etc.). */
+  body?: unknown;
+  query?: Record<string, string>;
+  headers?: Record<string, string>;
+  /** Authenticates the request with a real signed BetterAuth session cookie. */
+  as?: TestSession;
+}
+
+export interface ApiResponse<T> {
+  statusCode: number;
+  headers: Record<string, string>;
+  /**
+   * Netlify's channel for repeated headers. `Set-Cookie` has to go through
+   * here — the Headers API folds repeats into one comma-joined value — so
+   * cookie assertions read this, not `headers`.
+   */
+  multiValueHeaders: Record<string, string[]>;
+  /** Parsed JSON body, or the raw string when the response is not JSON. */
+  body: T;
+  raw: string | undefined;
+}
+
+/**
+ * Build the HandlerEvent a Netlify function receives. Exported for the few
+ * tests that need to hand-roll an event (multipart uploads, base64 bodies).
+ */
+export function makeEvent(
+  options: RequestOptions & { path: string; httpMethod: string },
+): HandlerEvent {
+  const query = options.query ?? {};
+  const rawQuery = new URLSearchParams(query).toString();
+  const body =
+    options.body === undefined
+      ? null
+      : typeof options.body === "string"
+        ? options.body
+        : JSON.stringify(options.body);
+
+  return {
+    rawUrl: `https://localhost${options.path}${rawQuery ? `?${rawQuery}` : ""}`,
+    rawQuery,
+    path: options.path,
+    httpMethod: options.httpMethod,
+    headers: {
+      ...(options.as ? { cookie: options.as.cookie } : {}),
+      ...options.headers,
+    },
+    multiValueHeaders: {},
+    queryStringParameters: Object.keys(query).length > 0 ? query : null,
+    multiValueQueryStringParameters: null,
+    body,
+    isBase64Encoded: false,
+  };
+}
+
+/**
+ * `JSON.parse` typed to what the caller expects. Like `axios.get<T>`, this
+ * types the boundary unchecked — the test's assertions are what actually
+ * verify the shape.
+ */
+const parseJson: <T>(input: string) => T = JSON.parse;
+
+/**
+ * Hand a body back with the caller's type without going through the parser:
+ * for SVG and redirect responses, and for the handlers that answer
+ * `ok("Joined club successfully")` — a bare string under a JSON content type.
+ */
+function asBody<T>(value: string | undefined): T {
+  return parseJson<T>(JSON.stringify(value ?? null));
+}
+
+function parseBody<T>(raw: string | undefined, isJson: boolean): T {
+  if (!isJson || raw === undefined || raw === "") {
+    return asBody<T>(raw);
+  }
+  try {
+    return parseJson<T>(raw);
+  } catch {
+    return asBody<T>(raw);
+  }
+}
+
+/** Invoke a handler with a fully-formed event and normalize what comes back. */
+export async function send<T = unknown>(
+  handler: Handler,
+  event: HandlerEvent,
+): Promise<ApiResponse<T>> {
+  const result = await handler(event, stubContext, () => {
+    // Netlify's callback style is unused by these handlers.
+  });
+
+  const response: HandlerResponse = ensure(
+    result ?? undefined,
+    `${event.httpMethod} ${event.path} returned void — expected a HandlerResponse`,
+  );
+
+  const headers: Record<string, string> = Object.fromEntries(
+    Object.entries(response.headers ?? {}).map(([key, value]) => [key, String(value)]),
+  );
+  const raw = response.body ?? undefined;
+  // The response helpers send `Content-Type`; BetterAuth's Web `Response`
+  // lowercases it. Header names are case-insensitive, so match on both.
+  const contentType = Object.entries(headers).find(
+    ([key]) => key.toLowerCase() === "content-type",
+  )?.[1];
+  const isJson = contentType?.includes("application/json") === true;
+
+  const multiValueHeaders: Record<string, string[]> = Object.fromEntries(
+    Object.entries(response.multiValueHeaders ?? {}).map(([key, values]) => [
+      key,
+      values.map(String),
+    ]),
+  );
+
+  return {
+    statusCode: response.statusCode,
+    headers,
+    multiValueHeaders,
+    body: parseBody<T>(raw, isJson),
+    raw,
+  };
+}
+
+/**
+ * Wraps a Netlify function handler in a small HTTP-shaped client so tests read
+ * like the requests the frontend actually makes:
+ *
+ * ```ts
+ * const api = requester(handler);
+ * const res = await api.get<ClubPreview>(`/api/club/${club.slug}`);
+ * await api.post("/api/club", { body: { name: "New" }, as: alice });
+ * ```
+ */
+export function requester(handler: Handler) {
+  const call = <T>(httpMethod: string, path: string, options: RequestOptions = {}) =>
+    send<T>(handler, makeEvent({ ...options, path, httpMethod }));
+
+  return {
+    get: <T = unknown>(path: string, options?: RequestOptions) => call<T>("GET", path, options),
+    post: <T = unknown>(path: string, options?: RequestOptions) => call<T>("POST", path, options),
+    put: <T = unknown>(path: string, options?: RequestOptions) => call<T>("PUT", path, options),
+    delete: <T = unknown>(path: string, options?: RequestOptions) =>
+      call<T>("DELETE", path, options),
+    patch: <T = unknown>(path: string, options?: RequestOptions) => call<T>("PATCH", path, options),
+    /** Escape hatch for requests that need a hand-built event (multipart, base64). */
+    send: <T = unknown>(event: HandlerEvent) => send<T>(handler, event),
+  };
+}

--- a/netlify/functions/tests/member.test.ts
+++ b/netlify/functions/tests/member.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Integration tests for `netlify/functions/member.ts` — the signed-in user's
+ * own profile: their clubs, display name and avatar.
+ *
+ * The avatar routes run the real Cloudinary SDK against an MSW-intercepted
+ * Cloudinary, so the multipart parsing and the upload/destroy calls are
+ * genuinely exercised. What the profile now looks like is read back off the
+ * club members endpoint, which is where a client sees it.
+ */
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { ClubPreview, Member } from "../../../lib/types/club";
+import { ClubType } from "../../../lib/types/generated/db";
+import { handler as clubHandler } from "../club/index";
+import { handler } from "../member";
+import { signIn, TestSession } from "./helpers/auth";
+import { createClub, SeededClub } from "./helpers/factories";
+import { makeEvent, requester } from "./helpers/http";
+import { requestsTo, server } from "./setup/externalApis";
+
+const api = requester(handler);
+const clubApi = requester(clubHandler);
+
+const AVATAR_URL = "https://res.cloudinary.com/test-cloud/image/upload/avatar.jpg";
+
+/** A minimal multipart/form-data body carrying one file field. */
+function multipartAvatar(fields: { file?: string; note?: string } = { file: "avatar.png" }) {
+  const boundary = "----movieclubtestboundary";
+  const parts = [`--${boundary}`];
+  if (fields.file !== undefined) {
+    parts.push(
+      `Content-Disposition: form-data; name="file"; filename="${fields.file}"`,
+      "Content-Type: image/png",
+      "",
+      "pretend-png-bytes",
+    );
+  } else {
+    parts.push('Content-Disposition: form-data; name="note"', "", fields.note ?? "hi");
+  }
+  parts.push(`--${boundary}--`, "");
+
+  return { boundary, body: parts.join("\r\n") };
+}
+
+function uploadAvatar(session: TestSession, fields?: Parameters<typeof multipartAvatar>[0]) {
+  const { boundary, body } = multipartAvatar(fields);
+  return api.send(
+    makeEvent({
+      path: "/api/member/avatar",
+      httpMethod: "POST",
+      body,
+      as: session,
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+    }),
+  );
+}
+
+/** The profile a club sees for `session` — how a client observes name and avatar. */
+async function profileIn(club: SeededClub, session: TestSession) {
+  const members = await clubApi.get<Member[]>(`/api/club/${club.slug}/members`);
+  return members.body.find((member) => member.id === session.userId);
+}
+
+describe("GET /api/member/clubs", () => {
+  it("returns a preview of every club the user belongs to", async () => {
+    const alice = await signIn("alice");
+    const movies = await createClub(alice, { name: "Movie Night" });
+    await createClub(alice, { name: "Books", type: ClubType.book });
+    await createClub(alice, { name: "Not Mine", members: [] });
+
+    const res = await api.get<ClubPreview[]>("/api/member/clubs", { as: alice });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body).toContainEqual({
+      clubId: movies.id,
+      clubName: "Movie Night",
+      slug: movies.slug,
+      type: ClubType.movie,
+    });
+    expect(res.body.map((club) => club.clubName).sort()).toEqual(["Books", "Movie Night"]);
+  });
+
+  it("returns an empty list for a user in no clubs", async () => {
+    const bob = await signIn("bob");
+
+    const res = await api.get<ClubPreview[]>("/api/member/clubs", { as: bob });
+
+    expect(res.body).toEqual([]);
+  });
+
+  it("returns 401 without a session", async () => {
+    const res = await api.get("/api/member/clubs");
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("PUT /api/member/name", () => {
+  it("renames the signed-in user everywhere they appear", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put("/api/member/name", { body: { name: "  Alice B  " }, as: alice });
+
+    expect(res.statusCode).toBe(200);
+    expect(await profileIn(club, alice)).toMatchObject({ name: "Alice B" });
+  });
+
+  it.each([
+    ["a name that is only whitespace", { name: "   " }, "Name cannot be empty"],
+    ["a name over 100 characters", { name: "x".repeat(101) }, "Name is too long"],
+  ])("returns 400 for %s", async (_label, body, message) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put<{ error: string }>("/api/member/name", { body, as: alice });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe(message);
+    expect(await profileIn(club, alice)).toMatchObject({ name: "Alice" });
+  });
+
+  it("returns 401 without a session", async () => {
+    const res = await api.put("/api/member/name", { body: { name: "Anon" } });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("POST /api/member/avatar", () => {
+  it("uploads the file to Cloudinary and shows the returned url on the profile", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await uploadAvatar(alice);
+
+    expect(res.statusCode).toBe(200);
+    expect(requestsTo("api.cloudinary.com")).toHaveLength(1);
+    expect(await profileIn(club, alice)).toMatchObject({ image: AVATAR_URL });
+  });
+
+  it("deletes the previous Cloudinary asset when replacing an avatar", async () => {
+    const alice = await signIn("alice");
+    await uploadAvatar(alice);
+
+    const destroyed: string[] = [];
+    server.use(
+      http.post("https://api.cloudinary.com/v1_1/:cloud/image/destroy", async ({ request }) => {
+        destroyed.push(await request.text());
+        return HttpResponse.json({ result: "ok" });
+      }),
+    );
+
+    const res = await uploadAvatar(alice);
+
+    expect(res.statusCode).toBe(200);
+    expect(destroyed.join()).toContain("avatar-public-id");
+  });
+
+  it("returns 400 when the request carries no file", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await uploadAvatar(alice, { note: "no file here" });
+
+    expect(res.statusCode).toBe(400);
+    expect(await profileIn(club, alice)).not.toHaveProperty("image");
+  });
+});
+
+describe("DELETE /api/member/avatar", () => {
+  it("clears the avatar and deletes the Cloudinary asset", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await uploadAvatar(alice);
+
+    const res = await api.delete("/api/member/avatar", { as: alice });
+
+    expect(res.statusCode).toBe(200);
+    // Upload + destroy.
+    expect(requestsTo("api.cloudinary.com")).toHaveLength(2);
+    expect(await profileIn(club, alice)).not.toHaveProperty("image");
+  });
+
+  it("skips Cloudinary when the user has no stored asset", async () => {
+    const alice = await signIn("alice");
+
+    const res = await api.delete("/api/member/avatar", { as: alice });
+
+    expect(res.statusCode).toBe(200);
+    expect(requestsTo("api.cloudinary.com")).toHaveLength(0);
+  });
+
+  it("returns 401 without a session", async () => {
+    const res = await api.delete("/api/member/avatar");
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("routing", () => {
+  it("returns 404 for an unknown path", async () => {
+    const res = await api.get("/api/member/unknown");
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 405 for a method the route does not define", async () => {
+    const res = await api.post("/api/member/clubs");
+
+    expect(res.statusCode).toBe(405);
+  });
+});

--- a/netlify/functions/tests/member.test.ts
+++ b/netlify/functions/tests/member.test.ts
@@ -2,10 +2,10 @@
  * Integration tests for `netlify/functions/member.ts` — the signed-in user's
  * own profile: their clubs, display name and avatar.
  *
- * The avatar routes run the real Cloudinary SDK against an MSW-intercepted
- * Cloudinary, so the multipart parsing and the upload/destroy calls are
- * genuinely exercised. What the profile now looks like is read back off the
- * club members endpoint, which is where a client sees it.
+ * The avatar routes run the real image-upload stack — multipart parsing and
+ * the SDK's own requests — against an MSW-intercepted host. Where the file
+ * ends up is an implementation detail; what the tests check is the round trip,
+ * read back off the club members endpoint, which is where a client sees it.
  */
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
@@ -17,12 +17,13 @@ import { handler } from "../member";
 import { signIn, TestSession } from "./helpers/auth";
 import { createClub, SeededClub } from "./helpers/factories";
 import { makeEvent, requester } from "./helpers/http";
-import { requestsTo, server } from "./setup/externalApis";
+import { CLOUDINARY_DESTROY, CLOUDINARY_UPLOAD, failOnRequest, server } from "./setup/externalApis";
 
 const api = requester(handler);
 const clubApi = requester(clubHandler);
 
 const AVATAR_URL = "https://res.cloudinary.com/test-cloud/image/upload/avatar.jpg";
+const REPLACEMENT_AVATAR_URL = "https://res.cloudinary.com/test-cloud/image/upload/second.jpg";
 
 /** A minimal multipart/form-data body carrying one file field. */
 function multipartAvatar(fields: { file?: string; note?: string } = { file: "avatar.png" }) {
@@ -130,33 +131,31 @@ describe("PUT /api/member/name", () => {
 });
 
 describe("POST /api/member/avatar", () => {
-  it("uploads the file to Cloudinary and shows the returned url on the profile", async () => {
+  it("stores the uploaded file and shows it on the profile", async () => {
     const alice = await signIn("alice");
     const club = await createClub(alice);
 
     const res = await uploadAvatar(alice);
 
     expect(res.statusCode).toBe(200);
-    expect(requestsTo("api.cloudinary.com")).toHaveLength(1);
     expect(await profileIn(club, alice)).toMatchObject({ image: AVATAR_URL });
   });
 
-  it("deletes the previous Cloudinary asset when replacing an avatar", async () => {
+  it("replaces an existing avatar with the newly uploaded one", async () => {
     const alice = await signIn("alice");
+    const club = await createClub(alice);
     await uploadAvatar(alice);
 
-    const destroyed: string[] = [];
     server.use(
-      http.post("https://api.cloudinary.com/v1_1/:cloud/image/destroy", async ({ request }) => {
-        destroyed.push(await request.text());
-        return HttpResponse.json({ result: "ok" });
-      }),
+      http.post(CLOUDINARY_UPLOAD, () =>
+        HttpResponse.json({ secure_url: REPLACEMENT_AVATAR_URL, public_id: "second-public-id" }),
+      ),
     );
 
     const res = await uploadAvatar(alice);
 
     expect(res.statusCode).toBe(200);
-    expect(destroyed.join()).toContain("avatar-public-id");
+    expect(await profileIn(club, alice)).toMatchObject({ image: REPLACEMENT_AVATAR_URL });
   });
 
   it("returns 400 when the request carries no file", async () => {
@@ -171,7 +170,7 @@ describe("POST /api/member/avatar", () => {
 });
 
 describe("DELETE /api/member/avatar", () => {
-  it("clears the avatar and deletes the Cloudinary asset", async () => {
+  it("clears the avatar off the profile", async () => {
     const alice = await signIn("alice");
     const club = await createClub(alice);
     await uploadAvatar(alice);
@@ -179,18 +178,17 @@ describe("DELETE /api/member/avatar", () => {
     const res = await api.delete("/api/member/avatar", { as: alice });
 
     expect(res.statusCode).toBe(200);
-    // Upload + destroy.
-    expect(requestsTo("api.cloudinary.com")).toHaveLength(2);
     expect(await profileIn(club, alice)).not.toHaveProperty("image");
   });
 
-  it("skips Cloudinary when the user has no stored asset", async () => {
+  it("succeeds when the user has no stored avatar", async () => {
     const alice = await signIn("alice");
+    // Nothing was ever uploaded, so there is nothing to delete remotely.
+    failOnRequest("post", CLOUDINARY_DESTROY);
 
     const res = await api.delete("/api/member/avatar", { as: alice });
 
     expect(res.statusCode).toBe(200);
-    expect(requestsTo("api.cloudinary.com")).toHaveLength(0);
   });
 
   it("returns 401 without a session", async () => {

--- a/netlify/functions/tests/members.test.ts
+++ b/netlify/functions/tests/members.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Integration tests for `netlify/functions/club/members.ts` and
+ * `club/members/join.ts` — membership listing, leaving, removal, and the
+ * invite-token join flow.
+ */
+import { describe, expect, it } from "vitest";
+
+import { Member } from "../../../lib/types/club";
+import { handler as clubHandler } from "../club/index";
+import { handler as memberHandler } from "../member";
+import { signIn, TestSession } from "./helpers/auth";
+import { createClub, createInvite, expireInvite, joinClub } from "./helpers/factories";
+import { makeEvent, requester } from "./helpers/http";
+
+const api = requester(clubHandler);
+const memberApi = requester(memberHandler);
+
+const membersOf = (slug: string) => api.get<Member[]>(`/api/club/${slug}/members`);
+
+/** Upload an avatar as `session`, so a test can assert the image comes back. */
+async function uploadAvatar(session: TestSession) {
+  const boundary = "----movieclubtestboundary";
+  const body = [
+    `--${boundary}`,
+    'Content-Disposition: form-data; name="file"; filename="avatar.png"',
+    "Content-Type: image/png",
+    "",
+    "pretend-png-bytes",
+    `--${boundary}--`,
+    "",
+  ].join("\r\n");
+
+  return memberApi.send(
+    makeEvent({
+      path: "/api/member/avatar",
+      httpMethod: "POST",
+      body,
+      as: session,
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+    }),
+  );
+}
+
+describe("GET /api/club/:clubSlug/members", () => {
+  it("returns every member with their profile and role", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice, bob] });
+    await uploadAvatar(alice);
+
+    const res = await membersOf(club.slug);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body).toContainEqual({
+      id: alice.userId,
+      email: alice.email,
+      name: "Alice",
+      image: "https://res.cloudinary.com/test-cloud/image/upload/avatar.jpg",
+      role: "admin",
+    });
+    expect(res.body).toContainEqual({
+      id: bob.userId,
+      email: bob.email,
+      name: "Bob",
+      role: "member",
+    });
+  });
+
+  it("returns an empty list for a club with no members", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { members: [] });
+
+    const res = await membersOf(club.slug);
+
+    expect(res.body).toEqual([]);
+  });
+
+  it("does not leak another club's members", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [] });
+    await createClub(bob, { members: [bob] });
+
+    const res = await membersOf(club.slug);
+
+    expect(res.body).toEqual([]);
+  });
+
+  it("returns 404 for an unknown club", async () => {
+    const res = await api.get("/api/club/no-such-club/members");
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("DELETE /api/club/:clubSlug/members/self", () => {
+  it("removes the authenticated member from the club", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.delete(`/api/club/${club.slug}/members/self`, { as: alice });
+
+    expect(res.statusCode).toBe(200);
+    expect((await membersOf(club.slug)).body).toEqual([]);
+  });
+
+  it("returns 401 without a session", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.delete(`/api/club/${club.slug}/members/self`);
+
+    expect(res.statusCode).toBe(401);
+    expect((await membersOf(club.slug)).body).toHaveLength(1);
+  });
+});
+
+describe("DELETE /api/club/:clubSlug/members/:memberId", () => {
+  it("removes another member", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice, bob] });
+
+    const res = await api.delete(`/api/club/${club.slug}/members/${bob.userId}`, { as: alice });
+
+    expect(res.statusCode).toBe(200);
+    expect((await membersOf(club.slug)).body.map((member) => member.id)).toEqual([alice.userId]);
+  });
+
+  it("returns 401 for a signed-in user outside the club", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+
+    const res = await api.delete(`/api/club/${club.slug}/members/${alice.userId}`, { as: bob });
+
+    expect(res.statusCode).toBe(401);
+    expect((await membersOf(club.slug)).body).toHaveLength(1);
+  });
+});
+
+describe("GET /api/club/:clubSlug/members/join", () => {
+  it("adds the signed-in user to the club", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+
+    const res = await api.get(`/api/club/${club.slug}/members/join`, { as: bob });
+
+    expect(res.statusCode).toBe(200);
+    expect((await membersOf(club.slug)).body.map((member) => member.id).sort()).toEqual(
+      [alice.userId, bob.userId].sort(),
+    );
+  });
+
+  it("returns 401 without a session", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { members: [] });
+
+    const res = await api.get(`/api/club/${club.slug}/members/join`);
+
+    expect(res.statusCode).toBe(401);
+    expect((await membersOf(club.slug)).body).toEqual([]);
+  });
+});
+
+describe("POST /api/club/join", () => {
+  it("joins the club the invite token belongs to", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+    const token = await createInvite(club, alice);
+
+    const res = await api.post(`/api/club/join`, { body: { token }, as: bob });
+
+    expect(res.statusCode).toBe(200);
+    const members = await membersOf(club.slug);
+    expect(members.body).toContainEqual(
+      expect.objectContaining({ id: bob.userId, role: "member" }),
+    );
+  });
+
+  it("shows up in the joiner's own club list", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { name: "Joinable", members: [alice] });
+    const token = await createInvite(club, alice);
+
+    await api.post(`/api/club/join`, { body: { token }, as: bob });
+
+    const clubs = await memberApi.get<{ clubName: string }[]>("/api/member/clubs", { as: bob });
+    expect(clubs.body.map((entry) => entry.clubName)).toEqual(["Joinable"]);
+  });
+
+  it("rejects an unknown token", async () => {
+    const alice = await signIn("alice");
+
+    const res = await api.post<{ error: string }>(`/api/club/join`, {
+      body: { token: "made-up" },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Invalid invite token");
+  });
+
+  it("rejects an expired token and retires it", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+    const token = await createInvite(club, alice);
+    await expireInvite(token);
+
+    const res = await api.post<{ error: string }>(`/api/club/join`, { body: { token }, as: bob });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Invite token expired");
+    expect((await membersOf(club.slug)).body).toHaveLength(1);
+
+    // The expired token is gone, so it now reads as invalid rather than stale.
+    const retry = await api.post<{ error: string }>(`/api/club/join`, { body: { token }, as: bob });
+    expect(retry.body.error).toBe("Invalid invite token");
+  });
+
+  it.each([
+    ["no body", undefined],
+    ["a body without a token", { notAToken: "x" }],
+  ])("returns 400 with %s", async (_label, body) => {
+    const alice = await signIn("alice");
+
+    const res = await api.post(`/api/club/join`, { body, as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 401 without a session", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { members: [alice] });
+    const token = await createInvite(club, alice);
+
+    const res = await api.post(`/api/club/join`, { body: { token } });
+
+    expect(res.statusCode).toBe(401);
+    expect((await membersOf(club.slug)).body).toHaveLength(1);
+  });
+});
+
+describe("GET /api/club/joinInfo/:token", () => {
+  it("returns the club behind a valid token", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { name: "Invite Club" });
+    const token = await createInvite(club, alice);
+
+    const res = await api.get<{ clubId: string; clubName: string }>(`/api/club/joinInfo/${token}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.clubId).toBe(club.id);
+    expect(res.body.clubName).toBe("Invite Club");
+  });
+
+  it("returns 400 for an expired token", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const token = await createInvite(club, alice);
+    await expireInvite(token);
+
+    const res = await api.get<{ error: string }>(`/api/club/joinInfo/${token}`);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Invite token expired");
+  });
+
+  it("returns 400 for an unknown token", async () => {
+    const res = await api.get<{ error: string }>(`/api/club/joinInfo/nope`);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Invalid invite token");
+  });
+});
+
+describe("leaving and rejoining", () => {
+  it("drops the club from the member's own list and puts it back", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { name: "Revolving Door", members: [alice, bob] });
+
+    await api.delete(`/api/club/${club.slug}/members/self`, { as: bob });
+    expect((await memberApi.get<unknown[]>("/api/member/clubs", { as: bob })).body).toEqual([]);
+
+    await joinClub(club, bob);
+    const clubs = await memberApi.get<{ clubName: string }[]>("/api/member/clubs", { as: bob });
+    expect(clubs.body.map((entry) => entry.clubName)).toEqual(["Revolving Door"]);
+  });
+});

--- a/netlify/functions/tests/setup/env.ts
+++ b/netlify/functions/tests/setup/env.ts
@@ -1,0 +1,38 @@
+import { existsSync } from "fs";
+import path from "path";
+import { inject } from "vitest";
+
+/**
+ * Points the backend at the throwaway CockroachDB started by `globalSetup.ts`.
+ *
+ * `utils/database.ts` builds its pool from `DATABASE_URL` at import time, and
+ * the container's port is only known once it is running — so unlike the static
+ * service credentials (which live in `vite.config.ts`'s `test.env`) this one
+ * cannot be declared up front. Importing this module first, before anything
+ * that reaches `utils/database.ts`, is what makes the ordering work; see
+ * `setup/integration.ts`.
+ */
+const databaseUrl = inject("databaseUrl");
+
+// `getDbUrl()` prefers ./database-config.json over the environment, so a
+// developer with a leftover one from `netlify dev` would silently run the
+// integration suite — resets and all — against whatever database that file
+// names. Refuse to start rather than truncate someone's dev data.
+const configPath = path.resolve("./database-config.json");
+if (existsSync(configPath)) {
+  throw new Error(
+    `${configPath} exists and takes precedence over DATABASE_URL, so the integration suite ` +
+      `would run against that database and delete its contents. Move or remove it first.`,
+  );
+}
+
+process.env.DATABASE_URL = databaseUrl;
+
+// `DatabaseCleanupRepository` builds its own admin pool against `defaultdb`
+// from this, defaulting `sslmode` to `verify-full` when the URL does not say
+// otherwise — which an insecure test container refuses. Say otherwise.
+const rootUrl = new URL(databaseUrl);
+rootUrl.searchParams.set("sslmode", "disable");
+process.env.DATABASE_URL_ROOT = rootUrl.toString();
+
+export { databaseUrl };

--- a/netlify/functions/tests/setup/externalApis.ts
+++ b/netlify/functions/tests/setup/externalApis.ts
@@ -1,0 +1,117 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { z } from "zod";
+
+import { geminiJsonResponse, googleBooksVolume, tmdbConfig, tmdbMovie } from "../fixtures/external";
+
+/**
+ * The only thing the integration suite fakes: the third-party HTTP APIs.
+ *
+ * Everything below the network — routers, middleware, repositories, Kysely,
+ * BetterAuth — runs for real against a live CockroachDB. Intercepting at the
+ * boundary rather than with `vi.mock` means `utils/tmdb.ts`,
+ * `providers/googleBooks.ts`, `utils/gemini.ts`, `utils/email.ts` and the
+ * Cloudinary SDK all execute their real request-building and response-parsing
+ * code, so a test can catch a bug in any of it.
+ *
+ * `onUnhandledRequest: "error"` (see `integration.ts`) means a handler reaching
+ * an unmocked host fails the test instead of hitting the internet.
+ */
+
+const TMDB = "https://api.themoviedb.org/3";
+const GOOGLE_BOOKS = "https://www.googleapis.com/books/v1";
+// The Gemini path ends in `models/<model>:generateContent`; the colon would be
+// read as a path parameter by MSW's matcher, so match the host instead.
+const GEMINI = /generativelanguage\.googleapis\.com/;
+
+/**
+ * Every request MSW intercepted during the current test, so a test can assert
+ * on cache behaviour ("re-adding a known movie makes no second TMDB call")
+ * rather than just on the response body. Cleared before each test.
+ */
+export const externalRequests: { method: string; url: string }[] = [];
+
+export interface SentEmail {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+/**
+ * Emails BetterAuth handed to Resend during the current test. Cleared before
+ * each test.
+ *
+ * This is the test suite's inbox: `helpers/auth.ts` confirms a new account by
+ * following the link out of the verification email, exactly as a user would,
+ * rather than flipping `emailVerified` in the database.
+ */
+export const sentEmails: SentEmail[] = [];
+
+const resendPayloadSchema = z.object({
+  to: z.union([z.string(), z.array(z.string())]),
+  subject: z.string(),
+  html: z.string(),
+});
+
+export const server = setupServer(
+  http.get(`${TMDB}/configuration`, () => HttpResponse.json(tmdbConfig())),
+
+  http.get(`${TMDB}/movie/:movieId`, ({ params }) =>
+    HttpResponse.json(tmdbMovie(Number(params.movieId))),
+  ),
+
+  http.get(`${GOOGLE_BOOKS}/volumes/:volumeId`, ({ params }) =>
+    HttpResponse.json(googleBooksVolume(String(params.volumeId))),
+  ),
+
+  http.get(`${GOOGLE_BOOKS}/volumes`, ({ request }) => {
+    const query = new URL(request.url).searchParams.get("q") ?? "";
+    return HttpResponse.json({ totalItems: 1, items: [googleBooksVolume(`vol-${query}`)] });
+  }),
+
+  http.post(GEMINI, () =>
+    HttpResponse.json(
+      geminiJsonResponse({
+        questions: ["What did you make of the ending?", "Who was the villain?"],
+      }),
+    ),
+  ),
+
+  // Resend, reached through the SDK by BetterAuth's verification and
+  // password-reset emails. The payload is kept so tests (and the sign-up
+  // fixture) can read what was actually sent.
+  http.post("https://api.resend.com/emails", async ({ request }) => {
+    const payload = resendPayloadSchema.parse(await request.json());
+    sentEmails.push({
+      to: Array.isArray(payload.to) ? payload.to[0] : payload.to,
+      subject: payload.subject,
+      html: payload.html,
+    });
+    return HttpResponse.json({ id: "test-email-id" });
+  }),
+
+  // Cloudinary avatar upload / delete.
+  http.post("https://api.cloudinary.com/v1_1/:cloud/image/upload", () =>
+    HttpResponse.json({
+      secure_url: "https://res.cloudinary.com/test-cloud/image/upload/avatar.jpg",
+      public_id: "avatar-public-id",
+    }),
+  ),
+  http.post("https://api.cloudinary.com/v1_1/:cloud/image/destroy", () =>
+    HttpResponse.json({ result: "ok" }),
+  ),
+);
+
+server.events.on("request:start", ({ request }) => {
+  externalRequests.push({ method: request.method, url: request.url });
+});
+
+/** Requests made to `host` during this test, most recent last. */
+export function requestsTo(host: string) {
+  return externalRequests.filter((request) => request.url.includes(host));
+}
+
+/** The most recent email sent to `address`, or undefined if there is none. */
+export function lastEmailTo(address: string): SentEmail | undefined {
+  return sentEmails.filter((email) => email.to === address).at(-1);
+}

--- a/netlify/functions/tests/setup/externalApis.ts
+++ b/netlify/functions/tests/setup/externalApis.ts
@@ -18,18 +18,15 @@ import { geminiJsonResponse, googleBooksVolume, tmdbConfig, tmdbMovie } from "..
  * an unmocked host fails the test instead of hitting the internet.
  */
 
-const TMDB = "https://api.themoviedb.org/3";
-const GOOGLE_BOOKS = "https://www.googleapis.com/books/v1";
+export const TMDB = "https://api.themoviedb.org/3";
+export const GOOGLE_BOOKS = "https://www.googleapis.com/books/v1";
 // The Gemini path ends in `models/<model>:generateContent`; the colon would be
 // read as a path parameter by MSW's matcher, so match the host instead.
 const GEMINI = /generativelanguage\.googleapis\.com/;
 
-/**
- * Every request MSW intercepted during the current test, so a test can assert
- * on cache behaviour ("re-adding a known movie makes no second TMDB call")
- * rather than just on the response body. Cleared before each test.
- */
-export const externalRequests: { method: string; url: string }[] = [];
+const CLOUDINARY = "https://api.cloudinary.com/v1_1/:cloud";
+export const CLOUDINARY_UPLOAD = `${CLOUDINARY}/image/upload`;
+export const CLOUDINARY_DESTROY = `${CLOUDINARY}/image/destroy`;
 
 export interface SentEmail {
   to: string;
@@ -91,24 +88,30 @@ export const server = setupServer(
   }),
 
   // Cloudinary avatar upload / delete.
-  http.post("https://api.cloudinary.com/v1_1/:cloud/image/upload", () =>
+  http.post(CLOUDINARY_UPLOAD, () =>
     HttpResponse.json({
       secure_url: "https://res.cloudinary.com/test-cloud/image/upload/avatar.jpg",
       public_id: "avatar-public-id",
     }),
   ),
-  http.post("https://api.cloudinary.com/v1_1/:cloud/image/destroy", () =>
-    HttpResponse.json({ result: "ok" }),
-  ),
+  http.post(CLOUDINARY_DESTROY, () => HttpResponse.json({ result: "ok" })),
 );
 
-server.events.on("request:start", ({ request }) => {
-  externalRequests.push({ method: request.method, url: request.url });
-});
-
-/** Requests made to `host` during this test, most recent last. */
-export function requestsTo(host: string) {
-  return externalRequests.filter((request) => request.url.includes(host));
+/**
+ * Makes any matching request blow up for the rest of the current test.
+ *
+ * This is how the suite says "this endpoint must not be reached" — for a cache
+ * that should spare a second fetch, or a cleanup that has nothing to clean up.
+ * Asserting on a log of intercepted requests would instead couple the test to
+ * the calls a handler happens to make, which is the thing the integration
+ * suite is trying not to care about.
+ */
+export function failOnRequest(method: "get" | "post" | "delete", path: string | RegExp) {
+  server.use(
+    http[method](path, ({ request }) => {
+      throw new Error(`Unexpected request to ${request.method} ${request.url}`);
+    }),
+  );
 }
 
 /** The most recent email sent to `address`, or undefined if there is none. */

--- a/netlify/functions/tests/setup/globalSetup.ts
+++ b/netlify/functions/tests/setup/globalSetup.ts
@@ -1,0 +1,66 @@
+import { CockroachDbContainer, StartedCockroachDbContainer } from "@testcontainers/cockroachdb";
+import { execFileSync } from "child_process";
+import type { TestProject } from "vitest/node";
+
+/**
+ * The CockroachDB build the integration suite runs against.
+ *
+ * Pinned rather than floating on `latest` so a Cockroach release can never turn
+ * CI red on its own. Override with `COCKROACH_TEST_IMAGE` to reproduce a
+ * version-specific bug locally.
+ *
+ * v25 is the floor: on v24.1 the `20260407_ArbitraryClubLists` migration fails
+ * from scratch, because Cockroach still reports `work_list` as depending on
+ * `work_list_type` while the `DROP COLUMN` schema-change job is in flight, so
+ * the `DROP TYPE` two statements later errors.
+ */
+const IMAGE = process.env.COCKROACH_TEST_IMAGE ?? "cockroachdb/cockroach:v25.3.3";
+
+let container: StartedCockroachDbContainer | undefined;
+
+/**
+ * Boots one throwaway CockroachDB for the whole integration run, migrates it
+ * from scratch, and hands the connection string to the workers via `provide`
+ * (see `setup/env.ts`, which is what actually points `utils/database.ts` at it).
+ *
+ * One container for the entire run, not one per file: startup plus migrations
+ * costs ~45s, worth paying once. Test isolation comes from `resetDatabase()`
+ * between tests instead — see `helpers/database.ts`.
+ *
+ * Migrations run as a subprocess through `tsx`, exactly as `npm run migrate`
+ * does, rather than by importing the migrator here. Kysely's
+ * `FileMigrationProvider` `import()`s the migration files through Node's
+ * loader, which cannot resolve the extensionless specifiers they use — only
+ * esbuild (via tsx) can. Shelling out also guarantees the suite is testing the
+ * same schema the deploy applies.
+ */
+export default async function setup({ provide }: TestProject) {
+  container = await new CockroachDbContainer(IMAGE).withDatabase("movie_club_test").start();
+
+  const databaseUrl = container.getConnectionUri();
+
+  try {
+    // Captured rather than inherited: a clean migration run prints ~40 lines
+    // that would bury the test report. On failure the output is the error.
+    execFileSync("npx", ["tsx", "./migrations/schemaMigrator.ts"], {
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+      stdio: "pipe",
+      encoding: "utf-8",
+    });
+  } catch (error) {
+    const failure = error instanceof Error && "stdout" in error ? String(error.stdout) : "";
+    throw new Error(`Failed to migrate the test database.\n${failure}`);
+  }
+
+  provide("databaseUrl", databaseUrl);
+}
+
+export async function teardown() {
+  await container?.stop();
+}
+
+declare module "vitest" {
+  interface ProvidedContext {
+    databaseUrl: string;
+  }
+}

--- a/netlify/functions/tests/setup/integration.ts
+++ b/netlify/functions/tests/setup/integration.ts
@@ -6,7 +6,7 @@ import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
 
 import { restoreFixtureUsers } from "../helpers/auth";
 import { closeDatabase, resetDatabase } from "../helpers/database";
-import { externalRequests, sentEmails, server } from "./externalApis";
+import { sentEmails, server } from "./externalApis";
 
 beforeAll(() => {
   // Anything reaching a host without a handler is a bug in the test, not a
@@ -15,7 +15,6 @@ beforeAll(() => {
 });
 
 beforeEach(async () => {
-  externalRequests.length = 0;
   sentEmails.length = 0;
   await resetDatabase();
 });

--- a/netlify/functions/tests/setup/integration.ts
+++ b/netlify/functions/tests/setup/integration.ts
@@ -1,0 +1,33 @@
+// Must come first: it points DATABASE_URL at the container started by
+// globalSetup before any module below reaches `utils/database.ts`, which builds
+// its connection pool at import time.
+import "./env";
+import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
+
+import { restoreFixtureUsers } from "../helpers/auth";
+import { closeDatabase, resetDatabase } from "../helpers/database";
+import { externalRequests, sentEmails, server } from "./externalApis";
+
+beforeAll(() => {
+  // Anything reaching a host without a handler is a bug in the test, not a
+  // reason to hit the internet from CI.
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+beforeEach(async () => {
+  externalRequests.length = 0;
+  sentEmails.length = 0;
+  await resetDatabase();
+});
+
+afterEach(async () => {
+  // Runs before resetHandlers so the profile endpoints still have their
+  // Cloudinary handler while undoing an avatar upload.
+  await restoreFixtureUsers();
+  server.resetHandlers();
+});
+
+afterAll(async () => {
+  server.close();
+  await closeDatabase();
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:unit": "vitest run --project client --project server",
+    "test:integration": "vitest run --project integration",
     "coverage": "vitest run --coverage",
     "type-check": "vue-tsc --noEmit --composite false",
     "migrate": "tsx ./migrations/schemaMigrator.ts && npm run codegen",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,6 +69,43 @@ export default defineConfig({
           ],
         },
       },
+      {
+        extends: true,
+        test: {
+          // Handler-level tests that run against a real CockroachDB started by
+          // globalSetup (see netlify/functions/tests/setup/). Requires Docker.
+          name: "integration",
+          globals: true,
+          environment: "node",
+          include: ["netlify/functions/tests/**/*.{test,spec}.ts"],
+          globalSetup: "netlify/functions/tests/setup/globalSetup.ts",
+          setupFiles: "netlify/functions/tests/setup/integration.ts",
+          // One worker, one database: the suite resets shared tables between
+          // tests, so files must not run concurrently.
+          fileParallelism: false,
+          // Pulling and booting the container is a one-off cost paid inside
+          // globalSetup's budget, and bcrypt makes the first sign-in of a file
+          // slower than a unit test.
+          testTimeout: 20_000,
+          hookTimeout: 120_000,
+          teardownTimeout: 60_000,
+          // Service credentials the backend reads at import time. Every one of
+          // these hosts is intercepted by MSW, so the values only need to exist
+          // — except BETTER_AUTH_SECRET, which really does sign the session
+          // cookies the tests send.
+          env: {
+            BETTER_AUTH_URL: "http://localhost:8888",
+            BETTER_AUTH_SECRET: "integration-test-secret-integration-test-secret",
+            GOOGLE_CLIENT_ID: "test-google-client-id",
+            GOOGLE_CLIENT_SECRET: "test-google-client-secret",
+            TMDB_API_KEY: "test-tmdb-key",
+            GOOGLE_BOOKS_API_KEY: "test-google-books-key",
+            GEMINI_API_KEY: "test-gemini-key",
+            RESEND_API_KEY: "test-resend-key",
+            CLOUDINARY_URL: "cloudinary://test-key:test-secret@test-cloud",
+          },
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
> Part 7 of 16 splitting #375 into reviewable pieces. Merge in stack order.

Adds an `integration` Vitest project that runs handler-level tests against
a real CockroachDB started by testcontainers, plus the harness it needs:

- setup/globalSetup.ts boots the container and runs the schema migrations
- setup/integration.ts resets shared tables between tests
- setup/externalApis.ts intercepts TMDB/Google Books/Gemini/Resend with MSW
- helpers/http.ts drives handlers through the public API surface, so tests
  assert on status codes and JSON rather than on repository call shapes
- helpers/auth.ts issues real signed session cookies
- helpers/factories.ts builds clubs, members, works and reviews

The project runs single-worker (`fileParallelism: false`) because the
tests share one database, with raised timeouts for container startup and
bcrypt.

First handler suites on top of it: auth, club, member and members. The
remaining handlers follow in the next change.

Requires Docker; `npm run test:unit` skips this project.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
