### PR TITLE
Add integration tests for the remaining backend handlers

### DIFF
--- a/netlify/functions/repositories/DatabaseCleanupRepository.ts
+++ b/netlify/functions/repositories/DatabaseCleanupRepository.ts
@@ -102,6 +102,17 @@ const rootDb = new Kysely({
 
 class DatabaseCleanupRepository {
   /**
+   * Closes the admin pool this repository opens against `defaultdb`.
+   *
+   * Only callers that outlive the work — the integration suite, which would
+   * otherwise hold a Vitest worker open on an idle client — need this; the
+   * scheduled function and the CLI exit on their own.
+   */
+  async close(): Promise<void> {
+    await rootPool.end();
+  }
+
+  /**
    * Lists all databases with their metadata
    */
   async listDatabases(): Promise<DatabaseInfo[]> {

--- a/netlify/functions/tests/awards.test.ts
+++ b/netlify/functions/tests/awards.test.ts
@@ -1,0 +1,560 @@
+/**
+ * Integration tests for `netlify/functions/club/awards/`.
+ *
+ * The awards data is a single JSON blob updated inside a `SELECT … FOR UPDATE`
+ * transaction, so every route here is a read-modify-write — exactly the shape a
+ * mocked repository cannot check. Each write is asserted by reading the year
+ * back through `GET /awards/:year`, which is the only view a client has.
+ */
+import { describe, expect, it } from "vitest";
+
+import { AwardsData, AwardsStep, ClubAwards } from "../../../lib/types/awards";
+import { handler } from "../club/index";
+import { signIn } from "./helpers/auth";
+import { createAwardsYear, createClub, SeededClub } from "./helpers/factories";
+import { requester } from "./helpers/http";
+
+const api = requester(handler);
+
+const YEAR = 2024;
+
+function awardsData(overrides: Partial<AwardsData> = {}): AwardsData {
+  return { step: AwardsStep.Nominations, awards: [], ...overrides };
+}
+
+/** The year as a client sees it. */
+const awardsOf = (club: SeededClub, year = YEAR) =>
+  api.get<ClubAwards>(`/api/club/${club.slug}/awards/${year}`);
+
+/** Categories, in order, as returned by the awards endpoint. */
+async function categoryTitles(club: SeededClub) {
+  const res = await awardsOf(club);
+  return res.body.awards.map((award) => award.title);
+}
+
+describe("GET /api/club/:clubSlug/awards/years", () => {
+  it("returns the club's award years, newest first", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(club, 2022, awardsData());
+    await createAwardsYear(club, 2024, awardsData());
+    await createAwardsYear(club, 2023, awardsData());
+
+    const res = await api.get<number[]>(`/api/club/${club.slug}/awards/years`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([2024, 2023, 2022]);
+  });
+
+  it("returns an empty array for a club with no awards", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.get<number[]>(`/api/club/${club.slug}/awards/years`);
+
+    expect(res.body).toEqual([]);
+  });
+
+  it("does not see another club's years", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const other = await createClub(alice);
+    await createAwardsYear(other, 2024, awardsData());
+
+    const res = await api.get<number[]>(`/api/club/${club.slug}/awards/years`);
+
+    expect(res.body).toEqual([]);
+  });
+});
+
+describe("GET /api/club/:clubSlug/awards/:year", () => {
+  it("returns the year's awards with each nomination hydrated from TMDB", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({
+        step: AwardsStep.Ratings,
+        awards: [
+          {
+            title: "Best Picture",
+            nominations: [{ movieId: 27, nominatedBy: ["7"], ranking: {} }],
+          },
+        ],
+      }),
+    );
+
+    const res = await awardsOf(club);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.year).toBe(YEAR);
+    expect(res.body.step).toBe(AwardsStep.Ratings);
+    expect(res.body.awards[0].title).toBe("Best Picture");
+    expect(res.body.awards[0].nominations[0]).toMatchObject({
+      movieId: 27,
+      movieTitle: "Movie 27",
+      posterUrl: "https://image.tmdb.org/t/p/w154/poster-27.jpg",
+    });
+  });
+
+  it("returns 404 for a year with no awards", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.get(`/api/club/${club.slug}/awards/1999`);
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 for an unknown club", async () => {
+    const res = await api.get(`/api/club/nope/awards/${YEAR}`);
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("POST /api/club/:clubSlug/awards/:year/category", () => {
+  it("appends a category with no nominations", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({ awards: [{ title: "Best Score", nominations: [] }] }),
+    );
+
+    const res = await api.post(`/api/club/${club.slug}/awards/${YEAR}/category`, {
+      body: { title: "Best Picture" },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const awards = await awardsOf(club);
+    expect(awards.body.awards.map((award) => award.title)).toEqual(["Best Score", "Best Picture"]);
+    expect(awards.body.awards[1].nominations).toEqual([]);
+  });
+
+  it.each([
+    ["no body", undefined],
+    ["a body without a title", { name: "Best Picture" }],
+  ])("returns 400 with %s", async (_label, body) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(club, YEAR, awardsData());
+
+    const res = await api.post(`/api/club/${club.slug}/awards/${YEAR}/category`, {
+      body,
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(await categoryTitles(club)).toEqual([]);
+  });
+
+  it("returns 401 for a non-member", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+    await createAwardsYear(club, YEAR, awardsData());
+
+    const res = await api.post(`/api/club/${club.slug}/awards/${YEAR}/category`, {
+      body: { title: "Best Picture" },
+      as: bob,
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(await categoryTitles(club)).toEqual([]);
+  });
+});
+
+describe("PUT /api/club/:clubSlug/awards/:year/category", () => {
+  it("reorders the categories to match the payload", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({
+        awards: [
+          { title: "A", nominations: [] },
+          { title: "B", nominations: [] },
+          { title: "C", nominations: [] },
+        ],
+      }),
+    );
+
+    const res = await api.put(`/api/club/${club.slug}/awards/${YEAR}/category`, {
+      body: { categories: ["C", "A", "B"] },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(await categoryTitles(club)).toEqual(["C", "A", "B"]);
+  });
+
+  it("returns 500 and leaves the order alone when a title does not exist", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({
+        awards: [
+          { title: "A", nominations: [] },
+          { title: "B", nominations: [] },
+        ],
+      }),
+    );
+
+    const res = await api.put(`/api/club/${club.slug}/awards/${YEAR}/category`, {
+      body: { categories: ["A", "Nonexistent"] },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(await categoryTitles(club)).toEqual(["A", "B"]);
+  });
+
+  it.each([
+    ["no body", undefined],
+    ["categories that are not strings", { categories: [1, 2] }],
+  ])("returns 400 with %s", async (_label, body) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(club, YEAR, awardsData());
+
+    const res = await api.put(`/api/club/${club.slug}/awards/${YEAR}/category`, {
+      body,
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("DELETE /api/club/:clubSlug/awards/:year/category/:awardTitle", () => {
+  it("removes just that category", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({
+        awards: [
+          { title: "Keep", nominations: [] },
+          { title: "Drop", nominations: [] },
+        ],
+      }),
+    );
+
+    const res = await api.delete(`/api/club/${club.slug}/awards/${YEAR}/category/Drop`, {
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(await categoryTitles(club)).toEqual(["Keep"]);
+  });
+});
+
+describe("POST /api/club/:clubSlug/awards/:year/nomination", () => {
+  it("creates a nomination for a movie nobody has nominated yet", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({ awards: [{ title: "Best Picture", nominations: [] }] }),
+    );
+
+    const res = await api.post(`/api/club/${club.slug}/awards/${YEAR}/nomination`, {
+      body: { awardTitle: "Best Picture", movieId: 27, nominatedBy: alice.userId },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const awards = await awardsOf(club);
+    expect(awards.body.awards[0].nominations).toHaveLength(1);
+    expect(awards.body.awards[0].nominations[0]).toMatchObject({
+      movieId: 27,
+      nominatedBy: [alice.userId],
+      ranking: {},
+    });
+  });
+
+  it("adds a second nominator to an existing nomination", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({
+        awards: [
+          {
+            title: "Best Picture",
+            nominations: [{ movieId: 27, nominatedBy: ["99"], ranking: {} }],
+          },
+        ],
+      }),
+    );
+
+    await api.post(`/api/club/${club.slug}/awards/${YEAR}/nomination`, {
+      body: { awardTitle: "Best Picture", movieId: 27, nominatedBy: alice.userId },
+      as: alice,
+    });
+
+    const awards = await awardsOf(club);
+    expect(awards.body.awards[0].nominations).toHaveLength(1);
+    expect(awards.body.awards[0].nominations[0].nominatedBy).toEqual(["99", alice.userId]);
+  });
+
+  it("leaves other categories untouched", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({
+        awards: [
+          { title: "Best Picture", nominations: [] },
+          { title: "Best Score", nominations: [] },
+        ],
+      }),
+    );
+
+    await api.post(`/api/club/${club.slug}/awards/${YEAR}/nomination`, {
+      body: { awardTitle: "Best Picture", movieId: 27, nominatedBy: alice.userId },
+      as: alice,
+    });
+
+    const awards = await awardsOf(club);
+    expect(awards.body.awards[1].nominations).toEqual([]);
+  });
+
+  it.each([
+    ["no body", undefined],
+    [
+      "a movieId that is not a number",
+      { awardTitle: "Best Picture", movieId: "27", nominatedBy: "1" },
+    ],
+  ])("returns 400 with %s", async (_label, body) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({ awards: [{ title: "Best Picture", nominations: [] }] }),
+    );
+
+    const res = await api.post(`/api/club/${club.slug}/awards/${YEAR}/nomination`, {
+      body,
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect((await awardsOf(club)).body.awards[0].nominations).toEqual([]);
+  });
+});
+
+describe("DELETE /api/club/:clubSlug/awards/:year/nomination/:movieId", () => {
+  it("drops the user from nominatedBy but keeps the nomination for the others", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({
+        awards: [
+          {
+            title: "Best Picture",
+            nominations: [{ movieId: 27, nominatedBy: [alice.userId, "99"], ranking: {} }],
+          },
+        ],
+      }),
+    );
+
+    const res = await api.delete(`/api/club/${club.slug}/awards/${YEAR}/nomination/27`, {
+      query: { awardTitle: "Best Picture", userId: alice.userId },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const awards = await awardsOf(club);
+    expect(awards.body.awards[0].nominations[0].nominatedBy).toEqual(["99"]);
+  });
+
+  it("removes the nomination entirely once its last nominator leaves", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({
+        awards: [
+          {
+            title: "Best Picture",
+            nominations: [{ movieId: 27, nominatedBy: [alice.userId], ranking: {} }],
+          },
+        ],
+      }),
+    );
+
+    await api.delete(`/api/club/${club.slug}/awards/${YEAR}/nomination/27`, {
+      query: { awardTitle: "Best Picture", userId: alice.userId },
+      as: alice,
+    });
+
+    const awards = await awardsOf(club);
+    expect(awards.body.awards[0].nominations).toEqual([]);
+  });
+
+  it.each([
+    ["awardTitle", { userId: "1" }],
+    ["userId", { awardTitle: "Best Picture" }],
+  ])("returns 400 when the %s query parameter is missing", async (_label, query) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({
+        awards: [
+          {
+            title: "Best Picture",
+            nominations: [{ movieId: 27, nominatedBy: [alice.userId], ranking: {} }],
+          },
+        ],
+      }),
+    );
+
+    const res = await api.delete(`/api/club/${club.slug}/awards/${YEAR}/nomination/27`, {
+      query,
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect((await awardsOf(club)).body.awards[0].nominations).toHaveLength(1);
+  });
+});
+
+describe("POST /api/club/:clubSlug/awards/:year/ranking", () => {
+  it("records the voter's ranking as the position of each movie", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({
+        awards: [
+          {
+            title: "Best Picture",
+            nominations: [
+              { movieId: 1, nominatedBy: ["9"], ranking: {} },
+              { movieId: 2, nominatedBy: ["9"], ranking: {} },
+              { movieId: 3, nominatedBy: ["9"], ranking: {} },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const res = await api.post(`/api/club/${club.slug}/awards/${YEAR}/ranking`, {
+      body: { awardTitle: "Best Picture", movies: [3, 1], voter: alice.userId },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const awards = await awardsOf(club);
+    expect(awards.body.awards[0].nominations.map((nomination) => nomination.ranking)).toEqual([
+      { [alice.userId]: 2 },
+      {},
+      { [alice.userId]: 1 },
+    ]);
+  });
+
+  it("keeps other voters' rankings", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(
+      club,
+      YEAR,
+      awardsData({
+        awards: [
+          {
+            title: "Best Picture",
+            nominations: [{ movieId: 1, nominatedBy: ["9"], ranking: { "9": 1 } }],
+          },
+        ],
+      }),
+    );
+
+    await api.post(`/api/club/${club.slug}/awards/${YEAR}/ranking`, {
+      body: { awardTitle: "Best Picture", movies: [1], voter: alice.userId },
+      as: alice,
+    });
+
+    const awards = await awardsOf(club);
+    expect(awards.body.awards[0].nominations[0].ranking).toEqual({ "9": 1, [alice.userId]: 1 });
+  });
+
+  it.each([
+    ["no body", undefined],
+    ["movies that are not numbers", { awardTitle: "Best Picture", movies: ["a"], voter: "1" }],
+  ])("returns 400 with %s", async (_label, body) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(club, YEAR, awardsData());
+
+    const res = await api.post(`/api/club/${club.slug}/awards/${YEAR}/ranking`, {
+      body,
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("PUT /api/club/:clubSlug/awards/:year/step", () => {
+  it("advances the awards to the given step", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(club, YEAR, awardsData({ step: AwardsStep.CategorySelect }));
+
+    const res = await api.put(`/api/club/${club.slug}/awards/${YEAR}/step`, {
+      body: { step: AwardsStep.Presentation },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect((await awardsOf(club)).body.step).toBe(AwardsStep.Presentation);
+  });
+
+  it.each([
+    ["no body", undefined],
+    ["a step that is not a number", { step: "Presentation" }],
+  ])("returns 400 with %s", async (_label, body) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createAwardsYear(club, YEAR, awardsData({ step: AwardsStep.CategorySelect }));
+
+    const res = await api.put(`/api/club/${club.slug}/awards/${YEAR}/step`, { body, as: alice });
+
+    expect(res.statusCode).toBe(400);
+    expect((await awardsOf(club)).body.step).toBe(AwardsStep.CategorySelect);
+  });
+
+  it("returns 401 for a non-member", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+    await createAwardsYear(club, YEAR, awardsData({ step: AwardsStep.CategorySelect }));
+
+    const res = await api.put(`/api/club/${club.slug}/awards/${YEAR}/step`, {
+      body: { step: AwardsStep.Completed },
+      as: bob,
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect((await awardsOf(club)).body.step).toBe(AwardsStep.CategorySelect);
+  });
+});

--- a/netlify/functions/tests/invite.test.ts
+++ b/netlify/functions/tests/invite.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Integration tests for `netlify/functions/club/invite.ts` — issuing club
+ * invite tokens, including the reuse and expiry-cleanup behaviour that lives in
+ * `ClubRepository.createClubInvite`.
+ */
+import { describe, expect, it } from "vitest";
+
+import { handler } from "../club/index";
+import { signIn } from "./helpers/auth";
+import { createClub, createInvite, expireInvite } from "./helpers/factories";
+import { requester } from "./helpers/http";
+
+const api = requester(handler);
+
+describe("POST /api/club/:clubSlug/invite", () => {
+  it("issues a token that the join-info endpoint resolves back to the club", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { name: "Invite Club" });
+
+    const res = await api.post<{ token: string }>(`/api/club/${club.slug}/invite`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toMatch(/^[0-9a-f]{32}$/);
+
+    const info = await api.get<{ clubName: string }>(`/api/club/joinInfo/${res.body.token}`);
+    expect(info.body.clubName).toBe("Invite Club");
+  });
+
+  it("reuses the club's live invite rather than issuing a second one", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const existing = await createInvite(club, alice);
+
+    const res = await api.post<{ token: string }>(`/api/club/${club.slug}/invite`);
+
+    expect(res.body.token).toBe(existing);
+  });
+
+  it("retires an expired invite and issues a fresh one", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const stale = await createInvite(club, alice);
+    await expireInvite(stale);
+
+    const res = await api.post<{ token: string }>(`/api/club/${club.slug}/invite`);
+
+    expect(res.body.token).not.toBe(stale);
+    // The old token no longer resolves; the new one does.
+    expect((await api.get<{ error: string }>(`/api/club/joinInfo/${stale}`)).body.error).toBe(
+      "Invalid invite token",
+    );
+    const info = await api.get<{ clubId: string }>(`/api/club/joinInfo/${res.body.token}`);
+    expect(info.body.clubId).toBe(club.id);
+  });
+
+  it("returns 404 for an unknown club", async () => {
+    const res = await api.post("/api/club/not-a-club/invite");
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/netlify/functions/tests/list.test.ts
+++ b/netlify/functions/tests/list.test.ts
@@ -1,0 +1,746 @@
+/**
+ * Integration tests for `netlify/functions/club/list.ts`.
+ *
+ * Lists are where the schema's constraints do most of the work — positions,
+ * the (list_id, work_id) unique index, the system-list partial index, the move
+ * transaction — so these run against a real CockroachDB. Adding a work also
+ * exercises the provider cache: the first add fetches TMDB (through MSW), later
+ * ones must not.
+ */
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { ClubType, WorkListSystemType, WorkType } from "../../../lib/types/generated/db";
+import { DetailedReviewListItem, DetailedWorkListItem } from "../../../lib/types/lists";
+import { MovieDataSummary } from "../../../lib/types/movie";
+import { handler } from "../club/index";
+import { signIn } from "./helpers/auth";
+import {
+  addReviewedWork,
+  addWork,
+  createClub,
+  createList,
+  joinClub,
+  leaveClub,
+  scoreWork,
+  setAddedDate,
+} from "./helpers/factories";
+import { requester } from "./helpers/http";
+import { failOnRequest, server, TMDB } from "./setup/externalApis";
+
+const api = requester(handler);
+
+interface ListSummary {
+  id: string;
+  title: string;
+  systemType: WorkListSystemType | null;
+  itemCount: number;
+}
+
+const listsOf = (slug: string) => api.get<ListSummary[]>(`/api/club/${slug}/list`);
+const itemsOf = (slug: string, listId: string) =>
+  api.get<DetailedWorkListItem<MovieDataSummary>[]>(`/api/club/${slug}/list/${listId}`);
+
+describe("GET /api/club/:clubSlug/list", () => {
+  it("returns the club's user lists with their item counts", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const shortlist = await createList(club, alice, "Shortlist");
+    await addWork(club, alice);
+
+    const res = await listsOf(club.slug);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([
+      { id: club.listId, title: "Watch List", systemType: null, itemCount: 1 },
+      { id: shortlist, title: "Shortlist", systemType: null, itemCount: 0 },
+    ]);
+  });
+
+  it("never exposes the reviews system list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await listsOf(club.slug);
+
+    expect(res.body.map((list) => list.id)).not.toContain(club.reviewsListId);
+  });
+});
+
+describe("GET /api/club/:clubSlug/list/reviews-id", () => {
+  it("returns the id of the reviews system list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.get<{ id: string }>(`/api/club/${club.slug}/list/reviews-id`, {
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.id).toBe(club.reviewsListId);
+  });
+
+  it("returns 401 for a non-member", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+
+    const res = await api.get(`/api/club/${club.slug}/list/reviews-id`, { as: bob });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("POST /api/club/:clubSlug/list", () => {
+  it("creates an empty list at the end of the club's ordering", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createList(club, alice, "Shortlist");
+
+    const res = await api.post<ListSummary>(`/api/club/${club.slug}/list`, {
+      body: { title: "Halloween" },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ title: "Halloween", systemType: null, itemCount: 0 });
+    const lists = await listsOf(club.slug);
+    expect(lists.body.map((list) => list.title)).toEqual(["Watch List", "Shortlist", "Halloween"]);
+  });
+
+  it.each([
+    ["no body", undefined],
+    ["an empty title", { title: "" }],
+    ["a title over 100 characters", { title: "x".repeat(101) }],
+  ])("returns 400 with %s", async (_label, body) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.post(`/api/club/${club.slug}/list`, { body, as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 401 for a non-member", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+
+    const res = await api.post(`/api/club/${club.slug}/list`, { body: { title: "X" }, as: bob });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("PUT /api/club/:clubSlug/list/reorder", () => {
+  it("reassigns positions to the order given", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const second = await createList(club, alice, "Second");
+
+    const res = await api.put(`/api/club/${club.slug}/list/reorder`, {
+      body: { listIds: [second, club.listId] },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const lists = await listsOf(club.slug);
+    expect(lists.body.map((list) => list.title)).toEqual(["Second", "Watch List"]);
+  });
+
+  it("rejects a payload that omits one of the club's lists", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await createList(club, alice, "Second");
+
+    const res = await api.put(`/api/club/${club.slug}/list/reorder`, {
+      body: { listIds: [club.listId] },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(500);
+    const lists = await listsOf(club.slug);
+    expect(lists.body.map((list) => list.title)).toEqual(["Watch List", "Second"]);
+  });
+
+  it.each([
+    ["no body", undefined],
+    ["an empty listIds array", { listIds: [] }],
+    ["malformed JSON", "{ not json"],
+  ])("returns 400 with %s", async (_label, body) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put(`/api/club/${club.slug}/list/reorder`, { body, as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("GET /api/club/:clubSlug/list/:listId", () => {
+  it("returns the list's items with their cached metadata, in the order they were added", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await addWork(club, alice, { title: "Star Wars", externalId: "11" });
+    await addWork(club, alice, { title: "Untracked", externalId: null });
+
+    const res = await itemsOf(club.slug, club.listId);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.map((item) => item.title)).toEqual(["Star Wars", "Untracked"]);
+    expect(res.body[0].externalData?.overview).toBe("Overview for movie 11");
+    // The bulk payload omits cast lists; only `castNames` rides along.
+    expect(res.body[0].externalData).not.toHaveProperty("actors");
+    expect(res.body[0].externalData?.castNames).toEqual(["Lead 11", "Support 11"]);
+    expect(res.body[1].externalData).toBeUndefined();
+  });
+
+  it("records who added an item and when", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice, bob] });
+    const addedDate = new Date("2024-03-04T05:06:07.000Z");
+    await addWork(club, bob, { externalId: null, addedDate });
+
+    const res = await itemsOf(club.slug, club.listId);
+
+    expect(res.body[0].addedBy).toBe(bob.userId);
+    expect(res.body[0].createdDate).toBe(addedDate.toISOString());
+  });
+
+  it("returns 404 for a list belonging to another club", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const other = await createClub(alice);
+
+    const res = await api.get(`/api/club/${club.slug}/list/${other.listId}`);
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("GET /api/club/:clubSlug/list/all-items", () => {
+  it("returns every user list's items tagged with its source list, reviews excluded", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const shortlist = await createList(club, alice, "Shortlist");
+    await addWork(club, alice, { title: "On Watch List", externalId: null });
+    await addWork(club, alice, { title: "On Shortlist", externalId: null, listId: shortlist });
+    await addReviewedWork(club, alice, { title: "Reviewed", externalId: null });
+
+    const res = await api.get<(DetailedWorkListItem & { sourceListTitle: string })[]>(
+      `/api/club/${club.slug}/list/all-items`,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.map((item) => [item.title, item.sourceListTitle])).toEqual([
+      ["On Watch List", "Watch List"],
+      ["On Shortlist", "Shortlist"],
+    ]);
+  });
+});
+
+describe("PUT /api/club/:clubSlug/list/:listId", () => {
+  it("renames a user list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put(`/api/club/${club.slug}/list/${club.listId}`, {
+      body: { title: "Renamed" },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const lists = await listsOf(club.slug);
+    expect(lists.body[0].title).toBe("Renamed");
+  });
+
+  it("refuses to rename a system list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put<{ error: string }>(
+      `/api/club/${club.slug}/list/${club.reviewsListId}`,
+      { body: { title: "Not Reviews" }, as: alice },
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Cannot rename a system list");
+    // Still hidden from the collection, so nothing about it changed.
+    const lists = await listsOf(club.slug);
+    expect(lists.body.map((list) => list.title)).toEqual(["Watch List"]);
+  });
+
+  it("returns 400 without a body", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put(`/api/club/${club.slug}/list/${club.listId}`, { as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("DELETE /api/club/:clubSlug/list/:listId", () => {
+  it("deletes a user list and everything on it", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await addWork(club, alice, { externalId: null });
+
+    const res = await api.delete(`/api/club/${club.slug}/list/${club.listId}`, { as: alice });
+
+    expect(res.statusCode).toBe(200);
+    expect((await listsOf(club.slug)).body).toEqual([]);
+    expect((await itemsOf(club.slug, club.listId)).statusCode).toBe(404);
+  });
+
+  it("refuses to delete a system list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.delete<{ error: string }>(
+      `/api/club/${club.slug}/list/${club.reviewsListId}`,
+      { as: alice },
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Cannot delete a system list");
+    const reviews = await api.get<{ id: string }>(`/api/club/${club.slug}/list/reviews-id`, {
+      as: alice,
+    });
+    expect(reviews.body.id).toBe(club.reviewsListId);
+  });
+});
+
+describe("POST /api/club/:clubSlug/list/:listId/items", () => {
+  it("creates the work, caches its TMDB metadata, and puts it on the list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.post(`/api/club/${club.slug}/list/${club.listId}/items`, {
+      body: { type: WorkType.movie, title: "Alien", externalId: "348", imageUrl: "/alien.jpg" },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    const items = await itemsOf(club.slug, club.listId);
+    expect(items.body).toHaveLength(1);
+    expect(items.body[0]).toMatchObject({
+      title: "Alien",
+      externalId: "348",
+      imageUrl: "/alien.jpg",
+      addedBy: alice.userId,
+    });
+    expect(items.body[0].externalData?.genres).toEqual(["Drama"]);
+  });
+
+  it("reuses the cached metadata rather than calling TMDB again", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const other = await createList(club, alice, "Other");
+
+    await addWork(club, alice, { title: "Alien", externalId: "348" });
+
+    // The first add cached the metadata, so a second one must not need TMDB.
+    failOnRequest("get", `${TMDB}/movie/348`);
+    await addWork(club, alice, { title: "Alien", externalId: "348", listId: other });
+
+    const items = await itemsOf(club.slug, other);
+    expect(items.body[0].externalData?.genres).toEqual(["Drama"]);
+  });
+
+  it("reuses the existing work when the same external id is added twice", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const other = await createList(club, alice, "Other");
+
+    const first = await addWork(club, alice, { title: "Alien", externalId: "348" });
+    const second = await addWork(club, alice, { title: "Alien", externalId: "348", listId: other });
+
+    expect(second.id).toBe(first.id);
+    const all = await api.get<DetailedWorkListItem[]>(`/api/club/${club.slug}/list/all-items`);
+    expect(all.body.map((item) => item.id)).toEqual([first.id, first.id]);
+  });
+
+  it("rejects a work that is already on the list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const body = { type: WorkType.movie, title: "Alien", externalId: "348" };
+
+    await api.post(`/api/club/${club.slug}/list/${club.listId}/items`, { body, as: alice });
+    const res = await api.post<{ error: string }>(
+      `/api/club/${club.slug}/list/${club.listId}/items`,
+      { body, as: alice },
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Item is already in list");
+    expect((await itemsOf(club.slug, club.listId)).body).toHaveLength(1);
+  });
+
+  it("appends each new item after the last one", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    for (const externalId of ["1", "2", "3"]) {
+      await addWork(club, alice, { title: `Movie ${externalId}`, externalId });
+    }
+
+    const items = await itemsOf(club.slug, club.listId);
+    expect(items.body.map((item) => item.title)).toEqual(["Movie 1", "Movie 2", "Movie 3"]);
+  });
+
+  it("still adds the work when the metadata provider fails", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    server.use(
+      http.get(
+        "https://api.themoviedb.org/3/movie/:id",
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+
+    const res = await api.post(`/api/club/${club.slug}/list/${club.listId}/items`, {
+      body: { type: WorkType.movie, title: "Flaky", externalId: "999" },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const items = await itemsOf(club.slug, club.listId);
+    expect(items.body[0].title).toBe("Flaky");
+    expect(items.body[0].externalData).toBeUndefined();
+  });
+
+  it("caches Google Books metadata for a book club", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { type: ClubType.book });
+
+    await addWork(club, alice, { type: WorkType.book, title: "Dune", externalId: "voldune" });
+
+    const items = await itemsOf(club.slug, club.listId);
+    expect(items.body[0].externalData).toMatchObject({
+      kind: "book",
+      title: "Book voldune",
+      authors: ["Author voldune"],
+      firstPublishYear: 1998,
+      numberOfPages: 321,
+    });
+  });
+
+  it("returns 400 without a body", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.post(`/api/club/${club.slug}/list/${club.listId}/items`, { as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 401 for a non-member", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+
+    const res = await api.post(`/api/club/${club.slug}/list/${club.listId}/items`, {
+      body: { type: WorkType.movie, title: "Alien", externalId: "348" },
+      as: bob,
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("DELETE /api/club/:clubSlug/list/:listId/items/:workId", () => {
+  it("removes the item and deletes the now-orphaned work", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addWork(club, alice, { externalId: null });
+
+    const res = await api.delete(`/api/club/${club.slug}/list/${club.listId}/items/${work.id}`, {
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect((await itemsOf(club.slug, club.listId)).body).toEqual([]);
+    expect((await api.get(`/api/club/${club.slug}/work/${work.id}/details`)).statusCode).toBe(404);
+  });
+
+  it("keeps the work when it is still on another list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const other = await createList(club, alice, "Other");
+    const work = await addWork(club, alice, { title: "Kept", externalId: "77" });
+    await addWork(club, alice, { title: "Kept", externalId: "77", listId: other });
+
+    const res = await api.delete(`/api/club/${club.slug}/list/${club.listId}/items/${work.id}`, {
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect((await itemsOf(club.slug, club.listId)).body).toEqual([]);
+    expect((await itemsOf(club.slug, other)).body.map((item) => item.id)).toEqual([work.id]);
+  });
+
+  it("returns 400 when the work is not on the list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const other = await createList(club, alice, "Other");
+    const work = await addWork(club, alice, { externalId: null, listId: other });
+
+    const res = await api.delete<{ error: string }>(
+      `/api/club/${club.slug}/list/${club.listId}/items/${work.id}`,
+      { as: alice },
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("This movie does not exist in the list");
+  });
+});
+
+describe("PUT /api/club/:clubSlug/list/:listId/reorder", () => {
+  it("reorders the given works into the slots they already occupied", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const works = [
+      await addWork(club, alice, { title: "A", externalId: null }),
+      await addWork(club, alice, { title: "B", externalId: null }),
+      await addWork(club, alice, { title: "C", externalId: null }),
+    ];
+
+    const res = await api.put(`/api/club/${club.slug}/list/${club.listId}/reorder`, {
+      body: { workIds: [works[2].id, works[0].id, works[1].id] },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const items = await itemsOf(club.slug, club.listId);
+    expect(items.body.map((item) => item.title)).toEqual(["C", "A", "B"]);
+  });
+
+  it("leaves works outside the payload in their own slots", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const works = [
+      await addWork(club, alice, { title: "A", externalId: null }),
+      await addWork(club, alice, { title: "B", externalId: null }),
+      await addWork(club, alice, { title: "C", externalId: null }),
+    ];
+
+    await api.put(`/api/club/${club.slug}/list/${club.listId}/reorder`, {
+      body: { workIds: [works[2].id, works[0].id] },
+      as: alice,
+    });
+
+    const items = await itemsOf(club.slug, club.listId);
+    expect(items.body.map((item) => item.title)).toEqual(["C", "B", "A"]);
+  });
+
+  it.each([
+    ["no body", undefined],
+    ["an empty workIds array", { workIds: [] }],
+    ["malformed JSON", "}{"],
+  ])("returns 400 with %s", async (_label, body) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.put(`/api/club/${club.slug}/list/${club.listId}/reorder`, {
+      body,
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("PUT /api/club/:clubSlug/list/:listId/items/:workId/added-date", () => {
+  it("updates the item's added date", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addWork(club, alice, { externalId: null });
+
+    const res = await api.put(
+      `/api/club/${club.slug}/list/${club.listId}/items/${work.id}/added-date`,
+      { body: { addedDate: "2020-01-02T03:04:05.000Z" }, as: alice },
+    );
+
+    expect(res.statusCode).toBe(200);
+    const items = await itemsOf(club.slug, club.listId);
+    expect(items.body[0].createdDate).toBe("2020-01-02T03:04:05.000Z");
+  });
+
+  it("returns 400 for a date that is not an ISO datetime with an offset", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addWork(club, alice, { externalId: null });
+
+    const res = await api.put(
+      `/api/club/${club.slug}/list/${club.listId}/items/${work.id}/added-date`,
+      { body: { addedDate: "2020-01-02" }, as: alice },
+    );
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 when the work is not on the list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const other = await createList(club, alice, "Other");
+    const work = await addWork(club, alice, { externalId: null, listId: other });
+
+    const res = await api.put<{ error: string }>(
+      `/api/club/${club.slug}/list/${club.listId}/items/${work.id}/added-date`,
+      { body: { addedDate: "2020-01-02T03:04:05.000Z" }, as: alice },
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("This work does not exist in the list");
+  });
+});
+
+describe("POST /api/club/:clubSlug/list/:listId/items/:workId/move", () => {
+  it("moves the work between lists, carrying its attribution forward", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice, bob] });
+    const destination = await createList(club, alice, "Destination");
+    const addedDate = new Date("2021-05-06T07:08:09.000Z");
+    const work = await addWork(club, bob, { title: "Moved", externalId: null, addedDate });
+
+    const res = await api.post(`/api/club/${club.slug}/list/${club.listId}/items/${work.id}/move`, {
+      body: { destinationListId: destination },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect((await itemsOf(club.slug, club.listId)).body).toEqual([]);
+
+    const moved = await itemsOf(club.slug, destination);
+    expect(moved.body[0]).toMatchObject({
+      title: "Moved",
+      addedBy: bob.userId,
+      createdDate: addedDate.toISOString(),
+    });
+  });
+
+  it("stamps the current time when moving into the reviews list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const longAgo = new Date("2015-01-01T00:00:00.000Z");
+    const work = await addWork(club, alice, { externalId: null, addedDate: longAgo });
+
+    const res = await api.post(`/api/club/${club.slug}/list/${club.listId}/items/${work.id}/move`, {
+      body: { destinationListId: club.reviewsListId },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const reviewed = await itemsOf(club.slug, club.reviewsListId);
+    expect(Date.parse(reviewed.body[0].createdDate)).toBeGreaterThan(longAgo.getTime());
+  });
+
+  it("returns 400 when the destination belongs to another club", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const otherClub = await createClub(alice);
+    const work = await addWork(club, alice, { externalId: null });
+
+    const res = await api.post<{ error: string }>(
+      `/api/club/${club.slug}/list/${club.listId}/items/${work.id}/move`,
+      { body: { destinationListId: otherClub.listId }, as: alice },
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Destination list not found");
+    expect((await itemsOf(club.slug, club.listId)).body.map((item) => item.id)).toEqual([work.id]);
+  });
+
+  it("returns 400 without a body", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addWork(club, alice, { externalId: null });
+
+    const res = await api.post(`/api/club/${club.slug}/list/${club.listId}/items/${work.id}/move`, {
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("GET /api/club/:clubSlug/list/reviews", () => {
+  it("returns each reviewed work with its per-member scores and average", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice, bob] });
+    const work = await addReviewedWork(club, alice, { title: "Forrest Gump", externalId: "13" });
+    await scoreWork(club, alice, work.id, 8);
+    await scoreWork(club, bob, work.id, 6);
+
+    const res = await api.get<DetailedReviewListItem<MovieDataSummary>[]>(
+      `/api/club/${club.slug}/list/reviews`,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].title).toBe("Forrest Gump");
+    expect(res.body[0].scores[alice.userId].score).toBe(8);
+    expect(res.body[0].scores[bob.userId].score).toBe(6);
+    expect(res.body[0].scores.average.score).toBe(7);
+    expect(res.body[0].externalData?.overview).toBe("Overview for movie 13");
+  });
+
+  it("excludes the scores of members who have left the club", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice, bob] });
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    await scoreWork(club, alice, work.id, 9);
+    await scoreWork(club, bob, work.id, 1);
+
+    await leaveClub(club, bob);
+
+    const res = await api.get<DetailedReviewListItem[]>(`/api/club/${club.slug}/list/reviews`);
+
+    expect(Object.keys(res.body[0].scores).sort()).toEqual([alice.userId, "average"].sort());
+    expect(res.body[0].scores.average.score).toBe(9);
+  });
+
+  it("brings a returning member's score back with them", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice, bob] });
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    await scoreWork(club, bob, work.id, 4);
+
+    await leaveClub(club, bob);
+    await joinClub(club, bob);
+
+    const res = await api.get<DetailedReviewListItem[]>(`/api/club/${club.slug}/list/reviews`);
+
+    expect(res.body[0].scores[bob.userId].score).toBe(4);
+  });
+
+  it("returns an empty scores map for a work nobody has scored", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.get<DetailedReviewListItem[]>(`/api/club/${club.slug}/list/reviews`);
+
+    expect(res.body[0].scores).toEqual({});
+  });
+
+  it("returns the most recently added work first", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const older = await addReviewedWork(club, alice, { title: "Older", externalId: null });
+    const newer = await addReviewedWork(club, alice, { title: "Newer", externalId: null });
+    await setAddedDate(club, alice, club.reviewsListId, older.id, new Date("2020-01-01T00:00:00Z"));
+    await setAddedDate(club, alice, club.reviewsListId, newer.id, new Date("2024-01-01T00:00:00Z"));
+
+    const res = await api.get<DetailedReviewListItem[]>(`/api/club/${club.slug}/list/reviews`);
+
+    expect(res.body.map((item) => item.title)).toEqual(["Newer", "Older"]);
+  });
+});

--- a/netlify/functions/tests/og-image.test.ts
+++ b/netlify/functions/tests/og-image.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests for `netlify/functions/og-image.ts` — the Open Graph image
+ * a shared review link unfurls to.
+ */
+import { describe, expect, it } from "vitest";
+
+import { handler } from "../og-image";
+import { signIn } from "./helpers/auth";
+import { addReviewedWork, createClub, scoreWork } from "./helpers/factories";
+import { requester } from "./helpers/http";
+
+const api = requester(handler);
+
+describe("GET /api/og-image", () => {
+  it("redirects to the work's own image when it has one", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, {
+      externalId: null,
+      imageUrl: "https://image.tmdb.org/t/p/w500/poster.jpg",
+    });
+
+    const res = await api.get("/api/og-image", {
+      query: { clubSlug: club.slug, workId: work.id },
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.Location).toBe("https://image.tmdb.org/t/p/w500/poster.jpg");
+  });
+
+  it("renders an SVG card with the title, average score and rating count", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice, bob] });
+    const work = await addReviewedWork(club, alice, { title: "No Poster", externalId: null });
+    await scoreWork(club, alice, work.id, 8);
+    await scoreWork(club, bob, work.id, 7);
+
+    const res = await api.get<string>("/api/og-image", {
+      query: { clubSlug: club.slug, workId: work.id },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["Content-Type"]).toBe("image/svg+xml");
+    expect(res.body).toContain("No Poster");
+    expect(res.body).toContain("7.5");
+    expect(res.body).toContain("from 2 ratings");
+  });
+
+  it("says N/A when nobody has scored the work", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.get<string>("/api/og-image", {
+      query: { clubSlug: club.slug, workId: work.id },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain("N/A");
+    // Known wart, pinned here rather than fixed in a test-only change: the
+    // rating count comes from the raw query rows, and `getReviewsByWorkId`
+    // left-joins `review`, so an unscored work still yields one (all-null)
+    // row. The card therefore reads "from 1 rating" with no ratings at all.
+    // Counting `scores` instead of `reviews` in og-image.ts is the fix.
+    expect(res.body).toContain("from 1 rating");
+  });
+
+  it("escapes XML-significant characters in the title", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, {
+      title: "Fish & <Chips>",
+      externalId: null,
+    });
+
+    const res = await api.get<string>("/api/og-image", {
+      query: { clubSlug: club.slug, workId: work.id },
+    });
+
+    expect(res.body).toContain("Fish &amp; &lt;Chips&gt;");
+  });
+
+  it("falls back to a generic card when the work does not exist", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.get<string>("/api/og-image", {
+      query: { clubSlug: club.slug, workId: "999999" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain("Movie Review");
+    expect(res.body).toContain("N/A");
+  });
+
+  it.each([
+    ["clubSlug", { workId: "1" }],
+    ["workId", { clubSlug: "some-club" }],
+    ["both parameters", {}],
+  ])("returns 400 when %s is missing", async (_label, query) => {
+    const res = await api.get("/api/og-image", { query });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 404 for an unknown club", async () => {
+    const res = await api.get("/api/og-image", {
+      query: { clubSlug: "no-such-club", workId: "1" },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/netlify/functions/tests/reviews.test.ts
+++ b/netlify/functions/tests/reviews.test.ts
@@ -1,0 +1,534 @@
+/**
+ * Integration tests for `netlify/functions/club/reviews.ts`.
+ *
+ * Scores, comments, the per-work scores map and the shared-review payload all
+ * go through the real repositories and CockroachDB. Gemini and TMDB are faked
+ * at the network boundary, so the discussion-questions route still builds its
+ * real prompt and parses a real Gemini response envelope.
+ */
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { WorkType } from "../../../lib/types/generated/db";
+import { ReviewScores, SharedReviewResponse, WorkCommentDto } from "../../../lib/types/lists";
+import { MovieCastMember } from "../../../lib/types/movie";
+import { handler } from "../club/index";
+import { geminiJsonResponse } from "./fixtures/external";
+import { signIn, TestSession } from "./helpers/auth";
+import {
+  addComment,
+  addReviewedWork,
+  addWork,
+  createClub,
+  scoreWork,
+  SeededClub,
+} from "./helpers/factories";
+import { requester } from "./helpers/http";
+import { server } from "./setup/externalApis";
+
+const api = requester(handler);
+
+const scoresOf = (club: SeededClub, workId: string, as: TestSession) =>
+  api.get<ReviewScores>(`/api/club/${club.slug}/reviews/${workId}/scores`, { as });
+
+const commentsOn = (club: SeededClub, workId: string, as: TestSession) =>
+  api.get<WorkCommentDto[]>(`/api/club/${club.slug}/reviews/${workId}/comments`, { as });
+
+describe("POST /api/club/:clubSlug/reviews", () => {
+  it("records the member's score for a work on the reviews list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.post(`/api/club/${club.slug}/reviews`, {
+      body: { workId: work.id, score: 8.5 },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const scores = await scoresOf(club, work.id, alice);
+    expect(scores.body[alice.userId].score).toBe(8.5);
+  });
+
+  it("rejects a work that is not on the reviews list", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addWork(club, alice, { externalId: null });
+
+    const res = await api.post<{ error: string }>(`/api/club/${club.slug}/reviews`, {
+      body: { workId: work.id, score: 5 },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("This movie does not exist in the list");
+  });
+
+  it.each([
+    ["a score above 10", 11],
+    ["a negative score", -1],
+  ])("returns 400 for %s", async (_label, score) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.post(`/api/club/${club.slug}/reviews`, {
+      body: { workId: work.id, score },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect((await scoresOf(club, work.id, alice)).body).toEqual({});
+  });
+
+  it("returns 400 without a body", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.post(`/api/club/${club.slug}/reviews`, { as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 401 for a non-member", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.post(`/api/club/${club.slug}/reviews`, {
+      body: { workId: work.id, score: 5 },
+      as: bob,
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("PUT /api/club/:clubSlug/reviews/:reviewId", () => {
+  it("updates the author's own score", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    await scoreWork(club, alice, work.id, 4);
+    const reviewId = (await scoresOf(club, work.id, alice)).body[alice.userId].id;
+
+    const res = await api.put(`/api/club/${club.slug}/reviews/${reviewId}`, {
+      body: { score: 9 },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const scores = await scoresOf(club, work.id, alice);
+    expect(scores.body[alice.userId].score).toBe(9);
+  });
+
+  it("refuses to update another member's score", async () => {
+    const alice = await signIn("alice");
+    const carol = await signIn("carol");
+    const club = await createClub(alice, { members: [alice, carol] });
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    await scoreWork(club, carol, work.id, 4);
+    const reviewId = (await scoresOf(club, work.id, alice)).body[carol.userId].id;
+
+    const res = await api.put<{ error: string }>(`/api/club/${club.slug}/reviews/${reviewId}`, {
+      body: { score: 1 },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("You are not allowed to edit this review");
+    const scores = await scoresOf(club, work.id, alice);
+    expect(scores.body[carol.userId].score).toBe(4);
+  });
+
+  it("cannot reach a review belonging to another club", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const otherClub = await createClub(alice);
+    const work = await addReviewedWork(otherClub, alice, { externalId: null });
+    await scoreWork(otherClub, alice, work.id, 4);
+    const reviewId = (await scoresOf(otherClub, work.id, alice)).body[alice.userId].id;
+
+    const res = await api.put(`/api/club/${club.slug}/reviews/${reviewId}`, {
+      body: { score: 1 },
+      as: alice,
+    });
+
+    // getById scopes the lookup to the club and throws when it finds nothing,
+    // which the router turns into a 500 rather than letting the edit through.
+    expect(res.statusCode).toBe(500);
+    const scores = await scoresOf(otherClub, work.id, alice);
+    expect(scores.body[alice.userId].score).toBe(4);
+  });
+
+  it("returns 400 without a body", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    await scoreWork(club, alice, work.id, 4);
+    const reviewId = (await scoresOf(club, work.id, alice)).body[alice.userId].id;
+
+    const res = await api.put(`/api/club/${club.slug}/reviews/${reviewId}`, { as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("GET /api/club/:clubSlug/reviews/:workId/scores", () => {
+  it("returns one entry per member plus the average", async () => {
+    const alice = await signIn("alice");
+    const carol = await signIn("carol");
+    const club = await createClub(alice, { members: [alice, carol] });
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    await scoreWork(club, alice, work.id, 7);
+    await scoreWork(club, carol, work.id, 5);
+
+    const res = await scoresOf(club, work.id, alice);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body[alice.userId].score).toBe(7);
+    expect(res.body[carol.userId].score).toBe(5);
+    expect(res.body.average.score).toBe(6);
+  });
+
+  it("returns an empty map before anyone has scored", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await scoresOf(club, work.id, alice);
+
+    expect(res.body).toEqual({});
+  });
+});
+
+describe("GET /api/club/:clubSlug/reviews/cast", () => {
+  it("returns the cast of every reviewed work, keyed by external id", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await addReviewedWork(club, alice, { externalId: "77" });
+
+    const res = await api.get<Record<string, MovieCastMember[]>>(
+      `/api/club/${club.slug}/reviews/cast`,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body["77"]).toEqual([
+      { name: "Lead 77", character: "Hero 77", profilePath: "/lead-77.jpg" },
+      { name: "Support 77", character: "Sidekick 77", profilePath: null },
+    ]);
+  });
+
+  it("returns an empty object for a club with no reviews", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.get(`/api/club/${club.slug}/reviews/cast`);
+
+    expect(res.body).toEqual({});
+  });
+});
+
+describe("comments on a reviewed work", () => {
+  it("returns comments oldest first with their author's profile", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    await addComment(club, alice, work.id, "First");
+    await addComment(club, alice, work.id, "Second", true);
+
+    const res = await commentsOn(club, work.id, alice);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.map((comment) => [comment.content, comment.spoiler])).toEqual([
+      ["First", false],
+      ["Second", true],
+    ]);
+    expect(res.body[0].userName).toBe("Alice");
+  });
+
+  it("adds a comment", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.post(`/api/club/${club.slug}/reviews/${work.id}/comments`, {
+      body: { content: "Loved the third act", spoiler: true },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const comments = await commentsOn(club, work.id, alice);
+    expect(comments.body[0]).toMatchObject({
+      content: "Loved the third act",
+      spoiler: true,
+      userId: alice.userId,
+    });
+  });
+
+  it("defaults spoiler to false", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    await api.post(`/api/club/${club.slug}/reviews/${work.id}/comments`, {
+      body: { content: "No spoilers here" },
+      as: alice,
+    });
+
+    const comments = await commentsOn(club, work.id, alice);
+    expect(comments.body[0].spoiler).toBe(false);
+  });
+
+  it.each([
+    ["empty content", { content: "" }],
+    ["content over 2000 characters", { content: "x".repeat(2001) }],
+    ["no body", undefined],
+  ])("returns 400 for %s", async (_label, body) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.post(`/api/club/${club.slug}/reviews/${work.id}/comments`, {
+      body,
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect((await commentsOn(club, work.id, alice)).body).toEqual([]);
+  });
+
+  it("lets the author edit their comment", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    const commentId = await addComment(club, alice, work.id, "Typo");
+
+    const res = await api.put(`/api/club/${club.slug}/reviews/${work.id}/comments/${commentId}`, {
+      body: { content: "Fixed", spoiler: true },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const comments = await commentsOn(club, work.id, alice);
+    expect(comments.body[0]).toMatchObject({ content: "Fixed", spoiler: true });
+  });
+
+  it("returns 401 when editing someone else's comment", async () => {
+    const alice = await signIn("alice");
+    const carol = await signIn("carol");
+    const club = await createClub(alice, { members: [alice, carol] });
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    const commentId = await addComment(club, carol, work.id, "Carol's take");
+
+    const res = await api.put<{ error: string }>(
+      `/api/club/${club.slug}/reviews/${work.id}/comments/${commentId}`,
+      { body: { content: "Hijacked" }, as: alice },
+    );
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error).toBe("You can only edit your own comments");
+    const comments = await commentsOn(club, work.id, alice);
+    expect(comments.body[0].content).toBe("Carol's take");
+  });
+
+  it("returns 400 when editing a comment that does not exist", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.put(`/api/club/${club.slug}/reviews/${work.id}/comments/999999`, {
+      body: { content: "Ghost" },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("lets the author delete their comment", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    const commentId = await addComment(club, alice, work.id, "Delete me");
+
+    const res = await api.delete(
+      `/api/club/${club.slug}/reviews/${work.id}/comments/${commentId}`,
+      { as: alice },
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect((await commentsOn(club, work.id, alice)).body).toEqual([]);
+  });
+
+  it("returns 401 when deleting someone else's comment", async () => {
+    const alice = await signIn("alice");
+    const carol = await signIn("carol");
+    const club = await createClub(alice, { members: [alice, carol] });
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    const commentId = await addComment(club, carol, work.id, "Carol's take");
+
+    const res = await api.delete<{ error: string }>(
+      `/api/club/${club.slug}/reviews/${work.id}/comments/${commentId}`,
+      { as: alice },
+    );
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error).toBe("You can only delete your own comments");
+    expect((await commentsOn(club, work.id, alice)).body).toHaveLength(1);
+  });
+
+  it("returns 400 when deleting a comment that does not exist", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.delete(`/api/club/${club.slug}/reviews/${work.id}/comments/999999`, {
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 401 for a non-member reading comments", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.get(`/api/club/${club.slug}/reviews/${work.id}/comments`, { as: bob });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("POST /api/club/:clubSlug/reviews/:workId/discussion-questions", () => {
+  it("returns the questions Gemini generated for the work", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { features: { discussionQuestions: true } });
+    const work = await addReviewedWork(club, alice, {
+      title: "The Lord of the Rings",
+      externalId: "120",
+    });
+
+    let prompt = "";
+    server.use(
+      http.post("https://generativelanguage.googleapis.com/*", async ({ request }) => {
+        prompt = await request.text();
+        return HttpResponse.json(geminiJsonResponse({ questions: ["Why the eagles?"] }));
+      }),
+    );
+
+    const res = await api.post<{ questions: string[] }>(
+      `/api/club/${club.slug}/reviews/${work.id}/discussion-questions`,
+      { as: alice },
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.questions).toEqual(["Why the eagles?"]);
+    // The prompt is built server-side from the stored work, including the
+    // release year from the cached TMDB details — a client cannot poison it.
+    expect(prompt).toContain("The Lord of the Rings (2001)");
+  });
+
+  it("returns 400 when the feature is off for the club", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.post<{ error: string }>(
+      `/api/club/${club.slug}/reviews/${work.id}/discussion-questions`,
+      { as: alice },
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Feature not enabled");
+  });
+
+  it("returns 400 for a work that is not in the club", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { features: { discussionQuestions: true } });
+
+    const res = await api.post<{ error: string }>(
+      `/api/club/${club.slug}/reviews/999999/discussion-questions`,
+      { as: alice },
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Work not found");
+  });
+
+  it("returns 500 when Gemini returns a payload the schema rejects", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { features: { discussionQuestions: true } });
+    const work = await addReviewedWork(club, alice, { externalId: null });
+    server.use(
+      http.post("https://generativelanguage.googleapis.com/*", () =>
+        HttpResponse.json(geminiJsonResponse({ questions: [42] })),
+      ),
+    );
+
+    const res = await api.post(`/api/club/${club.slug}/reviews/${work.id}/discussion-questions`, {
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+describe("GET /api/club/:clubSlug/reviews/:workId/shared", () => {
+  it("returns the work, its scores, members and comments without a session", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { name: "Shared Club" });
+    const work = await addReviewedWork(club, alice, {
+      title: "Reservoir Dogs",
+      externalId: "500",
+      imageUrl: "/dogs.jpg",
+    });
+    await scoreWork(club, alice, work.id, 9);
+    await addComment(club, alice, work.id, "A classic");
+
+    const res = await api.get<SharedReviewResponse>(
+      `/api/club/${club.slug}/reviews/${work.id}/shared`,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.clubName).toBe("Shared Club");
+    expect(res.body.work).toMatchObject({
+      id: work.id,
+      title: "Reservoir Dogs",
+      type: WorkType.movie,
+      imageUrl: "/dogs.jpg",
+      externalId: "500",
+    });
+    // The shared payload carries the full metadata, cast included.
+    expect(res.body.work.externalData).toMatchObject({ kind: "movie" });
+    expect(res.body.members.map((member) => member.name)).toEqual(["Alice"]);
+    expect(res.body.comments.map((comment) => comment.content)).toEqual(["A classic"]);
+    expect(res.body.reviews.map((review) => Number(review.score))).toEqual([9]);
+  });
+
+  it("omits external metadata for a work with no external id", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const res = await api.get<SharedReviewResponse>(
+      `/api/club/${club.slug}/reviews/${work.id}/shared`,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.work.externalData).toBeUndefined();
+    expect(res.body.work.externalId).toBeUndefined();
+  });
+
+  it("returns 400 for an unknown work", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.get<{ error: string }>(`/api/club/${club.slug}/reviews/999999/shared`);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Work not found");
+  });
+});

--- a/netlify/functions/tests/scheduled-db-cleanup.test.ts
+++ b/netlify/functions/tests/scheduled-db-cleanup.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration tests for `netlify/functions/scheduled-db-cleanup.ts`.
+ *
+ * The cleanup reads `SHOW DATABASES WITH COMMENT` and issues `DROP DATABASE`,
+ * so it only means anything against a real cluster. These tests create throwaway
+ * `pr_*` databases on the test container, comment them with the metadata the
+ * preview-database plugin writes, and check which ones survive.
+ *
+ * The raw SQL here is deliberate and has no API alternative: the subject under
+ * test operates on databases, not on rows, and the Netlify plugin that creates
+ * preview databases is the only thing that ever issues these statements in
+ * production. Assertions still go through `DatabaseCleanupRepository`, which is
+ * the interface the scheduled function itself uses.
+ *
+ * The fixtures run their DDL on the app connection rather than the repository's
+ * admin pool: `CREATE`/`DROP DATABASE` work from any database on the cluster,
+ * and the admin pool is the subject's own internal detail.
+ */
+import { sql } from "kysely";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+
+import DatabaseCleanupRepository from "../repositories/DatabaseCleanupRepository";
+import cleanupHandler from "../scheduled-db-cleanup";
+import { db } from "../utils/database";
+
+const created: string[] = [];
+
+async function createPreviewDatabase(name: string, createdAt: Date) {
+  await sql`CREATE DATABASE IF NOT EXISTS ${sql.id(name)}`.execute(db);
+  await sql`COMMENT ON DATABASE ${sql.id(name)} IS ${sql.lit(
+    JSON.stringify({ created_at: createdAt.toISOString(), created_by: "tests", pr_number: 1 }),
+  )}`.execute(db);
+  created.push(name);
+}
+
+function daysAgo(days: number) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+function scheduledRequest(body: unknown) {
+  return new Request("https://localhost/.netlify/functions/scheduled-db-cleanup", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+afterEach(async () => {
+  for (const name of created.splice(0)) {
+    await sql`DROP DATABASE IF EXISTS ${sql.id(name)}`.execute(db);
+  }
+});
+
+afterAll(async () => {
+  // The repository's admin pool is separate from the one `closeDatabase()`
+  // ends, and an idle client on it would keep the worker alive.
+  await DatabaseCleanupRepository.close();
+});
+
+describe("scheduled database cleanup", () => {
+  it("drops preview databases past the retention window and keeps the rest", async () => {
+    await createPreviewDatabase("pr_stale_cleanup_test", daysAgo(30));
+    await createPreviewDatabase("pr_fresh_cleanup_test", daysAgo(1));
+
+    const response = await cleanupHandler(scheduledRequest({ next_run: "2026-01-01T00:00:00Z" }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({ success: true, count: 1, deleted: ["pr_stale_cleanup_test"] });
+
+    const remaining = await DatabaseCleanupRepository.listDatabases();
+    const names = remaining.map((database) => database.name);
+    expect(names).toContain("pr_fresh_cleanup_test");
+    expect(names).not.toContain("pr_stale_cleanup_test");
+  });
+
+  it("leaves databases whose comment carries no creation date", async () => {
+    await sql`CREATE DATABASE IF NOT EXISTS ${sql.id("pr_undated_cleanup_test")}`.execute(db);
+    created.push("pr_undated_cleanup_test");
+
+    const response = await cleanupHandler(scheduledRequest({ next_run: "2026-01-01T00:00:00Z" }));
+
+    const body = await response.json();
+    expect(body).toMatchObject({ count: 0, deleted: [] });
+  });
+
+  it("reports success with nothing deleted when no database is stale", async () => {
+    const response = await cleanupHandler(scheduledRequest({ next_run: "2026-01-01T00:00:00Z" }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      success: true,
+      count: 0,
+      deleted: [],
+      next_run: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("returns 500 when the scheduled payload is not the expected shape", async () => {
+    const response = await cleanupHandler(scheduledRequest({ wrong: "shape" }));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({ success: false });
+  });
+});
+
+describe("DatabaseCleanupRepository.canDeleteDatabase", () => {
+  it.each(["dev", "prod", "defaultdb", "postgres", "system"])("protects %s", (name) => {
+    expect(DatabaseCleanupRepository.canDeleteDatabase(name)).toBe(false);
+  });
+
+  it("refuses names outside the pr_ / dev_ prefixes", () => {
+    expect(DatabaseCleanupRepository.canDeleteDatabase("movie_club_test")).toBe(false);
+  });
+
+  it("allows preview and spawned databases", () => {
+    expect(DatabaseCleanupRepository.canDeleteDatabase("pr_123")).toBe(true);
+    expect(DatabaseCleanupRepository.canDeleteDatabase("dev_someone_feature")).toBe(true);
+  });
+
+  it("refuses to drop a protected database even when asked directly", async () => {
+    await expect(DatabaseCleanupRepository.dropDatabase("prod")).rejects.toThrow(
+      /Cannot delete protected database/,
+    );
+  });
+});

--- a/netlify/functions/tests/scheduled-work-refresh.test.ts
+++ b/netlify/functions/tests/scheduled-work-refresh.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Integration tests for `netlify/functions/scheduled-work-refresh.ts` — the
+ * daily sweep that re-fetches the oldest cached metadata for every media
+ * provider.
+ *
+ * The job exists to rewrite cached rows, so it is only meaningful against a
+ * real database. What it wrote is read back off the list endpoint, which is
+ * where the refreshed metadata actually reaches a client.
+ */
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { ClubType, WorkType } from "../../../lib/types/generated/db";
+import { DetailedWorkListItem } from "../../../lib/types/lists";
+import { MovieDataSummary } from "../../../lib/types/movie";
+import { handler as clubHandler } from "../club/index";
+import refreshHandler from "../scheduled-work-refresh";
+import { googleBooksVolume, tmdbMovie } from "./fixtures/external";
+import { signIn } from "./helpers/auth";
+import { addWork, createClub, SeededClub } from "./helpers/factories";
+import { requester } from "./helpers/http";
+import { failOnRequest, GOOGLE_BOOKS, server } from "./setup/externalApis";
+
+const api = requester(clubHandler);
+
+function scheduledRequest(body: unknown) {
+  return new Request("https://localhost/.netlify/functions/scheduled-work-refresh", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+function run() {
+  return refreshHandler(scheduledRequest({ next_run: "2026-01-01T00:00:00Z" }));
+}
+
+const metadataOf = async (club: SeededClub) => {
+  const items = await api.get<DetailedWorkListItem[]>(`/api/club/${club.slug}/list/${club.listId}`);
+  return items.body.map((item) => item.externalData);
+};
+
+describe("scheduled work refresh", () => {
+  it("rewrites cached movie details from TMDB", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await addWork(club, alice, { title: "Stale", externalId: "42" });
+    expect(await metadataOf(club)).toMatchObject([
+      { tagline: "Tagline 42", overview: "Overview for movie 42" },
+    ]);
+
+    server.use(
+      http.get("https://api.themoviedb.org/3/movie/42", () =>
+        HttpResponse.json(
+          tmdbMovie(42, { tagline: "Fresh tagline", overview: "A freshly fetched overview" }),
+        ),
+      ),
+    );
+
+    const response = await run();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ success: true, processed: 1, updated: 1 });
+    expect(await metadataOf(club)).toMatchObject([
+      { tagline: "Fresh tagline", overview: "A freshly fetched overview" },
+    ]);
+  });
+
+  it("replaces the cast rather than appending to it", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await addWork(club, alice, { externalId: "42" });
+
+    server.use(
+      http.get("https://api.themoviedb.org/3/movie/42", () =>
+        HttpResponse.json(
+          tmdbMovie(42, {
+            credits: {
+              cast: [
+                {
+                  id: 1,
+                  name: "Only Actor",
+                  character: "Only Role",
+                  order: 0,
+                  profile_path: null,
+                  popularity: 3,
+                },
+              ],
+              crew: [],
+            },
+          }),
+        ),
+      ),
+    );
+
+    await run();
+
+    const [metadata] = await metadataOf(club);
+    expect((metadata as MovieDataSummary).castNames).toEqual(["Only Actor"]);
+  });
+
+  it("refreshes book details and their authors", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { type: ClubType.book });
+    await addWork(club, alice, { type: WorkType.book, externalId: "bookvolume" });
+
+    server.use(
+      http.get("https://www.googleapis.com/books/v1/volumes/bookvolume", () =>
+        HttpResponse.json(
+          googleBooksVolume("bookvolume", { title: "Fresh Book", authors: ["Fresh Author"] }),
+        ),
+      ),
+    );
+
+    const response = await run();
+
+    expect(await response.json()).toMatchObject({ success: true, processed: 1, updated: 1 });
+    expect(await metadataOf(club)).toMatchObject([
+      { kind: "book", title: "Fresh Book", authors: ["Fresh Author"] },
+    ]);
+  });
+
+  it("skips legacy OpenLibrary ids that Google Books cannot resolve", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { type: ClubType.book });
+    server.use(
+      http.get("https://www.googleapis.com/books/v1/volumes/OL45804W", () =>
+        HttpResponse.json(googleBooksVolume("OL45804W")),
+      ),
+    );
+    await addWork(club, alice, { type: WorkType.book, externalId: "OL45804W" });
+
+    // The id is unresolvable, so the sweep must leave it alone rather than
+    // spend a Google Books call on it.
+    failOnRequest("get", `${GOOGLE_BOOKS}/volumes/:volumeId`);
+    failOnRequest("get", `${GOOGLE_BOOKS}/volumes`);
+
+    const response = await run();
+
+    expect(await response.json()).toMatchObject({ processed: 0 });
+  });
+
+  it("keeps going and reports the failure when one work's fetch errors", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+    await addWork(club, alice, { externalId: "42" });
+    await addWork(club, alice, { externalId: "43" });
+
+    server.use(
+      http.get(
+        "https://api.themoviedb.org/3/movie/42",
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+
+    const response = await run();
+    const body = await response.json();
+
+    expect(body).toMatchObject({ success: true, processed: 2, updated: 1, skipped: 1 });
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0]).toMatchObject({ type: "movie", externalId: "42" });
+  });
+
+  it("reports success with nothing to do when no metadata is cached", async () => {
+    const response = await run();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ processed: 0, updated: 0, skipped: 0 });
+  });
+
+  it("returns 500 when the scheduled payload is not the expected shape", async () => {
+    const response = await refreshHandler(scheduledRequest({ wrong: "shape" }));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({ success: false });
+  });
+});

--- a/netlify/functions/tests/settings.test.ts
+++ b/netlify/functions/tests/settings.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration tests for `netlify/functions/club/settings.ts` — the club feature
+ * flags, stored as a JSON blob in `club_settings` and merged on write.
+ */
+import { describe, expect, it } from "vitest";
+
+import { handler } from "../club/index";
+import { ClubSettings } from "../repositories/SettingsRepository";
+import { signIn } from "./helpers/auth";
+import { addReviewedWork, createClub } from "./helpers/factories";
+import { requester } from "./helpers/http";
+
+const api = requester(handler);
+
+describe("GET /api/club/:clubSlug/settings", () => {
+  it("returns the club's stored feature flags", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { features: { awards: true } });
+
+    const res = await api.get<ClubSettings>(`/api/club/${club.slug}/settings`, { as: alice });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ features: { awards: true, discussionQuestions: false } });
+  });
+
+  it("returns 401 for a non-member", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+
+    const res = await api.get(`/api/club/${club.slug}/settings`, { as: bob });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 404 for an unknown club", async () => {
+    const alice = await signIn("alice");
+
+    const res = await api.get("/api/club/not-a-club/settings", { as: alice });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("POST /api/club/:clubSlug/settings", () => {
+  it("enables a feature and persists it", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.post<ClubSettings>(`/api/club/${club.slug}/settings`, {
+      body: { features: { awards: true } },
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ features: { awards: true, discussionQuestions: false } });
+
+    const reread = await api.get<ClubSettings>(`/api/club/${club.slug}/settings`, { as: alice });
+    expect(reread.body.features.awards).toBe(true);
+  });
+
+  it("leaves the features it was not given alone", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { features: { discussionQuestions: true } });
+
+    const res = await api.post<ClubSettings>(`/api/club/${club.slug}/settings`, {
+      body: { features: { awards: true } },
+      as: alice,
+    });
+
+    expect(res.body).toEqual({ features: { awards: true, discussionQuestions: true } });
+  });
+
+  it("treats an empty body object as a no-op", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { features: { awards: true } });
+
+    const res = await api.post<ClubSettings>(`/api/club/${club.slug}/settings`, {
+      body: {},
+      as: alice,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ features: { awards: true, discussionQuestions: false } });
+  });
+
+  it("gates the feature it names — turning discussion questions off closes the route", async () => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice, { features: { discussionQuestions: true } });
+    const work = await addReviewedWork(club, alice, { externalId: null });
+
+    const enabled = await api.post(
+      `/api/club/${club.slug}/reviews/${work.id}/discussion-questions`,
+      { as: alice },
+    );
+    expect(enabled.statusCode).toBe(200);
+
+    await api.post(`/api/club/${club.slug}/settings`, {
+      body: { features: { discussionQuestions: false } },
+      as: alice,
+    });
+
+    const disabled = await api.post<{ error: string }>(
+      `/api/club/${club.slug}/reviews/${work.id}/discussion-questions`,
+      { as: alice },
+    );
+    expect(disabled.statusCode).toBe(400);
+    expect(disabled.body.error).toBe("Feature not enabled");
+  });
+
+  it.each([
+    ["no body", undefined],
+    ["a non-boolean feature flag", { features: { awards: "yes" } }],
+  ])("returns 400 with %s", async (_label, body) => {
+    const alice = await signIn("alice");
+    const club = await createClub(alice);
+
+    const res = await api.post(`/api/club/${club.slug}/settings`, { body, as: alice });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 401 for a non-member", async () => {
+    const alice = await signIn("alice");
+    const bob = await signIn("bob");
+    const club = await createClub(alice, { members: [alice] });
+
+    const res = await api.post(`/api/club/${club.slug}/settings`, {
+      body: { features: { awards: true } },
+      as: bob,
+    });
+
+    expect(res.statusCode).toBe(401);
+    const settings = await api.get<ClubSettings>(`/api/club/${club.slug}/settings`, { as: alice });
+    expect(settings.body.features.awards).toBe(false);
+  });
+});


### PR DESCRIPTION
> Part 8 of 16 splitting #375 into reviewable pieces. Merge in stack order.

Covers awards (categories, nominations, rankings, step transitions),
lists, reviews, invites, club settings, OG image generation, and the two
scheduled functions (database cleanup and work refresh).

Like the core suites these drive the handlers through the public API and
assert on responses, so they exercise routing, auth, validation and the
repository layer together.

The awards suites are what surfaced the four sub-routers still matching
`:clubId<\d+>` instead of `:clubSlug` — fixed earlier in this stack.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
