### PR TITLE
Remove unused isRequest type guard

### DIFF
--- a/netlify/functions/utils/router.ts
+++ b/netlify/functions/utils/router.ts
@@ -33,12 +33,6 @@ export interface Request {
   params: StringRecord;
 }
 
-export function isRequest(req: unknown): req is Request {
-  return (
-    typeof req === "object" && req !== null && "event" in req && "context" in req && "params" in req
-  );
-}
-
 export type MiddlewareCallback<T, R> = (
   req: T,
   res: (data: HandlerResponse) => RouterResponse,


### PR DESCRIPTION
## What

Removes the unused `isRequest` type guard from `netlify/functions/utils/router.ts`.

## Why

`isRequest` is a type-guard sibling to `isRouterResponse` (which is actively used across the router chain), but nothing in the codebase ever calls it. A repo-wide grep for `isRequest` (`grep -rn "\bisRequest\b" .`) only matches its own definition — no imports, no call sites, and no dynamic/reflective usage.

```
export function isRequest(req: unknown): req is Request {
  return (
    typeof req === "object" && req !== null && "event" in req && "context" in req && "params" in req
  );
}
```

## Verification

- `npm run lint` — passes
- `npm run type-check` — passes
- `npm run format:check` — passes
- No test file exercises `router.ts` directly, so no test changes were needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_013C2VxDbm6UDLKDZPfEbtKL)_