### PR TITLE
Show each club's last review date in the Busiest clubs widget

### DIFF
--- a/lib/types/metrics.ts
+++ b/lib/types/metrics.ts
@@ -137,6 +137,12 @@ export const topClubSchema = z.object({
   reviewCount: z.number(),
   /** Null for clubs whose creation date could not be backfilled (no activity). */
   createdAt: z.string().nullable(),
+  /**
+   * When the club last logged a review, as a UTC calendar date. Null for a club
+   * that has never reviewed anything — the count says how much a club has done,
+   * this says whether it is still doing it.
+   */
+  lastReviewAt: z.string().nullable(),
 });
 export type TopClub = z.infer<typeof topClubSchema>;
 

--- a/netlify/functions/repositories/MetricsRepository.ts
+++ b/netlify/functions/repositories/MetricsRepository.ts
@@ -575,6 +575,12 @@ class MetricsRepository {
           .whereRef("work_list.club_id", "=", "club.id")
           .select((e) => e.fn.countAll<string>().as("c"))
           .as("review_count"),
+        eb
+          .selectFrom("review")
+          .innerJoin("work_list", "work_list.id", "review.list_id")
+          .whereRef("work_list.club_id", "=", "club.id")
+          .select((e) => e.fn.max("review.created_date").as("d"))
+          .as("last_review_at"),
       ])
       .orderBy(sql`review_count`, "desc")
       .limit(TOP_CLUB_LIMIT)
@@ -594,6 +600,8 @@ class MetricsRepository {
         memberNames: memberNames.get(String(row.id)) ?? [],
         reviewCount: toCount(row.review_count),
         createdAt: isDefined(row.created_at) ? toIsoDate(row.created_at) : null,
+        // Null for a club with no reviews at all — max() over an empty set.
+        lastReviewAt: isDefined(row.last_review_at) ? toIsoDate(row.last_review_at) : null,
       }),
     );
   }

--- a/src/features/admin/components/TopClubsWidget.vue
+++ b/src/features/admin/components/TopClubsWidget.vue
@@ -7,6 +7,7 @@
             <th scope="col" class="py-2 pr-3 font-medium">Club</th>
             <th scope="col" class="py-2 pr-3 font-medium">Members</th>
             <th scope="col" class="py-2 pr-3 text-right font-medium">Reviews</th>
+            <th scope="col" class="py-2 pr-3 text-right font-medium">Last review</th>
             <th scope="col" class="py-2 text-right font-medium">Since</th>
           </tr>
         </thead>
@@ -39,6 +40,12 @@
               </span>
             </td>
             <td class="py-2 pr-3 text-right text-white">{{ formatCount(club.reviewCount) }}</td>
+            <td class="py-2 pr-3 text-right text-slate-400">
+              <span v-if="hasValue(club.lastReviewAt)">{{ club.lastReviewAt }}</span>
+              <span v-else class="text-slate-600" title="This club has never logged a review">
+                never
+              </span>
+            </td>
             <td class="py-2 text-right text-slate-400">
               <span v-if="hasValue(club.createdAt)">{{ club.createdAt }}</span>
               <span v-else class="text-slate-600" title="No activity to date this club from">

--- a/src/features/admin/tests/AdminDashboardView.spec.ts
+++ b/src/features/admin/tests/AdminDashboardView.spec.ts
@@ -47,6 +47,16 @@ describe("AdminDashboardView", () => {
     expect(await screen.findByText("Cobresun")).toBeInTheDocument();
     expect(screen.getByText("819")).toBeInTheDocument();
     expect(screen.getByText("2020-04-28")).toBeInTheDocument();
+    expect(screen.getByText("2026-07-30")).toBeInTheDocument();
+  });
+
+  it("says a club has never reviewed rather than leaving the last-review cell blank", async () => {
+    renderDashboard();
+
+    const name = await screen.findByText("Undated Club");
+    const row = ensure(name.closest("tr"), "expected the club name in a table row");
+
+    expect(within(row).getByText("never")).toBeInTheDocument();
   });
 
   it("names club members, collapsing the tail once the row would get long", async () => {

--- a/src/mocks/data/adminMetrics.json
+++ b/src/mocks/data/adminMetrics.json
@@ -151,12 +151,7 @@
       "reviewCount": 819,
       "createdAt": "2020-04-28",
       "lastReviewAt": "2026-07-30",
-      "memberNames": [
-        "Brian Norman",
-        "Kevin",
-        "sunny",
-        "wes"
-      ]
+      "memberNames": ["Brian Norman", "Kevin", "sunny", "wes"]
     },
     {
       "clubId": "940036320128499713",
@@ -167,10 +162,7 @@
       "reviewCount": 3,
       "createdAt": null,
       "lastReviewAt": null,
-      "memberNames": [
-        "Ada",
-        "Grace"
-      ]
+      "memberNames": ["Ada", "Grace"]
     }
   ]
 }

--- a/src/mocks/data/adminMetrics.json
+++ b/src/mocks/data/adminMetrics.json
@@ -150,7 +150,13 @@
       "memberCount": 4,
       "reviewCount": 819,
       "createdAt": "2020-04-28",
-      "memberNames": ["Brian Norman", "Kevin", "sunny", "wes"]
+      "lastReviewAt": "2026-07-30",
+      "memberNames": [
+        "Brian Norman",
+        "Kevin",
+        "sunny",
+        "wes"
+      ]
     },
     {
       "clubId": "940036320128499713",
@@ -160,7 +166,11 @@
       "memberCount": 2,
       "reviewCount": 3,
       "createdAt": null,
-      "memberNames": ["Ada", "Grace"]
+      "lastReviewAt": null,
+      "memberNames": [
+        "Ada",
+        "Grace"
+      ]
     }
   ]
 }


### PR DESCRIPTION
The review count on the admin dashboard's Busiest clubs leaderboard says how much a club has done, but nothing about whether it is still going — a club with 800 reviews and nothing since 2023 reads identically to an active one.

## Changes

- `MetricsRepository.getTopClubs` gains a `max(review.created_date)` correlated subquery alongside the existing member/review count subqueries, exposed as `lastReviewAt` (UTC calendar date, same format as `createdAt`).
- `topClubSchema` gains a nullable `lastReviewAt`. Null means the club has never logged a review (`max()` over an empty set).
- `TopClubsWidget` renders a "Last review" column between Reviews and Since, falling back to a muted "never" rather than an empty cell.
- Fixture (`adminMetrics.json`) updated; two tests cover the populated date and the "never" case.

## Testing

- `npx vitest run src/features/admin/tests/AdminDashboardView.spec.ts` — 12 passed
- `npm run type-check`, oxlint, oxfmt clean

No schema migration — this reads existing columns.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRXP5CMP5ej5FkbwT8d5CD)_