### PR TITLE
Remove unused DateObject and MovieSearchIndex types

### DIFF
--- a/lib/types/common.ts
+++ b/lib/types/common.ts
@@ -6,7 +6,3 @@ export interface Header {
   includeHeader?: boolean;
   centerHeader?: boolean;
 }
-
-export type DateObject = {
-  "@ts": string;
-};

--- a/lib/types/movie.ts
+++ b/lib/types/movie.ts
@@ -149,13 +149,6 @@ export interface TMDBWatchProvidersResponse {
   results: Record<string, TMDBWatchProviderRegion | undefined>;
 }
 
-export interface MovieSearchIndex {
-  title: string;
-  release_date: string;
-  id: number;
-  poster_path: string;
-}
-
 export interface ProductionCompany {
   id: number;
   logo_path: string;


### PR DESCRIPTION
## What was removed

- `DateObject` type in `lib/types/common.ts`
- `MovieSearchIndex` interface in `lib/types/movie.ts`

## Why

Both types were introduced in the same commit (`e40c551`, "Fix delete confirmation modal showing 'Delete Review' for non-review lists") but never had a consumer. A repo-wide grep (excluding their own definitions) turns up zero references:

```
$ grep -rn "DateObject" --include="*.ts" --include="*.vue" .
./lib/types/common.ts:10:export type DateObject = {

$ grep -rn "MovieSearchIndex" --include="*.ts" --include="*.vue" .
./lib/types/movie.ts:152:export interface MovieSearchIndex {
```

Also checked for the `DateObject`'s only field (`"@ts"`) as a literal string anywhere it might be constructed — no hits. Both are type-only exports, so removing them has no runtime effect.

## Testing

- [x] `npm run type-check` — passes
- [x] `npm run lint` — passes
- [x] Repo-wide grep confirms no remaining references to either symbol

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMtESPizqP84Su2Se8xVho)_