### PR TITLE
Show only first names on review score chips

### DIFF
--- a/src/common/memberName.ts
+++ b/src/common/memberName.ts
@@ -1,0 +1,7 @@
+/**
+ * Members are stored with their full name, but compact UI (score chips, chart
+ * labels) only has room for the part that identifies them at a glance.
+ */
+export function firstName(name: string): string {
+  return name.split(" ")[0];
+}

--- a/src/features/reviews/views/ReviewView.vue
+++ b/src/features/reviews/views/ReviewView.vue
@@ -77,6 +77,7 @@ import { clubTypeConfig } from "@/common/clubType";
 import EmptyState from "@/common/components/EmptyState.vue";
 import SearchFilterBar from "@/common/components/SearchFilterBar.vue";
 import VAvatar from "@/common/components/VAvatar.vue";
+import { firstName } from "@/common/memberName";
 import AddReviewPrompt from "@/features/reviews/components/AddReviewPrompt.vue";
 import { useClub, useMembers } from "@/service/useClub";
 import { useDeleteReview, useReviewsList, useReviewsListId } from "@/service/useList";
@@ -206,7 +207,9 @@ const columns = computed(() => [
               name: member.name,
               size,
             }),
-            h("span", { class: "truncate" }, member.name),
+            // Chips are narrow — the first name is enough to tell members
+            // apart, and the avatar carries the rest.
+            h("span", { class: "truncate" }, firstName(member.name)),
           ]);
         } else {
           return h(VAvatar, {

--- a/src/features/statistics/components/ClubConsensusWidget.vue
+++ b/src/features/statistics/components/ClubConsensusWidget.vue
@@ -59,6 +59,7 @@ import { computeClubConsensus } from "../statsComputers";
 import type { WorkStatsData } from "../types";
 import SegmentedToggle from "./SegmentedToggle.vue";
 import WidgetShell from "@/common/components/WidgetShell.vue";
+import { firstName } from "@/common/memberName";
 
 type Mode = "agreed" | "divisive";
 
@@ -85,8 +86,4 @@ const activeEntries = computed(() =>
 const subtitle = computed(() =>
   mode.value === "agreed" ? "Scores that landed closest together" : "Scores that split the room",
 );
-
-function firstName(name: string): string {
-  return name.split(" ")[0];
-}
 </script>

--- a/src/features/statistics/components/TasteSimilarityWidget.vue
+++ b/src/features/statistics/components/TasteSimilarityWidget.vue
@@ -62,6 +62,7 @@ import type { WorkStatsData } from "../types";
 import SegmentedToggle from "./SegmentedToggle.vue";
 import VAvatar from "@/common/components/VAvatar.vue";
 import WidgetShell from "@/common/components/WidgetShell.vue";
+import { firstName } from "@/common/memberName";
 
 type Mode = "most" | "least";
 
@@ -116,8 +117,4 @@ const subtitle = computed(() =>
     ? "The pair whose scores line up the closest"
     : "The pair whose scores clash the hardest",
 );
-
-function firstName(name: string): string {
-  return name.split(" ")[0];
-}
 </script>


### PR DESCRIPTION
The member score chips in the work details sheet rendered each member's full name, which truncated on the narrow tiles. They now show just the first name — the avatar carries the rest of the identity.

### Changes

- `src/common/memberName.ts` (new): shared `firstName` helper.
- `src/features/reviews/views/ReviewView.vue`: the member column header, when rendered with `showName` (i.e. the score chips in the details sheet), uses `firstName(member.name)`. The avatar still receives the full name for its initials/alt text, and the gallery/table headers (avatar-only) are unchanged.
- `src/features/statistics/components/{ClubConsensusWidget,TasteSimilarityWidget}.vue`: dropped their two private copies of the same helper in favour of the shared one.

Type-check, lint, and `npm test` (299 tests) all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_013miE6NGMtQiYMa9Sp3SuhG)_