### PR TITLE
Remove unused isWorkType type guard from WorkRepository

### DIFF
--- a/netlify/functions/repositories/WorkRepository.ts
+++ b/netlify/functions/repositories/WorkRepository.ts
@@ -1,5 +1,4 @@
 import { hasValue } from "../../../lib/checks/checks.js";
-import { WorkType } from "../../../lib/types/generated/db.js";
 import { ListInsertDto } from "../../../lib/types/lists.js";
 import { db } from "../utils/database";
 import { getProvider } from "../utils/providers";
@@ -65,10 +64,6 @@ class WorkRepository {
   async delete(clubId: string, workId: string) {
     return db.deleteFrom("work").where("id", "=", workId).where("club_id", "=", clubId).execute();
   }
-}
-
-export function isWorkType(type: string): type is WorkType {
-  return Object.values(WorkType).includes(type as WorkType);
 }
 
 export default new WorkRepository();


### PR DESCRIPTION
## What

Removes the unused `isWorkType` type-guard function from `netlify/functions/repositories/WorkRepository.ts`, along with the `WorkType` import it needed.

## Why

`isWorkType` had zero callers anywhere in the codebase (`src/`, `netlify/`, `migrations/`, `scripts/`, tests) — a grep for the symbol only ever matched its own definition. It was introduced alongside a statistics widget but never wired up; work-type validation is handled elsewhere in the app. It's a pure, side-effect-free helper, so deleting it can't change any runtime behavior.

## Verification

- `npm run type-check` — passes
- `npm run lint` (oxlint) — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6Z3nYxGGoN8NBY5TjRFvf)_