### PR TITLE
Start the score field caret at the end instead of selecting the value

### DIFF
--- a/src/features/reviews/components/ScoreDial.vue
+++ b/src/features/reviews/components/ScoreDial.vue
@@ -207,9 +207,19 @@ const endDrag = () => {
 };
 
 defineExpose({
+  // Caret at the end, not a full selection: reopening the entry surface on an
+  // existing score should let you tweak a digit rather than have the first
+  // keystroke wipe the value. `setSelectionRange` throws on `type="number"`,
+  // so the field is flipped to text for the one call — the caret survives the
+  // flip back, and the value never changes, so no input event fires.
   focusInput: () => {
-    scoreInput.value?.focus();
-    scoreInput.value?.select();
+    const input = scoreInput.value;
+    if (!isDefined(input)) return;
+    const end = input.value.length;
+    input.type = "text";
+    input.focus();
+    input.setSelectionRange(end, end);
+    input.type = "number";
   },
 });
 </script>

--- a/src/features/reviews/tests/ScoreEntryPanel.spec.ts
+++ b/src/features/reviews/tests/ScoreEntryPanel.spec.ts
@@ -106,6 +106,26 @@ describe("ScoreEntryPanel", () => {
     await waitFor(() => expect(put).toEqual({ score: 7 }));
   });
 
+  it("autofocuses a prefilled field with the caret at the end, not selecting it", async () => {
+    // Asserted through the calls rather than `selectionStart`: jsdom reports a
+    // null caret for `type="number"` and resets the selection when the field
+    // flips back from text, so the placement itself is unobservable here.
+    const setSelectionRange = vi.spyOn(HTMLInputElement.prototype, "setSelectionRange");
+    const select = vi.spyOn(HTMLInputElement.prototype, "select");
+
+    render(ScoreEntryPanel, {
+      props: { workId: "target", reviewId: "rev1", score: 8.5, autofocus: true },
+    });
+
+    const input = screen.getByRole("spinbutton", { name: "Score" });
+    await waitFor(() => expect(input).toHaveFocus());
+
+    // "8.5" — caret past the last character, so a keystroke appends instead of
+    // replacing the whole score.
+    expect(setSelectionRange).toHaveBeenCalledWith(3, 3);
+    expect(select).not.toHaveBeenCalled();
+  });
+
   it("re-seeds the field when the score prop changes out from under it", async () => {
     // Mirrors returning from Score Assist: the saved suggestion flows in as a new
     // `score` prop, and the (mount-seeded) field must follow it rather than keep


### PR DESCRIPTION
Opening the score entry surface on an existing score focused the manual input and called `select()`, so the whole value was highlighted and the first keystroke wiped it. Now the caret lands past the last character, so typing edits the existing score instead of replacing it.

`setSelectionRange` throws `InvalidStateError` on `<input type="number">`, so `ScoreDial`'s `focusInput` flips the field to `type="text"` for the one call and back. The value never changes, so no `input` event fires. Verified in headless Chromium: with the old `select()`, typing `7` into a field holding `8.5` yields `7`; with the swap, it yields `8.57`.

Also adds a regression test in `ScoreEntryPanel.spec.ts`. It asserts through the calls (`setSelectionRange(3, 3)`, no `select()`) rather than `selectionStart`, because jsdom reports a null caret for number inputs and resets the selection when the type flips back — the placement itself isn't observable there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwNAW8qwjau5sn6yxmB5FS)_