### PR TITLE
Remove unused AuthRequest type from auth.ts

### DIFF
--- a/netlify/functions/utils/auth.ts
+++ b/netlify/functions/utils/auth.ts
@@ -114,10 +114,6 @@ export const auth = betterAuth({
   },
 });
 
-export type AuthRequest<T extends Request = Request> = T & {
-  userId: string;
-};
-
 export const loggedIn = async <T extends Request>(
   req: T,
   res: (data: HandlerResponse) => RouterResponse,


### PR DESCRIPTION
## What

Removes the `AuthRequest` type from `netlify/functions/utils/auth.ts`:

```ts
export type AuthRequest<T extends Request = Request> = T & {
  userId: string;
};
```

## Why

A repo-wide grep found no references to `AuthRequest` anywhere outside its own declaration — not even within `auth.ts` itself. `loggedIn` and its callers (`secured`, `siteAdmin`) already rely on structural typing (spreading `userId` onto the request) without ever annotating with this type, so it was dead code.

## Verification

- `npm run type-check` — passes
- `npm run lint` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4qEHJs6L73axDQYE15D4A)_