### PR TITLE
Remove unused SnapshotHistoryMetrics type alias

### DIFF
--- a/lib/types/metrics.ts
+++ b/lib/types/metrics.ts
@@ -240,7 +240,6 @@ export const snapshotHistoryMetricsSchema = z.object({
     })
     .optional(),
 });
-export type SnapshotHistoryMetrics = z.infer<typeof snapshotHistoryMetricsSchema>;
 
 export const snapshotHistoryPointSchema = z.object({
   capturedOn: z.string(),


### PR DESCRIPTION
## Summary
- Removes the `SnapshotHistoryMetrics` type alias from `lib/types/metrics.ts`, which was never imported or referenced anywhere else in the codebase.

## Why
While scanning for dead code, I found this type alias sits right next to `SnapshotHistoryPoint` (which *is* actively used in `SnapshotHistoryWidget.vue`, `formatMetrics.ts`, `useAdminMetrics.ts`, and `MetricsRepository.ts`) and `snapshotHistoryMetricsSchema` (used in `MetricsRepository.ts`). `SnapshotHistoryMetrics` itself appears to have been superseded by `SnapshotHistoryPoint` at some point but was never cleaned up — a repo-wide grep for the symbol turns up only its own declaration.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] Repo-wide grep confirms no remaining references to `SnapshotHistoryMetrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkGKbqGCiFtDpb8PrZJftx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkGKbqGCiFtDpb8PrZJftx)_