### PR TITLE
Remove dead named exports from DatabaseCleanupRepository

### DIFF
--- a/netlify/functions/repositories/DatabaseCleanupRepository.ts
+++ b/netlify/functions/repositories/DatabaseCleanupRepository.ts
@@ -249,5 +249,3 @@ class DatabaseCleanupRepository {
 }
 
 export default new DatabaseCleanupRepository();
-export { PROTECTED_DATABASES };
-export type { DatabaseInfo, CleanupResult };


### PR DESCRIPTION
## Summary

- `netlify/functions/repositories/DatabaseCleanupRepository.ts` re-exported `PROTECTED_DATABASES`, `DatabaseInfo`, and `CleanupResult` alongside its default export (the singleton `DatabaseCleanupRepository` instance).
- Neither consumer of this file (`scripts/db-cleanup.ts`, `netlify/functions/scheduled-db-cleanup.ts`) imports these named exports — both use the default export only.
- `scripts/db-spawn.ts` and `scripts/db-list.ts` each declare their own local copies of `PROTECTED_DATABASES`/`DatabaseInfo` instead of importing from this file, so nothing in the repo references the named exports at all.
- Removed the two orphaned `export`/`export type` statements. The symbols remain in module scope and are still used internally by the class's own methods — this is a pure export-surface cleanup with no behavior change.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] Grepped the whole repo for `PROTECTED_DATABASES`, `DatabaseInfo`, and `CleanupResult` to confirm no external importers exist

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZgneKLVnyXTZ2APtUqZW8)_