### PR TITLE
Remove stray exports from DatabaseCleanupRepository

### DIFF
--- a/netlify/functions/repositories/DatabaseCleanupRepository.ts
+++ b/netlify/functions/repositories/DatabaseCleanupRepository.ts
@@ -88,15 +88,15 @@ function getRootDbUrl(): string | undefined {
   return buildConnectionString(connParams, "defaultdb");
 }
 
-export const rootPool = new Pool({
+const rootPool = new Pool({
   connectionString: getRootDbUrl(),
 });
 
-export const rootDialect = new CockroachDialect({
+const rootDialect = new CockroachDialect({
   pool: rootPool,
 });
 
-export const rootDb = new Kysely({
+const rootDb = new Kysely({
   dialect: rootDialect,
 });
 


### PR DESCRIPTION
## What

Drops the `export` keyword from `rootPool`, `rootDialect`, and `rootDb` in `netlify/functions/repositories/DatabaseCleanupRepository.ts`.

## Why

These three module-level constants are only ever used inside this same file, to build the connection the `DatabaseCleanupRepository` class queries against (`rootDb` is used directly in `listDatabases()`; `rootPool`/`rootDialect` only to construct `rootDb`). A repo-wide search confirms no other file imports `rootPool`, `rootDialect`, or `rootDb` — every other file that touches this repository only consumes its default-exported singleton instance.

This is a small follow-up to #479 ("Remove dead named exports from DatabaseCleanupRepository"), which removed this file's other unused named exports (`PROTECTED_DATABASES`, `DatabaseInfo`, `CleanupResult`) but missed these three.

## Verification

- `npm run type-check` — passes
- `npm run lint` — passes
- Pure visibility change (`export const` → `const`); no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnFpf1WhyL2Kk624eTD5Ep)_