### PR TITLE
Remove stray exports from useReviews.ts

### DIFF
--- a/src/service/useReviews.ts
+++ b/src/service/useReviews.ts
@@ -87,7 +87,7 @@ function startScorePoll(
   setTimeout(() => void tick(0), SCORE_POLL_INTERVAL_MS);
 }
 
-export function useReviewWork(clubSlug: string) {
+function useReviewWork(clubSlug: string) {
   const auth = useAuthStore();
   const queryClient = useQueryClient();
   const user = useUser();
@@ -140,7 +140,7 @@ export function useReviewWork(clubSlug: string) {
   });
 }
 
-export function useUpdateReviewScore(clubSlug: string) {
+function useUpdateReviewScore(clubSlug: string) {
   const auth = useAuthStore();
   const queryClient = useQueryClient();
   const user = useUser();


### PR DESCRIPTION
## What

Removes the unnecessary `export` keyword from two composables in `src/service/useReviews.ts`:

- `useReviewWork`
- `useUpdateReviewScore`

## Why

Both are only ever called from `useSubmitScore` in the same file, which is the intended public entry point (its docstring explains it collapses the `reviewId ? update : create` branch that `ReviewScore`, `ScoreEntryPanel`, and `ScoreAssistModal` would otherwise each repeat). Nothing else in the repo imports either function directly — grepping for `useReviewWork` and `useUpdateReviewScore` across the codebase turns up only their declaration and their use inside `useSubmitScore`.

Dropping the `export` keeps the module's public surface limited to what other files actually use, matching the pattern from previous stray-export cleanups (#481, #475).

## Verification

- `npm run type-check` passes
- `npm run lint` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_016AX73qj8FB2YPzKKpEpcbV)_