### PR TITLE
Remove dead named exports from db-* scripts

### DIFF
--- a/scripts/db-cleanup.ts
+++ b/scripts/db-cleanup.ts
@@ -209,5 +209,3 @@ async function main() {
 if (import.meta.url === `file://${process.argv[1]}`) {
   void main();
 }
-
-export { cleanupDatabases };

--- a/scripts/db-list.ts
+++ b/scripts/db-list.ts
@@ -197,5 +197,3 @@ async function main() {
 if (import.meta.url === `file://${process.argv[1]}`) {
   void main();
 }
-
-export { listDatabases };

--- a/scripts/db-snapshot.ts
+++ b/scripts/db-snapshot.ts
@@ -122,5 +122,3 @@ async function main() {
 if (import.meta.url === `file://${process.argv[1]}`) {
   void main();
 }
-
-export { snapshotDatabase, listSnapshots, buildS3Uri };

--- a/scripts/db-spawn.ts
+++ b/scripts/db-spawn.ts
@@ -363,5 +363,3 @@ async function main() {
 if (import.meta.url === `file://${process.argv[1]}`) {
   void main();
 }
-
-export { spawnDatabase, parseConnectionString, buildConnectionString };


### PR DESCRIPTION
## What

Removes the trailing `export { ... }` statement at the end of each of the four `scripts/db-*.ts` CLI scripts:

- `scripts/db-cleanup.ts` — `export { cleanupDatabases };`
- `scripts/db-list.ts` — `export { listDatabases };`
- `scripts/db-snapshot.ts` — `export { snapshotDatabase, listSnapshots, buildS3Uri };`
- `scripts/db-spawn.ts` — `export { spawnDatabase, parseConnectionString, buildConnectionString };`

## Why

These scripts are only ever invoked directly via `tsx` through the `db:cleanup` / `db:list` / `db:snapshot` / `db:spawn` npm scripts (see `package.json`) — never imported as modules from anywhere else in the repo. I confirmed with a repo-wide grep for each exported symbol name that the only usages are the functions' own internal definitions and their call sites within each script's own `main()`. So these named exports had no consumers and were dead code — a stray public export surface left over on scripts that are really just standalone CLI entry points.

This mirrors the same pattern recently fixed in #482 ("Remove stray exports from useReviews.ts").

## Changes

- Deleted the trailing `export { ... }` line from each of the 4 files.
- The functions themselves are unchanged — they're still defined and still called normally from each script's own `main()`.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] Verified via grep that no other file in the repo imports any of the removed export names

---
_Generated by [Claude Code](https://claude.ai/code/session_0185jp1gqzkrBgvw45beFyWH)_