### PR TITLE
Simplify guilty pleasures / club curmudgeons duplication

### DIFF
--- a/src/features/statistics/statsComputers.ts
+++ b/src/features/statistics/statsComputers.ts
@@ -580,7 +580,83 @@ export function computeScoreVariance(workData: WorkStatsData[]): ScoreVariancePo
   return points;
 }
 
-const MIN_SCORES_FOR_GUILTY_PLEASURE = 2;
+const MIN_SCORES_FOR_SCORE_OUTLIER = 2;
+
+interface ScoreOutlierMovie {
+  title: string;
+  imageUrl: string | undefined;
+  memberScore: number;
+  clubAverage: number;
+  difference: number;
+}
+
+interface ScoreOutlierEntry {
+  member: { id: string; name: string; image?: string };
+  movies: ScoreOutlierMovie[];
+}
+
+/**
+ * Movies where exactly one member's score diverged from the club average by
+ * at least the threshold, grouped per member. `isOutlier` picks which side
+ * of the average counts (above for guilty pleasures, below for curmudgeons);
+ * `sortMovies` orders each member's list.
+ */
+function computeScoreOutliers(
+  workData: WorkStatsData[],
+  members: Member[],
+  isOutlier: (score: number, average: number) => boolean,
+  sortMovies: (a: ScoreOutlierMovie, b: ScoreOutlierMovie) => number,
+  maxMoviesPerMember: number,
+): ScoreOutlierEntry[] {
+  const memberMap = new Map(members.map((m) => [m.id, m]));
+  const memberMovies = new Map<string, ScoreOutlierMovie[]>();
+
+  for (const movie of workData) {
+    const validScores: { memberId: string; score: number }[] = [];
+    for (const [memberId, score] of Object.entries(movie.userScores)) {
+      if (isDefined(score) && !isNaN(score) && memberMap.has(memberId)) {
+        validScores.push({ memberId, score });
+      }
+    }
+
+    if (validScores.length < MIN_SCORES_FOR_SCORE_OUTLIER) continue;
+
+    const outliers = validScores.filter((s) => isOutlier(s.score, movie.average));
+
+    if (outliers.length !== 1) continue;
+
+    const outlier = outliers[0];
+    const entry: ScoreOutlierMovie = {
+      title: movie.title,
+      imageUrl: movie.imageUrl,
+      memberScore: outlier.score,
+      clubAverage: Math.round(movie.average * 100) / 100,
+      difference: Math.round((outlier.score - movie.average) * 100) / 100,
+    };
+
+    const existing = memberMovies.get(outlier.memberId);
+    if (isDefined(existing)) {
+      existing.push(entry);
+    } else {
+      memberMovies.set(outlier.memberId, [entry]);
+    }
+  }
+
+  const entries: ScoreOutlierEntry[] = [];
+  for (const [memberId, movies] of memberMovies) {
+    const member = memberMap.get(memberId);
+    if (!isDefined(member)) continue;
+
+    movies.sort(sortMovies);
+    entries.push({
+      member: { id: member.id, name: member.name, image: member.image },
+      movies: movies.slice(0, maxMoviesPerMember),
+    });
+  }
+
+  return entries.sort((a, b) => b.movies.length - a.movies.length);
+}
+
 const GUILTY_PLEASURE_THRESHOLD = 2;
 const MAX_GUILTY_PLEASURES_PER_MEMBER = 5;
 
@@ -588,69 +664,15 @@ export function computeGuiltyPleasures(
   workData: WorkStatsData[],
   members: Member[],
 ): GuiltyPleasureEntry[] {
-  const memberMap = new Map(members.map((m) => [m.id, m]));
-  const memberMovies = new Map<
-    string,
-    {
-      title: string;
-      imageUrl: string | undefined;
-      memberScore: number;
-      clubAverage: number;
-      difference: number;
-    }[]
-  >();
-
-  for (const movie of workData) {
-    const validScores: { memberId: string; score: number }[] = [];
-    for (const [memberId, score] of Object.entries(movie.userScores)) {
-      if (isDefined(score) && !isNaN(score) && memberMap.has(memberId)) {
-        validScores.push({ memberId, score });
-      }
-    }
-
-    if (validScores.length < MIN_SCORES_FOR_GUILTY_PLEASURE) continue;
-
-    const outliers = validScores.filter(
-      (s) => s.score - movie.average >= GUILTY_PLEASURE_THRESHOLD,
-    );
-
-    if (outliers.length !== 1) continue;
-
-    const outlier = outliers[0];
-    const difference = Math.round((outlier.score - movie.average) * 100) / 100;
-
-    const existing = memberMovies.get(outlier.memberId);
-    const entry = {
-      title: movie.title,
-      imageUrl: movie.imageUrl,
-      memberScore: outlier.score,
-      clubAverage: Math.round(movie.average * 100) / 100,
-      difference,
-    };
-
-    if (isDefined(existing)) {
-      existing.push(entry);
-    } else {
-      memberMovies.set(outlier.memberId, [entry]);
-    }
-  }
-
-  const entries: GuiltyPleasureEntry[] = [];
-  for (const [memberId, movies] of memberMovies) {
-    const member = memberMap.get(memberId);
-    if (!isDefined(member)) continue;
-
-    movies.sort((a, b) => b.difference - a.difference);
-    entries.push({
-      member: { id: member.id, name: member.name, image: member.image },
-      movies: movies.slice(0, MAX_GUILTY_PLEASURES_PER_MEMBER),
-    });
-  }
-
-  return entries.sort((a, b) => b.movies.length - a.movies.length);
+  return computeScoreOutliers(
+    workData,
+    members,
+    (score, average) => score - average >= GUILTY_PLEASURE_THRESHOLD,
+    (a, b) => b.difference - a.difference,
+    MAX_GUILTY_PLEASURES_PER_MEMBER,
+  );
 }
 
-const MIN_SCORES_FOR_CURMUDGEON = 2;
 const CURMUDGEON_THRESHOLD = 2;
 const MAX_CURMUDGEON_MOVIES_PER_MEMBER = 5;
 
@@ -658,64 +680,13 @@ export function computeClubCurmudgeons(
   workData: WorkStatsData[],
   members: Member[],
 ): ClubCurmudgeonEntry[] {
-  const memberMap = new Map(members.map((m) => [m.id, m]));
-  const memberMovies = new Map<
-    string,
-    {
-      title: string;
-      imageUrl: string | undefined;
-      memberScore: number;
-      clubAverage: number;
-      difference: number;
-    }[]
-  >();
-
-  for (const movie of workData) {
-    const validScores: { memberId: string; score: number }[] = [];
-    for (const [memberId, score] of Object.entries(movie.userScores)) {
-      if (isDefined(score) && !isNaN(score) && memberMap.has(memberId)) {
-        validScores.push({ memberId, score });
-      }
-    }
-
-    if (validScores.length < MIN_SCORES_FOR_CURMUDGEON) continue;
-
-    const outliers = validScores.filter((s) => movie.average - s.score >= CURMUDGEON_THRESHOLD);
-
-    if (outliers.length !== 1) continue;
-
-    const outlier = outliers[0];
-    const difference = Math.round((outlier.score - movie.average) * 100) / 100;
-
-    const existing = memberMovies.get(outlier.memberId);
-    const entry = {
-      title: movie.title,
-      imageUrl: movie.imageUrl,
-      memberScore: outlier.score,
-      clubAverage: Math.round(movie.average * 100) / 100,
-      difference,
-    };
-
-    if (isDefined(existing)) {
-      existing.push(entry);
-    } else {
-      memberMovies.set(outlier.memberId, [entry]);
-    }
-  }
-
-  const entries: ClubCurmudgeonEntry[] = [];
-  for (const [memberId, movies] of memberMovies) {
-    const member = memberMap.get(memberId);
-    if (!isDefined(member)) continue;
-
-    movies.sort((a, b) => a.difference - b.difference);
-    entries.push({
-      member: { id: member.id, name: member.name, image: member.image },
-      movies: movies.slice(0, MAX_CURMUDGEON_MOVIES_PER_MEMBER),
-    });
-  }
-
-  return entries.sort((a, b) => b.movies.length - a.movies.length);
+  return computeScoreOutliers(
+    workData,
+    members,
+    (score, average) => average - score >= CURMUDGEON_THRESHOLD,
+    (a, b) => a.difference - b.difference,
+    MAX_CURMUDGEON_MOVIES_PER_MEMBER,
+  );
 }
 
 export function computeHighestRatedByYear(workData: WorkStatsData[]): HighestRatedByYearEntry[] {

--- a/src/features/statistics/tests/statsComputers.test.ts
+++ b/src/features/statistics/tests/statsComputers.test.ts
@@ -4,6 +4,7 @@ import type { Member } from "../../../../lib/types/club";
 import { WorkType } from "../../../../lib/types/generated/db";
 import type { DetailedMovieData } from "../../../../lib/types/movie";
 import {
+  computeClubCurmudgeons,
   computeClubRecords,
   computeCumulativeCounts,
   computeGenreStats,
@@ -836,6 +837,190 @@ describe("computeGuiltyPleasures", () => {
     const result = computeGuiltyPleasures(movies, members);
     expect(result).toHaveLength(1);
     expect(result[0].movies[0].difference).toBe(2);
+  });
+});
+
+describe("computeClubCurmudgeons", () => {
+  it("returns empty array for empty movie list", () => {
+    const members = [makeMember({ id: "m1" })];
+    const result = computeClubCurmudgeons([], members);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when no scores are 2+ below average", () => {
+    const members = [
+      makeMember({ id: "m1", name: "Alice" }),
+      makeMember({ id: "m2", name: "Bob" }),
+    ];
+    const movies = [
+      makeMovie({ average: 7, userScores: { m1: 7.5, m2: 6.5 } }),
+      makeMovie({ average: 5, userScores: { m1: 5.5, m2: 4.5 } }),
+    ];
+    const result = computeClubCurmudgeons(movies, members);
+    expect(result).toEqual([]);
+  });
+
+  it("includes movie where exactly one member is 2+ below average", () => {
+    const members = [
+      makeMember({ id: "m1", name: "Alice" }),
+      makeMember({ id: "m2", name: "Bob" }),
+    ];
+    const movies = [
+      makeMovie({
+        title: "Panned Movie",
+        average: 5,
+        userScores: { m1: 2, m2: 8 },
+      }),
+    ];
+    const result = computeClubCurmudgeons(movies, members);
+    expect(result).toHaveLength(1);
+    expect(result[0].member.name).toBe("Alice");
+    expect(result[0].movies).toHaveLength(1);
+    expect(result[0].movies[0].title).toBe("Panned Movie");
+    expect(result[0].movies[0].memberScore).toBe(2);
+    expect(result[0].movies[0].clubAverage).toBe(5);
+    expect(result[0].movies[0].difference).toBe(-3);
+  });
+
+  it("excludes movie where two members are both 2+ below average", () => {
+    const members = [
+      makeMember({ id: "m1", name: "Alice" }),
+      makeMember({ id: "m2", name: "Bob" }),
+      makeMember({ id: "m3", name: "Carol" }),
+    ];
+    const movies = [
+      makeMovie({
+        title: "Both Hated",
+        average: 5,
+        userScores: { m1: 2, m2: 3, m3: 10 },
+      }),
+    ];
+    const result = computeClubCurmudgeons(movies, members);
+    expect(result).toEqual([]);
+  });
+
+  it("skips movies with fewer than 2 scores", () => {
+    const members = [
+      makeMember({ id: "m1", name: "Alice" }),
+      makeMember({ id: "m2", name: "Bob" }),
+    ];
+    const movies = [
+      makeMovie({
+        title: "Solo",
+        average: 1,
+        userScores: { m1: 1 },
+      }),
+    ];
+    const result = computeClubCurmudgeons(movies, members);
+    expect(result).toEqual([]);
+  });
+
+  it("skips members with undefined or NaN scores", () => {
+    const members = [
+      makeMember({ id: "m1", name: "Alice" }),
+      makeMember({ id: "m2", name: "Bob" }),
+      makeMember({ id: "m3", name: "Carol" }),
+    ];
+    const movies = [
+      makeMovie({
+        title: "Test",
+        average: 7,
+        userScores: { m1: undefined, m2: NaN, m3: 4 },
+      }),
+    ];
+    const result = computeClubCurmudgeons(movies, members);
+    // Only m3 has a valid score, but need 2+ valid scores
+    expect(result).toEqual([]);
+  });
+
+  it("sorts movies by difference ascending (most negative first) within each member", () => {
+    const members = [
+      makeMember({ id: "m1", name: "Alice" }),
+      makeMember({ id: "m2", name: "Bob" }),
+    ];
+    const movies = [
+      makeMovie({
+        title: "Small Gap",
+        average: 5,
+        userScores: { m1: 3, m2: 7 },
+      }),
+      makeMovie({
+        title: "Big Gap",
+        average: 6,
+        userScores: { m1: -1, m2: 9 },
+      }),
+    ];
+    const result = computeClubCurmudgeons(movies, members);
+    expect(result).toHaveLength(1);
+    expect(result[0].movies[0].title).toBe("Big Gap");
+    expect(result[0].movies[1].title).toBe("Small Gap");
+  });
+
+  it("sorts members by number of curmudgeon movies descending", () => {
+    const members = [
+      makeMember({ id: "m1", name: "Alice" }),
+      makeMember({ id: "m2", name: "Bob" }),
+      makeMember({ id: "m3", name: "Carol" }),
+    ];
+    const movies = [
+      makeMovie({
+        title: "A1",
+        average: 4,
+        userScores: { m1: 1, m2: 6, m3: 5 },
+      }),
+      makeMovie({
+        title: "B1",
+        average: 5,
+        userScores: { m1: 6, m2: 2, m3: 7 },
+      }),
+      makeMovie({
+        title: "B2",
+        average: 5,
+        userScores: { m1: 7, m2: 1, m3: 7 },
+      }),
+    ];
+    const result = computeClubCurmudgeons(movies, members);
+    expect(result[0].member.name).toBe("Bob");
+    expect(result[0].movies).toHaveLength(2);
+    expect(result[1].member.name).toBe("Alice");
+    expect(result[1].movies).toHaveLength(1);
+  });
+
+  it("limits each member to top 5 movies", () => {
+    const members = [
+      makeMember({ id: "m1", name: "Alice" }),
+      makeMember({ id: "m2", name: "Bob" }),
+    ];
+    const movies = Array.from({ length: 7 }, (_, i) =>
+      makeMovie({
+        id: `movie-${i}`,
+        title: `Movie ${i}`,
+        average: 6,
+        userScores: { m1: 1 - i * 0.1, m2: 9 },
+      }),
+    );
+    const result = computeClubCurmudgeons(movies, members);
+    expect(result).toHaveLength(1);
+    expect(result[0].movies).toHaveLength(5);
+    // Should keep the top 5 by difference (lowest scores first)
+    expect(result[0].movies[0].title).toBe("Movie 6");
+  });
+
+  it("includes movie at exactly 2 point threshold", () => {
+    const members = [
+      makeMember({ id: "m1", name: "Alice" }),
+      makeMember({ id: "m2", name: "Bob" }),
+    ];
+    const movies = [
+      makeMovie({
+        title: "Exact Threshold",
+        average: 5,
+        userScores: { m1: 3, m2: 7 },
+      }),
+    ];
+    const result = computeClubCurmudgeons(movies, members);
+    expect(result).toHaveLength(1);
+    expect(result[0].movies[0].difference).toBe(-2);
   });
 });
 


### PR DESCRIPTION
## What was simplified

`computeGuiltyPleasures` and `computeClubCurmudgeons` in `src/features/statistics/statsComputers.ts` were ~65-line near-verbatim duplicates. Both build a per-member list of "outlier" scores (movies where exactly one member's score diverged from the club average by ≥2), and differed only in:

1. which side of the average counts as an outlier (above for guilty pleasures, below for curmudgeons),
2. the sort direction of each member's movie list,
3. a couple of identically-valued constants with different names.

## Why

~65 lines of non-trivial logic (map bookkeeping, valid-score filtering, outlier detection, per-member grouping, two-level sorting) was copy-pasted with three parameterizable knobs changed. That's a maintenance hazard: a bugfix to the shared logic (e.g. the `validScores`/`memberMap` filtering) was easy to apply to one function and forget in the other.

## The change

Extracted the shared body into a `computeScoreOutliers(workData, members, isOutlier, sortMovies, maxMoviesPerMember)` helper. Both exported functions are now thin wrappers that pass in:
- an `isOutlier(score, average)` predicate,
- a `sortMovies` comparator,
- the per-member cap.

Behavior is byte-for-byte identical — same inputs produce the same outputs for both functions (verified by running the full existing `computeGuiltyPleasures` suite unchanged, plus the new `computeClubCurmudgeons` suite below).

## Tests

`computeClubCurmudgeons` had **zero dedicated tests** before this change (confirmed via search — it only appeared in `statsComputers.ts`, `types.ts`, and a `.vue` widget with no spec file). Added a `describe("computeClubCurmudgeons", ...)` block mirroring the existing `computeGuiltyPleasures` coverage (empty input, no-outlier case, two-outliers-excluded case, min-score-count guard, NaN/undefined handling, sort order, per-member cap, exact-threshold boundary) to pin down behavior and cover the new shared helper.

All 574 existing tests pass, plus `type-check` and `lint` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0182vP7xRza5iSuByrZkUcrh)_