### PR TITLE
Fix join club button on invite links

### DIFF
--- a/netlify/functions/repositories/ClubRepository.ts
+++ b/netlify/functions/repositories/ClubRepository.ts
@@ -113,6 +113,7 @@ class ClubRepository {
         user_id: userId,
         role: "member",
       })
+      .onConflict((oc) => oc.columns(["club_id", "user_id"]).doNothing())
       .execute();
 
     return { success: true };
@@ -122,7 +123,12 @@ class ClubRepository {
     return await db
       .selectFrom("club_invite")
       .innerJoin("club", "club.id", "club_invite.club_id")
-      .select(["club.id as clubId", "club.name as clubName", "club_invite.expires_at as expiresAt"])
+      .select([
+        "club.id as clubId",
+        "club.name as clubName",
+        "club.slug as slug",
+        "club_invite.expires_at as expiresAt",
+      ])
       .where("token", "=", token)
       .executeTakeFirst();
   }

--- a/netlify/functions/tests/members.test.ts
+++ b/netlify/functions/tests/members.test.ts
@@ -252,11 +252,15 @@ describe("GET /api/club/joinInfo/:token", () => {
     const club = await createClub(alice, { name: "Invite Club" });
     const token = await createInvite(club, alice);
 
-    const res = await api.get<{ clubId: string; clubName: string }>(`/api/club/joinInfo/${token}`);
+    const res = await api.get<{ clubId: string; clubName: string; slug: string }>(
+      `/api/club/joinInfo/${token}`,
+    );
 
     expect(res.statusCode).toBe(200);
     expect(res.body.clubId).toBe(club.id);
     expect(res.body.clubName).toBe("Invite Club");
+    // The join page needs the slug to redirect the new member into the club.
+    expect(res.body.slug).toBe(club.slug);
   });
 
   it("returns 400 for an expired token", async () => {


### PR DESCRIPTION
## The bug

Clicking **Join Club** on an invite link (`/join-club/:inviteToken`) appeared to do nothing — the spinner flashed and the user stayed on the invite page.

## Root cause

`ClubRepository.getClubDetailsByInvite` selected only `club.id` and `club.name`, so `GET /api/club/joinInfo/:token` returned a payload with no `slug` — even though the frontend types it as `ClubPreview`, which has one.

`JoinClubView` derives everything downstream from that slug:

```ts
const clubSlug = computed(() => clubDetails.value?.slug ?? "");
const isInClub = useIsInClub(clubSlug);
```

With `clubSlug` permanently `""`, `useIsInClub` can never match a club, and the redirect watcher is additionally gated on `hasValue(clubSlug)`. So the membership **was** created server-side, but the page had no way to notice or navigate — the button looked broken.

## Changes

- `getClubDetailsByInvite` now selects `club.slug` as well, so the view can redirect into the club once the membership list refreshes.
- `joinClubWithInvite` inserts with `onConflict(...).doNothing()`. `club_member` is keyed on `(club_id, user_id)`, so a repeat join — double click, or an already-joined member reusing the link — raised a PK violation that surfaced to the user as "Internal server error". Joining is now idempotent.
- Extended the `GET /api/club/joinInfo/:token` integration test to assert the slug comes back.

## Testing

- `npm run lint` and `vue-tsc --noEmit` pass.
- `vitest run --project server --project client` — 564 tests pass.
- The `integration` project could not run in this environment (testcontainers needs a container runtime); the new assertion lives there and will run in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_016FGeXyRQFrE8TxL1ZMvXee)_